### PR TITLE
Split the Reserved Word tests into three parts

### DIFF
--- a/python/lsst/ts/xml/testutils.py
+++ b/python/lsst/ts/xml/testutils.py
@@ -58,7 +58,11 @@ idl_reserved = [
     'VALUETYPE', 'VOID', 'WCHAR', 'WSTRING'
 ]
 
-db_reserved = [
+db_critical_reserved = [
+    "TIME"
+]
+
+db_optional_reserved = [
     "ALL", "ALTER", "ANALYZE", "ANY", "AS", "ASC", "BEGIN", "BY", "CREATE",
     "CONTINUOUS", "DATABASE", "DATABASES", "DEFAULT", "DELETE", "DESC",
     "DESTINATIONS", "DIAGNOSTICS", "DISTINCT", "DROP", "DURATION", "END",
@@ -68,7 +72,7 @@ db_reserved = [
     "PASSWORD", "POLICY", "POLICIES", "PRIVILEGES", "QUERIES", "QUERY", "READ",
     "REPLICATION", "RESAMPLE", "RETENTION", "REVOKE", "SELECT", "SERIES", "SET",
     "SHARD", "SHARDS", "SLIMIT", "SOFFSET", "STATS", "SUBSCRIPTION",
-    "SUBSCRIPTIONS", "TAG", "TIME", "TO", "USER", "USERS", "VALUES", "WHERE",
+    "SUBSCRIPTIONS", "TAG", "TO", "USER", "USERS", "VALUES", "WHERE",
     "WITH", "WRITE"
 ]
 

--- a/tests/test_NoReservedWords.py
+++ b/tests/test_NoReservedWords.py
@@ -5,38 +5,53 @@ import xml.etree.ElementTree as et
 import lsst.ts.xml as ts_xml
 
 
-def check_for_issues(csc, topic):
-    if csc == "ATAOS" and topic == "Commands":
+def check_for_issues(csc, topic, language):
+    if csc == "ATAOS" and topic == "Commands" and language == "optional":
         jira = "DM-22612"
-    elif csc == "ATMCS" and (topic == "Commands" or topic == "Events"):
+    elif (csc == "ATMCS" and topic in ("Commands", "Events") and
+            language == "critical"):
         jira = "DM-22613"
-    elif csc == "ATSpectrograph" and (topic == "Commands" or topic == "Events"):
+    elif (csc == "ATSpectrograph" and topic in ("Commands", "Events") and
+            language == "optional"):
         jira = "DM-22614"
-    elif csc == "CatchupArchiver" and (topic == "Telemetry" or topic == "Events"):
+    elif (csc == "CatchupArchiver" and topic in ("Telemetry", "Events") and
+            language == "optional"):
         jira = "CAP-399"
-    elif csc == "FiberSpectrograph" and topic == "Commands":
+    elif (csc == "FiberSpectrograph" and topic == "Commands" and
+            language == "optional"):
         jira = "DM-22616"
-    elif csc == "LOVE" and topic == "Events":
+    elif (csc == "LOVE" and topic == "Events" and
+            language == "optional"):
         jira = "DM-22617"
-    elif csc == "MTAOS" and topic == "Telemetry":
+    elif (csc == "MTAOS" and topic == "Telemetry" and
+            language == "optional"):
         jira = "DM-22618"
-    elif csc == "MTArchiver" and topic == "Events":
+    elif (csc == "MTArchiver" and topic == "Events" and
+            language == "optional"):
         jira = "CAP398"
-    elif csc == "MTCamera" and topic == "Commands":
+    elif (csc == "MTCamera" and topic == "Commands" and
+            language == "optional"):
         jira = "CAP-397"
-    elif csc == "MTMount" and topic == "Commands":
+    elif (csc == "MTMount" and topic == "Commands" and
+            language == "critical"):
         jira = "DM-22622"
-    elif csc == "OCS" and (topic == "Telemetry" or topic == "Events"):
+    elif (csc == "OCS" and topic in ("Telemetry", "Events") and
+            language == "optional"):
         jira = "DM-22623"
-    elif csc == "PromptProcessing" and (topic == "Telemetry" or topic == "Events"):
+    elif (csc == "PromptProcessing" and topic in ("Telemetry", "Events") and
+            language == "optional"):
         jira = "DM-22624"
-    elif csc == "Scheduler" and topic == "Telemetry":
+    elif (csc == "Scheduler" and topic == "Telemetry" and
+            language == "optional"):
         jira = "DM-22625"
-    elif csc == "Script" and topic == "Events":
+    elif (csc == "Script" and topic == "Events" and
+            language == "optional"):
         jira = "DM-22626"
-    elif csc == "Test" and topic == "Commands":
+    elif (csc == "Test" and topic == "Commands" and
+            language == "optional"):
         jira = "DM-22627"
-    elif csc == "Watcher" and (topic == "Commands" or topic == "Events"):
+    elif (csc == "Watcher" and topic in ("Commands", "Events") and
+            language == "optional"):
         jira = "DM-22628"
     else:
         jira = ""
@@ -44,8 +59,8 @@ def check_for_issues(csc, topic):
 
 
 @pytest.mark.parametrize("xmlfile,csc,topic", ts_xml.get_xmlfile_csc_topic())
-def test_no_reserved_words(xmlfile, csc, topic):
-    """Test that the <EFDB_Name> field does not use any Reserved Words.
+def test_no_idl_reserved_words(xmlfile, csc, topic):
+    """Test that the <EFDB_Name> field does not use any IDL Reserved Words.
 
     Parameters
     ----------
@@ -58,16 +73,83 @@ def test_no_reserved_words(xmlfile, csc, topic):
     """
     saltype = "SAL" + topic.rstrip('s')
     # Check for known issues.
-    jira = check_for_issues(csc, topic)
+    jira = check_for_issues(csc, topic, "idl")
     if jira:
-        pytest.skip(jira + ": " + str(xmlfile.name) + " <EFDB_Name> is not properly formed.")
+        pytest.skip(jira + ": " + str(xmlfile.name) +
+                    " <EFDB_Name> uses IDL reserved word.")
     # Test the <EFDB_Name> fields do not use Reserved Words.
     with open(str(xmlfile), "r", encoding="utf-8") as f:
         tree = et.parse(f)
     root = tree.getroot()
     bad_names = []
     for name in root.findall(f"./{saltype}/item/EFDB_Name"):
-        if name.text.upper() in set(ts_xml.idl_reserved + ts_xml.db_reserved):
+        if name.text.upper() in ts_xml.idl_reserved:
             bad_names.append(name.text.upper())
     assert bad_names == [], \
-        "Reserved Words used one or more times: " + str(bad_names)
+        "IDL Reserved Words used one or more times: " + str(bad_names)
+
+
+@pytest.mark.parametrize("xmlfile,csc,topic", ts_xml.get_xmlfile_csc_topic())
+def test_no_db_critical_reserved_words(xmlfile, csc, topic):
+    """Test that the <EFDB_Name> field does not use any critical
+    database Reserved Words.
+
+    Parameters
+    ----------
+    xmlfile : `pathlib.Path`
+        Full filepath to the Commands or Events XML file for the CSC.
+    csc : `testutils.subsystems`
+        Name of the CSC
+    topic : `xmlfile.stem`
+        One of ['Commands','Events','Telemetry']
+    """
+    saltype = "SAL" + topic.rstrip('s')
+    # Check for known issues.
+    jira = check_for_issues(csc, topic, "critical")
+    if jira:
+        pytest.skip(jira + ": " + str(xmlfile.name) +
+                    " <EFDB_Name> uses database CRITICAL reserved word.")
+    # Test the <EFDB_Name> fields do not use Reserved Words.
+    with open(str(xmlfile), "r", encoding="utf-8") as f:
+        tree = et.parse(f)
+    root = tree.getroot()
+    bad_names = []
+    for name in root.findall(f"./{saltype}/item/EFDB_Name"):
+        if name.text.upper() in ts_xml.db_critical_reserved:
+            bad_names.append(name.text.upper())
+    assert bad_names == [], \
+        "Critical database Reserved Words used one or more times: " + \
+        str(bad_names)
+
+
+@pytest.mark.parametrize("xmlfile,csc,topic", ts_xml.get_xmlfile_csc_topic())
+def test_no_db_optional_reserved_words(xmlfile, csc, topic):
+    """Test that the <EFDB_Name> field does not use any optional
+    database Reserved Words.
+
+    Parameters
+    ----------
+    xmlfile : `pathlib.Path`
+        Full filepath to the Commands or Events XML file for the CSC.
+    csc : `testutils.subsystems`
+        Name of the CSC
+    topic : `xmlfile.stem`
+        One of ['Commands','Events','Telemetry']
+    """
+    saltype = "SAL" + topic.rstrip('s')
+    # Check for known issues.
+    jira = check_for_issues(csc, topic, "optional")
+    if jira:
+        pytest.skip(jira + ": " + str(xmlfile.name) +
+                    " <EFDB_Name> uses database optional reserved word.")
+    # Test the <EFDB_Name> fields do not use Reserved Words.
+    with open(str(xmlfile), "r", encoding="utf-8") as f:
+        tree = et.parse(f)
+    root = tree.getroot()
+    bad_names = []
+    for name in root.findall(f"./{saltype}/item/EFDB_Name"):
+        if name.text.upper() in ts_xml.db_optional_reserved:
+            bad_names.append(name.text.upper())
+    assert bad_names == [], \
+        "Optional database Reserved Words used one or more times: " + \
+        str(bad_names)


### PR DESCRIPTION
The Reserved Word tests now check IDL, DB Critical and DB Optional as three separate tests.  As DB optional words become critical, simply remove the words from the optional list and add them to the critical list in testutils.py