### PR TITLE
Tickets/tseia 111

### DIFF
--- a/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -478,6 +478,45 @@
     <Subsystem>ATCamera</Subsystem>
     <Version>3.7.1</Version>
     <Author></Author>
+    <EFDB_Topic>ATCamera_logevent_settingsApplied</EFDB_Topic>
+    <Alias>settingsApplied</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/ATCamera_logevent_settingsApplied.html</Explanation>
+    <item>
+        <EFDB_Name>settings</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+        <item>
+        <EFDB_Name>version</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>wrebSettingsVersion</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>bonnShutterSettingsVersion</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>ATCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
     <EFDB_Topic>ATCamera_logevent_bonnShutterSettingsApplied</EFDB_Topic>
     <Alias>bonnShutterSettingsApplied</Alias>
     <Explanation>http://project.lsst.org/ts/sal_objects/help/ATCamera_logevent_bonnShutterSettingsApplied.html</Explanation>

--- a/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -34,6 +34,13 @@
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total  number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>imageName</EFDB_Name>
         <Description>The imageName for this specific exposure</Description>
         <IDL_Type>string</IDL_Type>
@@ -155,6 +162,13 @@
         <Description>The imageSequenceName as passed to the takeImages command</Description>
         <IDL_Type>string</IDL_Type>
         <IDL_Size>256</IDL_Size>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total  number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
         <Units></Units>
         <Count>1</Count>
     </item>
@@ -332,6 +346,13 @@
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total  number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>imageName</EFDB_Name>
         <Description>The imageName for this specific exposure</Description>
         <IDL_Type>string</IDL_Type>
@@ -457,6 +478,13 @@
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total  number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>imageName</EFDB_Name>
         <Description>The imageName for this specific exposure</Description>
         <IDL_Type>string</IDL_Type>
@@ -493,4 +521,102 @@
     <EFDB_Topic>MTCamera_logevent_startRotateCarousel</EFDB_Topic>
     <Alias>startRotateCarousel</Alias>
     <Explanation>http://project.lsst.org/ts/sal_objects/help/MTCamera_logevent_startRotateCarousel.html</Explanation>
-</SALEvent></SALEventSet>
+</SALEvent>
+<SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>MTCamera_logevent_imageReadoutParameters</EFDB_Topic>
+    <Alias>imageReadoutParameters</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/MTCamera_logevent_imageReadoutParameters.html</Explanation>
+    <item>
+        <EFDB_Name>imageName</EFDB_Name>
+        <Description>The imageName for this specific exposure</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdNames</EFDB_Name>
+        <Description>A list of all ccds currently configured, of the form RnnSnn,: delimited (empty if entry not used)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdType</EFDB_Name>
+        <Description>The type of each CCD, this determines segRows, segCols and serCols</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+        <Enumeration>E2V, ITL</Enumeration>
+    </item>
+    <item>
+        <EFDB_Name>overRows</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>overCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>readRows</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>readCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>readCols2</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>preCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>preRows</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+    <item>
+        <EFDB_Name>postCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units> </Units>
+        <Count>201</Count>
+    </item>
+</SALEvent>
+</SALEventSet>


### PR DESCRIPTION
These changes to ATCamera_events are required for operation of the ATCamera. There is no new functionality, just restoring things as they were for the previous pathfinder exercise.

The changes to MTCamera_events are less urgent, they just bring MTCamera and ATCamera back into alignment, but I would suggest including them.