### PR TITLE
DM-20471: Fix minor errors in Watcher XML

### DIFF
--- a/sal_interfaces/Watcher/Watcher_Commands.xml
+++ b/sal_interfaces/Watcher/Watcher_Commands.xml
@@ -13,7 +13,7 @@
     <Property></Property>
     <Action></Action>
     <Value></Value>
-    <Explanation>Acknowledge an alarm.</Explanation>
+    <Description>Acknowledge an alarm.</Description>
     <item>
         <EFDB_Name>name</EFDB_Name>
         <Description>Name of alarm or alarms to acknowledge. Specify a regular expression to acknowledge multiple alarms.</Description>

--- a/sal_interfaces/Watcher/Watcher_Events.xml
+++ b/sal_interfaces/Watcher/Watcher_Events.xml
@@ -10,7 +10,7 @@
     <Author></Author>
     <EFDB_Topic>Watcher_logevent_heartbeat</EFDB_Topic>
     <Alias>heartbeat</Alias>
-    <Explanation></Explanation>
+    <Description>Standard heartbeat event.</Description>
     <item>
         <EFDB_Name>heartbeat</EFDB_Name>
         <Description>This field is not set.</Description>
@@ -26,7 +26,7 @@
     <Author></Author>
     <EFDB_Topic>Watcher_logevent_alarm</EFDB_Topic>
     <Alias>alarm</Alias>
-    <Explanation>Alarm about a problem.</Explanation>
+    <Description>Alarm about a problem.</Description>
     <item>
         <EFDB_Name>name</EFDB_Name>
         <Description>Name of alarm. Each alarm has a unique name.</Description>


### PR DESCRIPTION
Use Description instead of Explanation for topics.
Add missing description for the heartbeat event.