### PR TITLE
Renamed attribute 'localTime' to 'localTimeString'.

### DIFF
--- a/sal_interfaces/ATPtg/ATPtg_Telemetry.xml
+++ b/sal_interfaces/ATPtg/ATPtg_Telemetry.xml
@@ -549,7 +549,7 @@
         <Count>1</Count>
     </item>
     <item>
-        <EFDB_Name>localTime</EFDB_Name>
+        <EFDB_Name>localTimeString</EFDB_Name>
         <Description>Local Time (UTC) as a sexagesimal string (HH:MM:SS.SSS)
 </Description>
         <IDL_Type>string</IDL_Type>

--- a/sal_interfaces/MTPtg/MTPtg_Telemetry.xml
+++ b/sal_interfaces/MTPtg/MTPtg_Telemetry.xml
@@ -549,7 +549,7 @@
         <Count>1</Count>
     </item>
     <item>
-        <EFDB_Name>localTime</EFDB_Name>
+        <EFDB_Name>localTimeString</EFDB_Name>
         <Description>Local Time (UTC) as a sexagesimal string (HH:MM:SS.SSS)
 </Description>
         <IDL_Type>string</IDL_Type>


### PR DESCRIPTION
Renamed attribute 'localTime' to 'localTimeString' to avoid using MySQL reserved word LOCALTIME.