### PR TITLE
At whitelight additions

### DIFF
--- a/sal_interfaces/ATWhiteLight/ATWhiteLight_Commands.xml
+++ b/sal_interfaces/ATWhiteLight/ATWhiteLight_Commands.xml
@@ -41,6 +41,25 @@
     </item>
 </SALCommand>
 <SALCommand>
+	<Subsystem>ATWhiteLight</Subsystem>
+	<Version>3.7.1</Version>
+	<Author></Author>
+	<EFDB_Topic>ATWhiteLight_command_emergencyPowerLightOff</EFDBTopic>
+	<Alias>emergencyPowerLightOff</Alias>
+	<Device></Device>
+	<Property></Property>
+	<Action></Action>
+	<Value></Value>
+	<Explanation>http://sal.lsst.org</Explanation>
+	<item>
+		<EFDB_Name>power</EFDB_Name>
+		<Description></Description>
+		<IDL_Type>boolean</IDL_Type>
+		<Units></Units>
+		<Count>1</Count>
+	</item>
+</SALCommand>
+<SALCommand>
     <Subsystem>ATWhiteLight</Subsystem>
     <Version>3.7.1</Version>
     <Author></Author>

--- a/sal_interfaces/ATWhiteLight/ATWhiteLight_Commands.xml
+++ b/sal_interfaces/ATWhiteLight/ATWhiteLight_Commands.xml
@@ -44,7 +44,7 @@
 	<Subsystem>ATWhiteLight</Subsystem>
 	<Version>3.7.1</Version>
 	<Author></Author>
-	<EFDB_Topic>ATWhiteLight_command_emergencyPowerLightOff</EFDBTopic>
+	<EFDB_Topic>ATWhiteLight_command_emergencyPowerLightOff</EFDB_Topic>
 	<Alias>emergencyPowerLightOff</Alias>
 	<Device></Device>
 	<Property></Property>

--- a/sal_interfaces/ATWhiteLight/ATWhiteLight_Events.xml
+++ b/sal_interfaces/ATWhiteLight/ATWhiteLight_Events.xml
@@ -73,6 +73,13 @@
     <Alias>whiteLightStatus</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
+        <EFDB_Name>wattageChange</EFDB_Name>
+        <Description>Current Wattage reporting from the CSC.</Description>
+        <IDL_Type>float</IDL_Type>  
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>coolingDown</EFDB_Name>
         <Description>Blue LED status from the digital output</Description>
         <IDL_Type>boolean</IDL_Type>

--- a/sal_interfaces/ATWhiteLight/ATWhiteLight_Telemetry.xml
+++ b/sal_interfaces/ATWhiteLight/ATWhiteLight_Telemetry.xml
@@ -27,6 +27,7 @@
         <Units></Units>
         <Count>1</Count>
     </item>
+</SALTelemetry>
 <SALTelemetry>
     <Subsystem>ATWhiteLight</Subsystem>
     <Version>3.7.1</Version>
@@ -39,6 +40,7 @@
         <Units></Units>
         <Count>1</Count>
     </item>
+</SALTelemetry>
 <SALTelemetry>
     <Subsystem>ATWhiteLight</Subsystem>
     <Version>3.7.1</Version>

--- a/sal_interfaces/ATWhiteLight/ATWhiteLight_Telemetry.xml
+++ b/sal_interfaces/ATWhiteLight/ATWhiteLight_Telemetry.xml
@@ -27,4 +27,28 @@
         <Units></Units>
         <Count>1</Count>
     </item>
+<SALTelemetry>
+    <Subsystem>ATWhiteLight</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>ATWhiteLight_bulbHours</EFDB_Topic>
+    <item>
+        <EFDB_Name>bulbHours</EFDB_Name>
+        <Description>The uptime of the WLS bulb</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+<SALTelemetry>
+    <Subsystem>ATWhiteLight</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>ATWhiteLight_bulbWattHours</EFDB_Topic>
+    <item>
+        <EFDB_Name>bulbHours</EFDB_Name>
+        <Description>The uptime in watt-hours of the WLS bulb</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
 </SALTelemetry></SALTelemetrySet>

--- a/sal_interfaces/MTAOS/MTAOS_Commands.xml
+++ b/sal_interfaces/MTAOS/MTAOS_Commands.xml
@@ -145,14 +145,14 @@
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>ra</EFDB_Name>
+            <EFDB_Name>fieldRA</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units></Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>dec</EFDB_Name>
+            <EFDB_Name>fieldDEC</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units></Units>
@@ -208,14 +208,14 @@
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>ra</EFDB_Name>
+            <EFDB_Name>fieldRA</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units></Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>dec</EFDB_Name>
+            <EFDB_Name>fieldDEC</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units></Units>
@@ -263,14 +263,14 @@
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>ra</EFDB_Name>
+            <EFDB_Name>fieldRA</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units></Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>dec</EFDB_Name>
+            <EFDB_Name>fieldDEC</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units></Units>


### PR DESCRIPTION
this updates ts_xml with changes for the AT White Light Source CSC. It adds 

emergencyPowerOff: a command for "emergency" power off, which overrides enforcement of mandatory cooldown and warmup periods designed to extend the life of the bulb. 
wattageChange: the event that is published whenever the KiloArc reports a change in status now includes changes to the wattage output of the bulb
bulbHours and bulbWattHours: telemetry topics that report the uptime of the bulb, so we know when it's getting to be time to replace it