### PR TITLE
Added resetFromFault command and telemetry event to atArchiver

### DIFF
--- a/sal_interfaces/atArchiver/atArchiver_Commands.xml
+++ b/sal_interfaces/atArchiver/atArchiver_Commands.xml
@@ -155,4 +155,16 @@
         <Units></Units>
         <Count>1</Count>
     </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>atArchiver</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>atArchiver_command_resetFromFault</EFDB_Topic>
+    <Alias>resetFromFault</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
 </SALCommand></SALCommandSet>

--- a/sal_interfaces/atArchiver/atArchiver_Events.xml
+++ b/sal_interfaces/atArchiver/atArchiver_Events.xml
@@ -272,4 +272,28 @@
         <Units></Units>
         <Count>1</Count>
     </item>
-</SALEvent></SALEventSet>
+</SALEvent>
+<SALEvent>
+    <Subsystem>atArchiver</Subsystem>
+    <Version>3.7.1</Version>
+    <Author>Htut Khine Htay Win(hwin16@illinois.edu)</Author>
+    <EFDB_Topic>atArchiver_logevent_telemetry</EFDB_Topic>
+    <Alias>telemetry</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/atArchiver_logevent_telemetry.html</Explanation>
+    <item>
+        <EFDB_Name>statusCode</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>int</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>description</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+</SALEventSet>


### PR DESCRIPTION
Currently, when atArchiver is in fault state, Patrick and admins cannot pull atArchiver out of fault state. To remedy that, Jim discussed with K-T and we are adding resetFromFault as DM command to recover from fault state. 

Along with this commit, we added logevent_telemetry to publish messages such as file transfer status back to OCS so that OCS can act upon it.