### PR TITLE
fixed white light event aliases to be unique

### DIFF
--- a/sal_interfaces/ATWhiteLight/ATWhiteLight_Events.xml
+++ b/sal_interfaces/ATWhiteLight/ATWhiteLight_Events.xml
@@ -91,7 +91,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerLowFlowWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerLowFlowWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>
@@ -113,7 +113,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerFluidLevelWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerFluidLevelWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>
@@ -135,7 +135,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerSwitchToSupplyTempWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerSwitchToSupplyTempWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>
@@ -157,7 +157,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerHighControlTempWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerHighControlTempWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>
@@ -179,7 +179,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerLowControlTempWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerLowControlTempWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>
@@ -201,7 +201,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerHighAmbientTempWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerHighAmbientTempWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>
@@ -223,7 +223,7 @@
     <Version>3.8.2</Version>
     <Author>Colin Winslow</Author>
     <EFDB_Topic>ATWhiteLight_logevent_chillerLowAmbientTempWarning</EFDB_Topic>
-    <Alias>chillerWarning</Alias>
+    <Alias>chillerLowAmbientTempWarning</Alias>
     <Explanation>http://sal.lsst.org</Explanation>
     <item>
         <EFDB_Name>warning</EFDB_Name>


### PR DESCRIPTION
Accidentally pushed some changes to atwhitelight events xml straight to develop...Original push was adding unique event topics for each of the chiller's warnings... this PR fixes the non-unique alias fields that were in those changes.