### PR TITLE
Tickets/cap 355

### DIFF
--- a/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -693,8 +693,8 @@
     <Subsystem>ATCamera</Subsystem>
     <Version>3.7.1</Version>
     <Author></Author>
-    <EFDB_Topic>ATCamera_logevent_settingsApplied</EFDB_Topic>
-    <Alias>settingsApplied</Alias>
+    <EFDB_Topic>ATCamera_logevent_settingsAppliedLegacy</EFDB_Topic>
+    <Alias>settingsAppliedLegacy</Alias>
     <Explanation>http://project.lsst.org/ts/sal_objects/help/ATCamera_logevent_settingsApplied.html</Explanation>
     <item>
         <EFDB_Name>settings</EFDB_Name>

--- a/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -556,22 +556,6 @@
     <Subsystem>MTCamera</Subsystem>
     <Version>3.7.1</Version>
     <Author></Author>
-    <EFDB_Topic>MTCamera_logevent_settingsAppliedLegacy</EFDB_Topic>
-    <Alias>settingsAppliedLegacy</Alias>
-    <Explanation>http://project.lsst.org/ts/sal_objects/help/MTCamera_logevent_settingsApplied.html</Explanation>
-    <item>
-        <EFDB_Name>settings</EFDB_Name>
-        <Description></Description>
-        <IDL_Type>string</IDL_Type>
-        <IDL_Size>256</IDL_Size>
-        <Units>unitless </Units>
-        <Count>1</Count>
-    </item>
-</SALEvent>
-<SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <Version>3.7.1</Version>
-    <Author></Author>
     <EFDB_Topic>MTCamera_logevent_endSetFilter</EFDB_Topic>
     <Alias>endSetFilter</Alias>
     <Explanation>http://project.lsst.org/ts/sal_objects/help/MTCamera_logevent_endSetFilter.html</Explanation>

--- a/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -556,8 +556,8 @@
     <Subsystem>MTCamera</Subsystem>
     <Version>3.7.1</Version>
     <Author></Author>
-    <EFDB_Topic>MTCamera_logevent_settingsApplied</EFDB_Topic>
-    <Alias>settingsApplied</Alias>
+    <EFDB_Topic>MTCamera_logevent_settingsAppliedLegacy</EFDB_Topic>
+    <Alias>settingsAppliedLegacy</Alias>
     <Explanation>http://project.lsst.org/ts/sal_objects/help/MTCamera_logevent_settingsApplied.html</Explanation>
     <item>
         <EFDB_Name>settings</EFDB_Name>


### PR DESCRIPTION
Renamed settings applied event for ATCamera to settingsAppliedLegacy (pending future removal assuming new generic event can be used to handle all needed information).
settingsApplied event removed from MTCamera
