### PR TITLE
Tickets/cap 376

### DIFF
--- a/python/lsst/ts/xml/testutils.py
+++ b/python/lsst/ts/xml/testutils.py
@@ -19,6 +19,8 @@ subsystems = [
     'ATMonochromator', 'ATPneumatics', 'ATPtg', 'ATSpectrograph', 'ATTCS',
     'ATWhiteLight', 'CCArchiver', 'CatchupArchiver', 'CBP', 'DIMM', 'Dome',
     'DSM', 'EAS', 'EFD', 'EFDTransformationServer', 'Electrometer', 'Environment',
+    'ATWhiteLight', 'CatchupArchiver', 'CCCamera', 'CBP', 'DIMM', 'Dome', 'DSM', 'EAS',
+    'EFD', 'EFDTransformationServer', 'Electrometer', 'Environment',
     'FiberSpectrograph', 'GenericCamera', 'IOTA', 'Hexapod', 'HVAC',
     'LinearStage', 'LOVE', 'MTAOS', 'MTArchiver', 'MTCamera',
     'MTDomeTrajectory', 'MTEEC', 'MTGuider', 'MTHeaderService',

--- a/python/lsst/ts/xml/testutils.py
+++ b/python/lsst/ts/xml/testutils.py
@@ -17,17 +17,16 @@ subsystems = [
     'ATAOS', 'ATArchiver', 'ATBuilding', 'ATCamera', 'ATDome',
     'ATDomeTrajectory', 'ATHeaderService', 'ATHexapod', 'ATMCS',
     'ATMonochromator', 'ATPneumatics', 'ATPtg', 'ATSpectrograph', 'ATTCS',
-    'ATWhiteLight', 'CCArchiver', 'CatchupArchiver', 'CBP', 'DIMM', 'Dome',
+    'ATWhiteLight', 'CCArchiver', 'CCCamera', 'CCHeaderService', 'CatchupArchiver',
+    'CBP', 'DIMM', 'Dome',
     'DSM', 'EAS', 'EFD', 'EFDTransformationServer', 'Electrometer', 'Environment',
-    'ATWhiteLight', 'CatchupArchiver', 'CCCamera', 'CBP', 'DIMM', 'Dome', 'DSM', 'EAS',
-    'EFD', 'EFDTransformationServer', 'Electrometer', 'Environment',
     'FiberSpectrograph', 'GenericCamera', 'IOTA', 'Hexapod', 'HVAC',
     'LinearStage', 'LOVE', 'MTAOS', 'MTArchiver', 'MTCamera',
     'MTDomeTrajectory', 'MTEEC', 'MTGuider', 'MTHeaderService',
     'MTLaserTracker', 'MTM1M3', 'MTM1M3TS', 'MTM2', 'MTMount', 'MTPtg', 'MTTCS',
     'MTVMS', 'PointingComponent', 'PromptProcessing', 'Rotator',
     'Scheduler', 'Script', 'ScriptQueue', 'SummitFacility', 'Test',
-    'TunableLaser', 'Watcher', 'CCHeaderService'
+    'TunableLaser', 'Watcher',
 ]
 
 """Define the array of Generic Commands."""

--- a/sal_interfaces/CCCamera/CCCamera_Commands.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Commands.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://project.lsst.org/ts/sal_objects/schema/SALCommandSet.xsl"?>
+<SALCommandSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://project.lsst.org/ts/sal_objects/schema/SALCommandSet.xsd">
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_discardRows</EFDB_Topic>
+    <Alias>discardRows</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>nRows</EFDB_Name>
+        <Description>Number of rows to discard</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_startImage</EFDB_Topic>
+    <Alias>startImage</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>shutter</EFDB_Name>
+        <Description>True if the shutter should be opened/closed</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>science</EFDB_Name>
+        <Description>True if science sensors should be read out</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>guide</EFDB_Name>
+        <Description>True if guide sensors should be read out</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>wfs</EFDB_Name>
+        <Description>True if wavefront sensors should be read out</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timeout</EFDB_Name>
+        <Description>Timeout after which imaging will be abandoned if no endImage command received</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageType</EFDB_Name>
+        <Description>Image type (a.k.a. IMGTYPE) (e.g. e.g. BIAS, DARK, FLAT, FE55, XTALK, CCOB, SPOT...)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>groupId</EFDB_Name>
+        <Description>Image groupId. Used to fill in FITS GROUPID header</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_disableCalibration</EFDB_Topic>
+    <Alias>disableCalibration</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>value</EFDB_Name>
+        <Description>Unused</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_initGuiders</EFDB_Topic>
+    <Alias>initGuiders</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>roiSpec</EFDB_Name>
+        <Description>TBD specification for region of interest</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_enableCalibration</EFDB_Topic>
+    <Alias>enableCalibration</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>value</EFDB_Name>
+        <Description>Unused</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_initImage</EFDB_Topic>
+    <Alias>initImage</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>deltaT</EFDB_Name>
+        <Description>Estimate of time period before takeImages will be issued</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_endImage</EFDB_Topic>
+    <Alias>endImage</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>value</EFDB_Name>
+        <Description>Unused</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_setFilter</EFDB_Topic>
+    <Alias>setFilter</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>name</EFDB_Name>
+        <Description>The filter name to install</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_clear</EFDB_Topic>
+    <Alias>clear</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>nClears</EFDB_Name>
+        <Description>Number of consecutive clear operations to perform</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_command_takeImages</EFDB_Topic>
+    <Alias>takeImages</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
+    <item>
+        <EFDB_Name>numImages</EFDB_Name>
+        <Description>Number of consecutive images to take</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>expTime</EFDB_Name>
+        <Description>Exposure time</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>shutter</EFDB_Name>
+        <Description>True if the shutter should be opened/closed</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>science</EFDB_Name>
+        <Description>True if science sensors should be read out</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>guide</EFDB_Name>
+        <Description>True if guide sensors should be read out</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>wfs</EFDB_Name>
+        <Description>True if wavefront sensors should be read out</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageType</EFDB_Name>
+        <Description>Image type (a.k.a. IMGTYPE) (e.g. e.g. BIAS, DARK, FLAT, FE55, XTALK, CCOB, SPOT...)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>groupId</EFDB_Name>
+        <Description>Image groupId. Used to fill in FITS GROUPID header</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+</SALCommandSet>

--- a/sal_interfaces/CCCamera/CCCamera_Commands.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Commands.xml
@@ -97,7 +97,7 @@
     <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
     <item>
         <EFDB_Name>value</EFDB_Name>
-        <Description>Unused</Description>
+        <Description>Attribute required by the API, but is unused.</Description>
         <IDL_Type>boolean</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>
@@ -136,7 +136,7 @@
     <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
     <item>
         <EFDB_Name>value</EFDB_Name>
-        <Description>Unused</Description>
+        <Description>Attribute required by the API, but is unused.</Description>
         <IDL_Type>boolean</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>
@@ -174,7 +174,7 @@
     <Explanation>http://project.lsst.org/ts/sal_objects/help</Explanation>
     <item>
         <EFDB_Name>value</EFDB_Name>
-        <Description>Unused</Description>
+        <Description>Attribute required by the API, but is unused.</Description>
         <IDL_Type>boolean</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -564,7 +564,7 @@
         <Description></Description>
         <IDL_Type>string</IDL_Type>
         <IDL_Size>256</IDL_Size>
-        <Units>unitless </Units>
+        <Units>unitless</Units>
         <Count>1</Count>
     </item>
 </SALEvent>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -374,7 +374,7 @@
     <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_filterChangerDetailedState.html</Explanation>
     <item>
         <EFDB_Name>substate</EFDB_Name>
-        <Description></Description>
+        <Description>The filter changer state</Description>
         <IDL_Type>long</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -556,22 +556,6 @@
     <Subsystem>CCCamera</Subsystem>
     <Version>3.7.1</Version>
     <Author></Author>
-    <EFDB_Topic>CCCamera_logevent_settingsApplied</EFDB_Topic>
-    <Alias>settingsApplied</Alias>
-    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_settingsApplied.html</Explanation>
-    <item>
-        <EFDB_Name>settings</EFDB_Name>
-        <Description></Description>
-        <IDL_Type>string</IDL_Type>
-        <IDL_Size>256</IDL_Size>
-        <Units>unitless</Units>
-        <Count>1</Count>
-    </item>
-</SALEvent>
-<SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <Version>3.7.1</Version>
-    <Author></Author>
     <EFDB_Topic>CCCamera_logevent_endSetFilter</EFDB_Topic>
     <Alias>endSetFilter</Alias>
     <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endSetFilter.html</Explanation>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -1,0 +1,831 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://project.lsst.org/ts/sal_objects/schema/SALEventSet.xsl"?>
+<SALEventSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://project.lsst.org/ts/sal_objects/schema/SALEventSet.xsd">
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_offlineDetailedState</EFDB_Topic>
+    <Alias>offlineDetailedState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_offlineDetailedState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description>Enumeration of valid substates</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>OFFLINE_AVAILABLE,OFFLINE_PUBLISH_ONLY</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endReadout</EFDB_Topic>
+    <Alias>endReadout</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endReadout.html</Explanation>
+    <item>
+        <EFDB_Name>imageType</EFDB_Name>
+        <Description>The imageType as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>groupId</EFDB_Name>
+        <Description>The groupId as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageName</EFDB_Name>
+        <Description>The imageName for this specific exposure, assigned by the camera</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>32</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageIndex</EFDB_Name>
+        <Description>The zero based index number for this specific exposure within the sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageSource</EFDB_Name>
+        <Description>The source component of the image name (AT/CC/MC)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>2</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageController</EFDB_Name>
+        <Description>The controller for the image  (O=OCS/C=CCS/...)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageDate</EFDB_Name>
+        <Description>The date component of the image name (YYYYMMDD)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>8</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageNumber</EFDB_Name>
+        <Description>The image number (SEQNO) component of the image name</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timeStampAcquisitionStart</EFDB_Name>
+        <Description>The effective time at which the image acquisition started (i.e. the end of the previous clear or readout)</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>exposureTime</EFDB_Name>
+        <Description>The requested exposure time</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <!-- Extra info add to endReadout as part of CAP-209 -->
+    <item>
+        <EFDB_Name>timeStampEndOfReadout</EFDB_Name>
+        <Description>The time at which the readout was completed</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>  
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endTakeImage</EFDB_Topic>
+    <Alias>endTakeImage</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endTakeImage.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_imageReadinessDetailedState</EFDB_Topic>
+    <Alias>imageReadinessDetailedState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_imageReadinessDetailedState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description>Enumeration of valid substates</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>READY,NOT_READY,GETTING_READY</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startSetFilter</EFDB_Topic>
+    <Alias>startSetFilter</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startSetFilter.html</Explanation>
+    <item>
+        <EFDB_Name>filterName</EFDB_Name>
+        <Description>The name of the filter being installed (e.g. U-001)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startUnloadFilter</EFDB_Topic>
+    <Alias>startUnloadFilter</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startUnloadFilter.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_notReadyToTakeImage</EFDB_Topic>
+    <Alias>notReadyToTakeImage</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_notReadyToTakeImage.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startShutterClose</EFDB_Topic>
+    <Alias>startShutterClose</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startShutterClose.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endInitializeGuider</EFDB_Topic>
+    <Alias>endInitializeGuider</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endInitializeGuider.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endShutterClose</EFDB_Topic>
+    <Alias>endShutterClose</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endShutterClose.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endOfImageTelemetry</EFDB_Topic>
+    <Alias>endOfImageTelemetry</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endOfImageTelemetry.html</Explanation>
+    <item>
+        <EFDB_Name>imageType</EFDB_Name>
+        <Description>The imageType as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>groupId</EFDB_Name>
+        <Description>The groupId as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageName</EFDB_Name>
+        <Description>The imageName for this specific exposure, assigned by the camera</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>32</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageIndex</EFDB_Name>
+        <Description>The zero based index number for this specific exposure within the sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageSource</EFDB_Name>
+        <Description>The source component of the image name (AT/CC/MC)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>2</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageController</EFDB_Name>
+        <Description>The controller for the image  (O=OCS/C=CCS/...)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageDate</EFDB_Name>
+        <Description>The date component of the image name (YYYYMMDD)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>8</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageNumber</EFDB_Name>
+        <Description>The image number (SEQNO) component of the image name</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timeStampAcquisitionStart</EFDB_Name>
+        <Description>The effective time at which the image acquisition started (i.e. the end of the previous clear or readout)</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>exposureTime</EFDB_Name>
+        <Description>The requested exposure time</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <!-- Additional information added as part of CAP-209. -->
+    <item>
+        <EFDB_Name>imageTag</EFDB_Name>
+        <Description>The DAQ assigned image tag (hex string)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>64</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timestampDateObs</EFDB_Name>
+        <Description>The observation date, as computed by CCS (as TAI)</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timestampDateEnd</EFDB_Name>
+        <Description>The end observation date, as computed by CCS (as TAI)</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>expTime</EFDB_Name>
+        <Description>The exposure time, as computed by CCS</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>darkTime</EFDB_Name>
+        <Description>The dark time, as computed by CCS</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endUnloadFilter</EFDB_Topic>
+    <Alias>endUnloadFilter</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endUnloadFilter.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_calibrationDetailedState</EFDB_Topic>
+    <Alias>calibrationDetailedState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_calibrationDetailedState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description>Enumeration of valid substates</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>DISABLED,ENABLED,INTEGRATING</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endRotateCarousel</EFDB_Topic>
+    <Alias>endRotateCarousel</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endRotateCarousel.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startLoadFilter</EFDB_Topic>
+    <Alias>startLoadFilter</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startLoadFilter.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_filterChangerDetailedState</EFDB_Topic>
+    <Alias>filterChangerDetailedState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_filterChangerDetailedState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>UNLOADING,LOADING,LOADED,UNLOADED,ROTATING</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_shutterDetailedState</EFDB_Topic>
+    <Alias>shutterDetailedState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_shutterDetailedState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description>Enumeration of valid substates</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>CLOSED,OPEN,CLOSING,OPENING</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_readyToTakeImage</EFDB_Topic>
+    <Alias>readyToTakeImage</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_readyToTakeImage.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_ccsCommandState</EFDB_Topic>
+    <Alias>ccsCommandState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_ccsCommandState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description>Substate of the CCS command.</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>IDLE,BUSY</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_prepareToTakeImage</EFDB_Topic>
+    <Alias>prepareToTakeImage</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_prepareToTakeImage.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_ccsConfigured</EFDB_Topic>
+    <Alias>ccsConfigured</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_ccsConfigured.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endLoadFilter</EFDB_Topic>
+    <Alias>endLoadFilter</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endLoadFilter.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endShutterOpen</EFDB_Topic>
+    <Alias>endShutterOpen</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endShutterOpen.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startIntegration</EFDB_Topic>
+    <Alias>startIntegration</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startIntegration.html</Explanation>
+    <item>
+        <EFDB_Name>imageType</EFDB_Name>
+        <Description>The imageType as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>groupId</EFDB_Name>
+        <Description>The groupId as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageName</EFDB_Name>
+        <Description>The imageName for this specific exposure, assigned by the camera</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>32</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageIndex</EFDB_Name>
+        <Description>The zero based index number for this specific exposure within the sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageSource</EFDB_Name>
+        <Description>The source component of the image name (AT/CC/MC)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>2</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageController</EFDB_Name>
+        <Description>The controller for the image  (O=OCS/C=CCS/...)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageDate</EFDB_Name>
+        <Description>The date component of the image name (YYYYMMDD)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>8</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageNumber</EFDB_Name>
+        <Description>The image number (SEQNO) component of the image name</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timeStampAcquisitionStart</EFDB_Name>
+        <Description>The effective time at which the image acquisition started (i.e. the end of the previous clear or readout)</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>exposureTime</EFDB_Name>
+        <Description>The requested exposure time</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endInitializeImage</EFDB_Topic>
+    <Alias>endInitializeImage</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endInitializeImage.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_settingsApplied</EFDB_Topic>
+    <Alias>settingsApplied</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_settingsApplied.html</Explanation>
+    <item>
+        <EFDB_Name>settings</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless </Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_endSetFilter</EFDB_Topic>
+    <Alias>endSetFilter</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_endSetFilter.html</Explanation>
+    <item>
+        <EFDB_Name>filterName</EFDB_Name>
+        <Description>The name of the filter being installed (e.g. U-001)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startShutterOpen</EFDB_Topic>
+    <Alias>startShutterOpen</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startShutterOpen.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_raftsDetailedState</EFDB_Topic>
+    <Alias>raftsDetailedState</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_raftsDetailedState.html</Explanation>
+    <item>
+        <EFDB_Name>substate</EFDB_Name>
+        <Description>Enumeration of valid substates</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+        <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT</Enumeration>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_availableFilters</EFDB_Topic>
+    <Alias>availableFilters</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_availableFilters.html</Explanation>
+    <item>
+        <EFDB_Name>filterNames</EFDB_Name>
+        <Description>A list of installed filter names (comma delimimted, U-001,G-004,R-010,Z-012,Y-014), in the same order as the list of filter types.</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startReadout</EFDB_Topic>
+    <Alias>startReadout</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startReadout.html</Explanation>
+    <item>
+        <EFDB_Name>imageType</EFDB_Name>
+        <Description>The imageType as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>groupId</EFDB_Name>
+        <Description>The groupId as passed to the takeImages command</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>256</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imagesInSequence</EFDB_Name>
+        <Description>The total number of requested images in sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageName</EFDB_Name>
+        <Description>The imageName for this specific exposure, assigned by the camera</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>32</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageIndex</EFDB_Name>
+        <Description>The zero based index number for this specific exposure within the sequence</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageSource</EFDB_Name>
+        <Description>The source component of the image name (AT/CC/MC)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>2</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageController</EFDB_Name>
+        <Description>The controller for the image  (O=OCS/C=CCS/...)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageDate</EFDB_Name>
+        <Description>The date component of the image name (YYYYMMDD)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>8</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>imageNumber</EFDB_Name>
+        <Description>The image number (SEQNO) component of the image name</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>timeStampAcquisitionStart</EFDB_Name>
+        <Description>The effective time at which the image acquisition started (i.e. the end of the previous clear or readout)</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>exposureTime</EFDB_Name>
+        <Description>The requested exposure time</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item>
+    <!-- Extra info add to startReadout as part of CAP-209 -->
+    <item>
+        <EFDB_Name>timeStampStartOfReadout</EFDB_Name>
+        <Description>The time at which the readout was triggered</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>second</Units>
+        <Count>1</Count>
+    </item> 
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_startRotateCarousel</EFDB_Topic>
+    <Alias>startRotateCarousel</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_startRotateCarousel.html</Explanation>
+</SALEvent>
+<SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.7.1</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_logevent_imageReadoutParameters</EFDB_Topic>
+    <Alias>imageReadoutParameters</Alias>
+    <Explanation>http://project.lsst.org/ts/sal_objects/help/CCCamera_logevent_imageReadoutParameters.html</Explanation>
+    <item>
+        <EFDB_Name>imageName</EFDB_Name>
+        <Description>The imageName for this specific exposure</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdNames</EFDB_Name>
+        <Description>A list of all ccds currently configured, of the form RnnSnn, : delimited (empty if entry not used)</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdType</EFDB_Name>
+        <Description>The type of each CCD, this determines segRows, segCols and serCols</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+        <Enumeration>E2V, ITL</Enumeration>
+    </item>
+    <item>
+        <EFDB_Name>overRows</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>overCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>readRows</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>readCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>readCols2</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>preCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>preRows</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>postCols</EFDB_Name>
+        <Description>See CCD Readout Parameters Diagram</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+</SALEvent>
+</SALEventSet>

--- a/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -8,21 +8,21 @@
         <Author></Author>
         <EFDB_Topic>CCCamera_filterChanger</EFDB_Topic>
         <item>
-            <EFDB_Name>MotorTemperature</EFDB_Name>
+            <EFDB_Name>motorTemperature</EFDB_Name>
             <Description>Measured motor temperature provided by motor controller</Description>
             <IDL_Type>float</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>MotorEncoder</EFDB_Name>
+            <EFDB_Name>motorEncoder</EFDB_Name>
             <Description>Relative position based on motor travel since startup</Description>
             <IDL_Type>float</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>LinearPosition</EFDB_Name>
+            <EFDB_Name>linearPosition</EFDB_Name>
             <Description>Filter changer position measured by linear encoder (0.005 mm)</Description>
             <IDL_Type>float</IDL_Type>
             <Units>unitless</Units>
@@ -34,73 +34,73 @@
         <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumTurboPump</EFDB_Topic>
         <item>
-            <EFDB_Name>TurboContTempAir</EFDB_Name>
+            <EFDB_Name>turboContTempAir</EFDB_Name>
             <Description>Turbo pump controller air temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboContTempSink</EFDB_Name>
+            <EFDB_Name>turboContTempSink</EFDB_Name>
             <Description>Turbo pump controller sink temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboCurrent</EFDB_Name>
+            <EFDB_Name>turboCurrent</EFDB_Name>
             <Description>Turbo pump current</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>amps</Units>
+            <Units>ampere</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboDriveFreq</EFDB_Name>
+            <EFDB_Name>turboDriveFreq</EFDB_Name>
             <Description>Turbopump drive frequency</Description>
             <IDL_Type>double</IDL_Type>
             <Units>hertz</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboPower</EFDB_Name>
+            <EFDB_Name>turboPower</EFDB_Name>
             <Description>Turbo pump power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboPumpTemp</EFDB_Name>
+            <EFDB_Name>turboPumpTemp</EFDB_Name>
             <Description>Turbo pump temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboRPM</EFDB_Name>
+            <EFDB_Name>turboRPM</EFDB_Name>
             <Description>Turbo pump RPM</Description>
             <IDL_Type>float</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboSpeed</EFDB_Name>
+            <EFDB_Name>turboSpeed</EFDB_Name>
             <Description>Turbo pump speed</Description>
             <IDL_Type>double</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboStatus</EFDB_Name>
+            <EFDB_Name>turboStatus</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>TurboVoltage</EFDB_Name>
+            <EFDB_Name>turboVoltage</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
-            <Units>volts</Units>
+            <Units>volt</Units>
             <Count>1</Count>
         </item>
     </SALTelemetry>
@@ -109,14 +109,14 @@
         <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumIonPump</EFDB_Topic>
         <item>
-            <EFDB_Name>CIP1_V</EFDB_Name>
+            <EFDB_Name>cIP1_V</EFDB_Name>
             <Description>Cryo Ion pump 1 voltage</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>volts</Units>
+            <Units>Volt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CIP1_I</EFDB_Name>
+            <EFDB_Name>cIP1_I</EFDB_Name>
             <Description>Cryo Ion pump 1 current</Description>
             <IDL_Type>double</IDL_Type>
             <Units>mA</Units>
@@ -128,59 +128,59 @@
         <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumCryoTelColdPlate1</EFDB_Topic>
        <item>
-            <EFDB_Name>Cold1AutoOff</EFDB_Name>
+            <EFDB_Name>cold1AutoOff</EFDB_Name>
             <Description>Cooler auto off state</Description>
             <IDL_Type>double</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1Pwr</EFDB_Name>
+            <EFDB_Name>cold1Pwr</EFDB_Name>
             <Description>Cooler power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1RejectTemp</EFDB_Name>
+            <EFDB_Name>cold1RejectTemp</EFDB_Name>
             <Description>Cooler reject temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1Temp</EFDB_Name>
+            <EFDB_Name>cold1Temp</EFDB_Name>
             <Description>Cooler temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1SetPt</EFDB_Name>
+            <EFDB_Name>cold1SetPt</EFDB_Name>
             <Description>cryo set point</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1SetPwr</EFDB_Name>
+            <EFDB_Name>cold1SetPwr</EFDB_Name>
             <Description>Cryo set power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1AutoOffTemp</EFDB_Name>
+            <EFDB_Name>cold1AutoOffTemp</EFDB_Name>
             <Description>cryo auto off temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold1AutoOnTemp</EFDB_Name>
+            <EFDB_Name>cold1AutoOnTemp</EFDB_Name>
             <Description>cryo auto on temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
     </SALTelemetry>
@@ -189,59 +189,59 @@
         <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumCryoTelColdPlate2</EFDB_Topic>
        <item>
-            <EFDB_Name>Cold2AutoOff</EFDB_Name>
+            <EFDB_Name>cold2AutoOff</EFDB_Name>
             <Description>Cooler auto off state</Description>
             <IDL_Type>double</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2Pwr</EFDB_Name>
+            <EFDB_Name>cold2Pwr</EFDB_Name>
             <Description>Cooler power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2RejectTemp</EFDB_Name>
+            <EFDB_Name>cold2RejectTemp</EFDB_Name>
             <Description>Cooler reject temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2Temp</EFDB_Name>
+            <EFDB_Name>cold2Temp</EFDB_Name>
             <Description>Cooler temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2SetPt</EFDB_Name>
+            <EFDB_Name>cold2SetPt</EFDB_Name>
             <Description>cryo set point</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2SetPwr</EFDB_Name>
+            <EFDB_Name>cold2SetPwr</EFDB_Name>
             <Description>Cryo set power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2AutoOffTemp</EFDB_Name>
+            <EFDB_Name>cold2AutoOffTemp</EFDB_Name>
             <Description>cryo auto off temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>Cold2AutoOnTemp</EFDB_Name>
+            <EFDB_Name>cold2AutoOnTemp</EFDB_Name>
             <Description>cryo auto on temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
     </SALTelemetry>
@@ -250,59 +250,59 @@
         <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumCryoTelCryoPlate</EFDB_Topic>
         <item>
-            <EFDB_Name>CryoAutoOff</EFDB_Name>
+            <EFDB_Name>cryoAutoOff</EFDB_Name>
             <Description>Cooler auto off state</Description>
             <IDL_Type>double</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoPwr</EFDB_Name>
+            <EFDB_Name>cryoPwr</EFDB_Name>
             <Description>Cooler power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoRejectTemp</EFDB_Name>
+            <EFDB_Name>cryoRejectTemp</EFDB_Name>
             <Description>Cooler reject temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoTemp</EFDB_Name>
+            <EFDB_Name>cryoTemp</EFDB_Name>
             <Description>Cooler temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoSetPt</EFDB_Name>
+            <EFDB_Name>cryoSetPt</EFDB_Name>
             <Description>cryo set point</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoSetPwr</EFDB_Name>
+            <EFDB_Name>cryoSetPwr</EFDB_Name>
             <Description>Cryo set power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoAutoOffTemp</EFDB_Name>
+            <EFDB_Name>cryoAutoOffTemp</EFDB_Name>
             <Description>cryo auto off temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>CryoAutoOnTemp</EFDB_Name>
+            <EFDB_Name>cryoAutoOnTemp</EFDB_Name>
             <Description>cryo auto on temperature</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>celsius</Units>
+            <Units>Celsius</Units>
             <Count>1</Count>
         </item>
     </SALTelemetry>
@@ -343,31 +343,31 @@
  <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumPowerDistributionUnit</EFDB_Topic>
         <item>
-            <EFDB_Name>PDU20Current</EFDB_Name>
+            <EFDB_Name>pDU20Current</EFDB_Name>
             <Description>PDU 20 current</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>amps</Units>
+            <Units>ampere</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>PDU20Power</EFDB_Name>
+            <EFDB_Name>pDU20Power</EFDB_Name>
             <Description>PDU 20 power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>amps</Units>
+            <Units>ampere</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>PDU15Current</EFDB_Name>
+            <EFDB_Name>pDU15Current</EFDB_Name>
             <Description>PDU 15 current</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>amps</Units>
+            <Units>ampere</Units>
             <Count>1</Count>
         </item>
         <item>
-            <EFDB_Name>PDU15Power</EFDB_Name>
+            <EFDB_Name>pDU15Power</EFDB_Name>
             <Description>PDU 15 power</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>watts</Units>
+            <Units>watt</Units>
             <Count>1</Count>
         </item>
 </SALTelemetry>
@@ -375,10 +375,10 @@
  <Version>3.10.2</Version>
         <EFDB_Topic>CCCamera_vacuumStatus</EFDB_Topic>
         <item>
-            <EFDB_Name>VQMState</EFDB_Name>
+            <EFDB_Name>vQMState</EFDB_Name>
             <Description>vacuum state</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>amps</Units>
+            <Units>ampere</Units>
             <Count>1</Count>
         </item>
 </SALTelemetry>

--- a/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://project.lsst.org/ts/sal_objects/schema/SALTelemetrySet.xsl"?>
+<SALTelemetrySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://project.lsst.org/ts/sal_objects/schema/SALTelemetrySet.xsd">
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <Author></Author>
+        <EFDB_Topic>CCCamera_filterChanger</EFDB_Topic>
+        <item>
+            <EFDB_Name>MotorTemperature</EFDB_Name>
+            <Description>Measured motor temperature provided by motor controller</Description>
+            <IDL_Type>float</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>MotorEncoder</EFDB_Name>
+            <Description>Relative position based on motor travel since startup</Description>
+            <IDL_Type>float</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>LinearPosition</EFDB_Name>
+            <Description>Filter changer position measured by linear encoder (0.005 mm)</Description>
+            <IDL_Type>float</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>    
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumTurboPump</EFDB_Topic>
+        <item>
+            <EFDB_Name>TurboContTempAir</EFDB_Name>
+            <Description>Turbo pump controller air temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboContTempSink</EFDB_Name>
+            <Description>Turbo pump controller sink temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboCurrent</EFDB_Name>
+            <Description>Turbo pump current</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>amps</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboDriveFreq</EFDB_Name>
+            <Description>Turbopump drive frequency</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>hertz</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboPower</EFDB_Name>
+            <Description>Turbo pump power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboPumpTemp</EFDB_Name>
+            <Description>Turbo pump temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboRPM</EFDB_Name>
+            <Description>Turbo pump RPM</Description>
+            <IDL_Type>float</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboSpeed</EFDB_Name>
+            <Description>Turbo pump speed</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboStatus</EFDB_Name>
+            <Description></Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>TurboVoltage</EFDB_Name>
+            <Description></Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>volts</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumIonPump</EFDB_Topic>
+        <item>
+            <EFDB_Name>CIP1_V</EFDB_Name>
+            <Description>Cryo Ion pump 1 voltage</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>volts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CIP1_I</EFDB_Name>
+            <Description>Cryo Ion pump 1 current</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>mA</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumCryoTelColdPlate1</EFDB_Topic>
+       <item>
+            <EFDB_Name>Cold1AutoOff</EFDB_Name>
+            <Description>Cooler auto off state</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1Pwr</EFDB_Name>
+            <Description>Cooler power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1RejectTemp</EFDB_Name>
+            <Description>Cooler reject temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1Temp</EFDB_Name>
+            <Description>Cooler temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1SetPt</EFDB_Name>
+            <Description>cryo set point</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1SetPwr</EFDB_Name>
+            <Description>Cryo set power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1AutoOffTemp</EFDB_Name>
+            <Description>cryo auto off temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold1AutoOnTemp</EFDB_Name>
+            <Description>cryo auto on temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumCryoTelColdPlate2</EFDB_Topic>
+       <item>
+            <EFDB_Name>Cold2AutoOff</EFDB_Name>
+            <Description>Cooler auto off state</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2Pwr</EFDB_Name>
+            <Description>Cooler power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2RejectTemp</EFDB_Name>
+            <Description>Cooler reject temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2Temp</EFDB_Name>
+            <Description>Cooler temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2SetPt</EFDB_Name>
+            <Description>cryo set point</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2SetPwr</EFDB_Name>
+            <Description>Cryo set power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2AutoOffTemp</EFDB_Name>
+            <Description>cryo auto off temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>Cold2AutoOnTemp</EFDB_Name>
+            <Description>cryo auto on temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumCryoTelCryoPlate</EFDB_Topic>
+        <item>
+            <EFDB_Name>CryoAutoOff</EFDB_Name>
+            <Description>Cooler auto off state</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>unitless</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoPwr</EFDB_Name>
+            <Description>Cooler power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoRejectTemp</EFDB_Name>
+            <Description>Cooler reject temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoTemp</EFDB_Name>
+            <Description>Cooler temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoSetPt</EFDB_Name>
+            <Description>cryo set point</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoSetPwr</EFDB_Name>
+            <Description>Cryo set power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoAutoOffTemp</EFDB_Name>
+            <Description>cryo auto off temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>CryoAutoOnTemp</EFDB_Name>
+            <Description>cryo auto on temperature</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>celsius</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>
+    <SALTelemetry>
+        <Subsystem>CCCamera</Subsystem>
+        <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumPressureGauge</EFDB_Topic>
+        <item>
+            <EFDB_Name>vqmpressure</EFDB_Name>
+            <Description></Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>torr</Units>
+            <Count>1</Count>
+        </item>
+    </SALTelemetry>
+    <SALTelemetry>
+    <Subsystem>CCCamera</Subsystem>
+    <Version>3.10.2</Version>
+    <Author></Author>
+    <EFDB_Topic>CCCamera_bonnShutter</EFDB_Topic>
+    <item>
+        <EFDB_Name>shutter5V</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>float</IDL_Type>
+        <Units>volt</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>shutter36V</EFDB_Name>
+        <Description></Description>
+        <IDL_Type>float</IDL_Type>
+        <Units>volt</Units>
+        <Count>1</Count>
+    </item>
+</SALTelemetry>
+
+<SALTelemetry>
+ <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumPowerDistributionUnit</EFDB_Topic>
+        <item>
+            <EFDB_Name>PDU20Current</EFDB_Name>
+            <Description>PDU 20 current</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>amps</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>PDU20Power</EFDB_Name>
+            <Description>PDU 20 power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>amps</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>PDU15Current</EFDB_Name>
+            <Description>PDU 15 current</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>amps</Units>
+            <Count>1</Count>
+        </item>
+        <item>
+            <EFDB_Name>PDU15Power</EFDB_Name>
+            <Description>PDU 15 power</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>watts</Units>
+            <Count>1</Count>
+        </item>
+</SALTelemetry>
+<SALTelemetry>
+ <Version>3.10.2</Version>
+        <EFDB_Topic>CCCamera_vacuumStatus</EFDB_Topic>
+        <item>
+            <EFDB_Name>VQMState</EFDB_Name>
+            <Description>vacuum state</Description>
+            <IDL_Type>double</IDL_Type>
+            <Units>amps</Units>
+            <Count>1</Count>
+        </item>
+</SALTelemetry>
+
+</SALTelemetrySet>

--- a/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -91,14 +91,14 @@
         </item>
         <item>
             <EFDB_Name>turboStatus</EFDB_Name>
-            <Description></Description>
+            <Description>TBD</Description>
             <IDL_Type>double</IDL_Type>
             <Units>unitless</Units>
             <Count>1</Count>
         </item>
         <item>
             <EFDB_Name>turboVoltage</EFDB_Name>
-            <Description></Description>
+            <Description>Turbo pump voltage</Description>
             <IDL_Type>double</IDL_Type>
             <Units>volt</Units>
             <Count>1</Count>
@@ -312,7 +312,7 @@
         <EFDB_Topic>CCCamera_vacuumPressureGauge</EFDB_Topic>
         <item>
             <EFDB_Name>vqmpressure</EFDB_Name>
-            <Description></Description>
+            <Description>Pressure as measured by VQM gauge</Description>
             <IDL_Type>double</IDL_Type>
             <Units>Torr</Units>
             <Count>1</Count>
@@ -325,14 +325,14 @@
     <EFDB_Topic>CCCamera_bonnShutter</EFDB_Topic>
     <item>
         <EFDB_Name>shutter5V</EFDB_Name>
-        <Description></Description>
+        <Description>Measured 5v supply coltage to bonn shutter</Description>
         <IDL_Type>float</IDL_Type>
         <Units>volt</Units>
         <Count>1</Count>
     </item>
     <item>
         <EFDB_Name>shutter36V</EFDB_Name>
-        <Description></Description>
+        <Description>Measured 24v supply voltage to bonn shutter</Description>
         <IDL_Type>float</IDL_Type>
         <Units>volt</Units>
         <Count>1</Count>

--- a/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -112,7 +112,7 @@
             <EFDB_Name>cIP1_V</EFDB_Name>
             <Description>Cryo Ion pump 1 voltage</Description>
             <IDL_Type>double</IDL_Type>
-            <Units>Volt</Units>
+            <Units>volt</Units>
             <Count>1</Count>
         </item>
         <item>
@@ -314,7 +314,7 @@
             <EFDB_Name>vqmpressure</EFDB_Name>
             <Description></Description>
             <IDL_Type>double</IDL_Type>
-            <Units>torr</Units>
+            <Units>Torr</Units>
             <Count>1</Count>
         </item>
     </SALTelemetry>

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -670,6 +670,29 @@
 </SALSubsystem>
 
 <SALSubsystem>
+  <Name>CCCamera</Name>
+  <Description>ComCam camera</Description>
+  <Enumeration></Enumeration>
+  <Generics>yes</Generics>
+  <Version></Version>
+  <Author>CCS Team</Author>
+  <ActiveDevelopers></ActiveDevelopers>
+  <PrincipalCSCOwner>Tony Johnson</PrincipalCSCOwner>
+  <Github>http://github.com/lsst-camera-ccs/</Github>
+  <JenkinsTestResults></JenkinsTestResults>
+  <LSSTPoC></LSSTPoC>
+  <CSCDocs></CSCDocs>
+  <ProductOwner></ProductOwner>
+  <RelatedDocuments>LSE-71</RelatedDocuments>
+  <SoftwareLanguage>Java</SoftwareLanguage>
+  <RuntimeLanguages>CPP,LabVIEW,Java,PyDDS,Python</RuntimeLanguages>
+  <VendorPoC></VendorPoC>
+  <ErrorCode></ErrorCode>
+  <Simulator></Simulator>
+  <Configurable>No</Configurable>
+</SALSubsystem>
+
+<SALSubsystem>
   <Name>MTCamera</Name>
   <Description>LSST Main Camera</Description>
   <Enumeration></Enumeration>

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -560,16 +560,16 @@
   <Enumeration></Enumeration>
   <Generics>yes</Generics>
   <Version></Version>
-  <Author></Author>
+  <Author>CCS Team</Author>
   <ActiveDevelopers></ActiveDevelopers>
-  <PrincipalCSCOwner></PrincipalCSCOwner>
-  <Github></Github>
+  <PrincipalCSCOwner>Tony Johnson</PrincipalCSCOwner>
+  <Github>http://github.com/lsst-camera-ccs/</Github>
   <JenkinsTestResults></JenkinsTestResults>
   <LSSTPoC></LSSTPoC>
   <CSCDocs></CSCDocs>
   <ProductOwner></ProductOwner>
-  <RelatedDocuments></RelatedDocuments>
-  <SoftwareLanguage></SoftwareLanguage>
+  <RelatedDocuments>LSE-71</RelatedDocuments>
+  <SoftwareLanguage>Java</SoftwareLanguage>
   <RuntimeLanguages>CPP,LabVIEW,Java,PyDDS,Python</RuntimeLanguages>
   <VendorPoC></VendorPoC>
   <ErrorCode></ErrorCode>
@@ -671,20 +671,20 @@
 
 <SALSubsystem>
   <Name>MTCamera</Name>
-  <Description></Description>
+  <Description>LSST Main Camera</Description>
   <Enumeration></Enumeration>
   <Generics>yes</Generics>
   <Version></Version>
-  <Author></Author>
+  <Author>CCS Team</Author>
   <ActiveDevelopers></ActiveDevelopers>
-  <PrincipalCSCOwner></PrincipalCSCOwner>
-  <Github></Github>
+  <PrincipalCSCOwner>Tony Johnson</PrincipalCSCOwner>
+  <Github>http://github.com/lsst-camera-ccs</Github>
   <JenkinsTestResults></JenkinsTestResults>
   <LSSTPoC></LSSTPoC>
   <CSCDocs></CSCDocs>
   <ProductOwner></ProductOwner>
-  <RelatedDocuments></RelatedDocuments>
-  <SoftwareLanguage></SoftwareLanguage>
+  <RelatedDocuments>LSE-71</RelatedDocuments>
+  <SoftwareLanguage>Java</SoftwareLanguage>
   <RuntimeLanguages>CPP,LabVIEW,Java,PyDDS,Python</RuntimeLanguages>
   <VendorPoC></VendorPoC>
   <ErrorCode></ErrorCode>

--- a/tests/test_NoReservedWords.py
+++ b/tests/test_NoReservedWords.py
@@ -32,6 +32,9 @@ def check_for_issues(csc, topic, language):
     elif (csc == "MTCamera" and topic == "Commands" and
             language == "optional"):
         jira = "CAP-397"
+    elif (csc == "CCCamera" and topic == "Commands" and
+            language == "optional"):
+        jira = "CAP-402"
     elif (csc == "MTMount" and topic == "Commands" and
             language == "critical"):
         jira = "DM-22622"


### PR DESCRIPTION
Starter set of ComCam commands/events/telemetry. Should be included in ts_xml 4.6 release.
Note pytest was riun, and appeared to pass except for unit torr (see CAP-396)