### PR TITLE
DM-17769: Restore Explanation fields to the original urls in ATDome XML

### DIFF
--- a/sal_interfaces/ATDome/ATDome_Commands.xml
+++ b/sal_interfaces/ATDome/ATDome_Commands.xml
@@ -12,7 +12,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Rotate the dome to the specified azimuth.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Rotate the dome to the specified azimuth. -->
         <item>
             <EFDB_Name>azimuth</EFDB_Name>
             <Description>Desired azimuth; must be in the range 0 to 360. The dome will take the shortest route to the specified position.</Description>
@@ -31,7 +32,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Close both shutter doors. This is the preferred way to close the shutter, because it automatically sequences the doors to prevent the main door from interfering with the dropout door.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Close both shutter doors. This is the preferred way to close the shutter, because it automatically sequences the doors to prevent the main door from interfering with the dropout door. -->
         <item>
             <EFDB_Name>ignored</EFDB_Name>
             <Description/>
@@ -50,7 +52,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Open both shutter doors. This is the preferred way to open the shutter because it automatically sequences the doors to prevent the main door from interfering with the dropout door.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Open both shutter doors. This is the preferred way to open the shutter because it automatically sequences the doors to prevent the main door from interfering with the dropout door. -->
         <item>
             <EFDB_Name>ignored</EFDB_Name>
             <Description/>
@@ -69,7 +72,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Stop all motion: azimuth, dropout door and main door.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Stop all motion: azimuth, dropout door and main door. -->
         <item>
             <EFDB_Name>ignored</EFDB_Name>
             <Description/>
@@ -89,7 +93,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Home the azimuth axis.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Home the azimuth axis. -->
         <item>
             <EFDB_Name>ignored</EFDB_Name>
             <Description/>
@@ -108,7 +113,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Open or close the shutter dropout door. Intended for engineering; use the openShutter and closeShutter commands for normal operation since they automatically sequence the doors to prevent the main door from interfering with the dropout door.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Open or close the shutter dropout door. Intended for engineering; use the openShutter and closeShutter commands for normal operation since they automatically sequence the doors to prevent the main door from interfering with the dropout door. -->
         <item>
             <EFDB_Name>open</EFDB_Name>
             <Description>Open the door if true, close it if false.</Description>
@@ -127,7 +133,8 @@
         <Property/>
         <Action/>
         <Value/>
-        <Explanation>Open or close the main shutter door. Intended for engineering; use the openShutter and closeShutter commands for normal operation since they automatically sequence the doors to prevent the main door from interfering with the dropout.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Open or close the main shutter door. Intended for engineering; use the openShutter and closeShutter commands for normal operation since they automatically sequence the doors to prevent the main door from interfering with the dropout. -->
         <item>
             <EFDB_Name>open</EFDB_Name>
             <Description>Open the door if true, close it if false.</Description>

--- a/sal_interfaces/ATDome/ATDome_Events.xml
+++ b/sal_interfaces/ATDome/ATDome_Events.xml
@@ -10,7 +10,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_heartbeat</EFDB_Topic>
         <Alias>heartbeat</Alias>
-        <Explanation>Heartbeat event.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Heartbeat event. -->
         <item>
             <EFDB_Name>heartbeat</EFDB_Name>
             <Description>Ignore this field.</Description>
@@ -26,7 +27,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_azimuthState</EFDB_Topic>
         <Alias>azimuthState</Alias>
-        <Explanation>State of azimuth drive.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- State of azimuth drive. -->
         <item>
             <EFDB_Name>state</EFDB_Name>
             <Description/>
@@ -49,7 +51,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_dropoutDoorState</EFDB_Topic>
         <Alias>dropoutDoorState</Alias>
-        <Explanation>State of the dropout shutter door.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- State of the dropout shutter door. -->
         <item>
             <EFDB_Name>state</EFDB_Name>
             <Description/>
@@ -65,7 +68,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_mainDoorState</EFDB_Topic>
         <Alias>mainDoorState</Alias>
-        <Explanation>State of the main shutter door.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- State of the main shutter door. -->
         <item>
             <EFDB_Name>state</EFDB_Name>
             <Description/>
@@ -81,7 +85,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_azimuthInPosition</EFDB_Topic>
         <Alias>azimuthInPosition</Alias>
-        <Explanation>Is the dome azimuth in the commanded position? Note: this will be false when the CSC starts up until a position is commanded.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Is the dome azimuth in the commanded position? Note: this will be false when the CSC starts up until a position is commanded. -->
         <item>
             <EFDB_Name>inPosition</EFDB_Name>
             <Description/>
@@ -96,7 +101,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_shutterInPosition</EFDB_Topic>
         <Alias>shutterInPosition</Alias>
-        <Explanation>Are the shutter doors in their commanded positions?</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Are the shutter doors in their commanded positions? -->
         <item>
             <EFDB_Name>inPosition</EFDB_Name>
             <Description>Are both shutter doors in position? Note: this will be false when the CSC starts up until a position is commanded for both doors.</Description>
@@ -111,7 +117,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_allAxesInPosition</EFDB_Topic>
         <Alias>allAxesInPosition</Alias>
-        <Explanation>Are all axes (azimuth and both shutter doors) in position?</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Are all axes (azimuth and both shutter doors) in position? -->
         <item>
             <EFDB_Name>inPosition</EFDB_Name>
             <Description/>
@@ -127,7 +134,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_emergencyStop</EFDB_Topic>
         <Alias>emergencyStop</Alias>
-        <Explanation>Has the emergency stop button been activated?</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Has the emergency stop button been activated? -->
         <item>
             <EFDB_Name>active</EFDB_Name>
             <Description/>
@@ -142,7 +150,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_scbLink</EFDB_Topic>
         <Alias>scbLink</Alias>
-        <Explanation>Can the main controller box (MCB) communicate with the shutter control box (SCB)?</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Can the main controller box (MCB) communicate with the shutter control box (SCB)? -->
         <item>
             <EFDB_Name>active</EFDB_Name>
             <Description/>
@@ -158,7 +167,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_settingsAppliedDomeController</EFDB_Topic>
         <Alias>settingsAppliedDomeController</Alias>
-        <Explanation>Settings internal to the ATDome TCP/IP controller.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Settings internal to the ATDome TCP/IP controller. -->
         <item>
             <EFDB_Name>rainSensorEnabled</EFDB_Name>
             <Description>Is the rain/snow sensor enabled?</Description>
@@ -222,7 +232,8 @@
         <Author/>
         <EFDB_Topic>ATDome_logevent_settingsAppliedDomeTcp</EFDB_Topic>
         <Alias>settingsAppliedDomeTcp</Alias>
-        <Explanation>Settings related to communication between the ATDome CSC and the ATDome TCP/IP controller.</Explanation>
+        <Explanation>http://sal.lsst.org</Explanation>
+        <!-- Settings related to communication between the ATDome CSC and the ATDome TCP/IP controller. -->
         <item>
             <EFDB_Name>host</EFDB_Name>
             <Description>Host name of the ATDome TCP/IP controller.</Description>


### PR DESCRIPTION
and move descriptive text to comments