### PR TITLE
trackId attribute added to target commands of ATPtg and MTPtg

### DIFF
--- a/sal_interfaces/ATPtg/ATPtg_Commands.xml
+++ b/sal_interfaces/ATPtg/ATPtg_Commands.xml
@@ -340,6 +340,13 @@
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>rotPA</EFDB_Name>
         <Description>Desired instrument position angle, Eastwards from North</Description>
         <IDL_Type>double</IDL_Type>
@@ -521,6 +528,13 @@
         <EFDB_Name>dRA</EFDB_Name>
         <Description>Differential Track Rate in RA</Description>
         <IDL_Type>double</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
         <Units></Units>
         <Count>1</Count>
     </item>
@@ -761,6 +775,13 @@ fixed   = maintain sky orientation ( = AZEL)
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>rotPA</EFDB_Name>
         <Description>Desired instrument position angle, Eastwards from North</Description>
         <IDL_Type>double</IDL_Type>
@@ -835,6 +856,13 @@ fixed   = maintain sky orientation ( = AZEL)
         <Description>Differential Track Rate in Declination , in addition to the planet's inherent tracking rate
 </Description>
         <IDL_Type>double</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
         <Units></Units>
         <Count>1</Count>
     </item>

--- a/sal_interfaces/MTPtg/MTPtg_Commands.xml
+++ b/sal_interfaces/MTPtg/MTPtg_Commands.xml
@@ -340,6 +340,13 @@
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>rotPA</EFDB_Name>
         <Description>Desired instrument position angle, Eastwards from North</Description>
         <IDL_Type>double</IDL_Type>
@@ -521,6 +528,13 @@
         <EFDB_Name>dRA</EFDB_Name>
         <Description>Differential Track Rate in RA</Description>
         <IDL_Type>double</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
         <Units></Units>
         <Count>1</Count>
     </item>
@@ -761,6 +775,13 @@ fixed   = maintain sky orientation ( = AZEL)
         <Count>1</Count>
     </item>
     <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
         <EFDB_Name>rotPA</EFDB_Name>
         <Description>Desired instrument position angle, Eastwards from North</Description>
         <IDL_Type>double</IDL_Type>
@@ -835,6 +856,13 @@ fixed   = maintain sky orientation ( = AZEL)
         <Description>Differential Track Rate in Declination , in addition to the planet's inherent tracking rate
 </Description>
         <IDL_Type>double</IDL_Type>
+        <Units></Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>trackId</EFDB_Name>
+        <Description>Target identifier.</Description>
+        <IDL_Type>long</IDL_Type>
         <Units></Units>
         <Count>1</Count>
     </item>


### PR DESCRIPTION
TPC-166. trackId attribute is added to ATPtg and MTPtg's raDecTarget, azElTarget, ephemTarget and planetTarget commands.