### PR TITLE
DM-23118: Add NewMTMount: a copy of MTMount commands and events

### DIFF
--- a/python/lsst/ts/xml/testutils.py
+++ b/python/lsst/ts/xml/testutils.py
@@ -24,7 +24,7 @@ subsystems = [
     'LinearStage', 'LOVE', 'MTAOS', 'MTAlignment', 'MTArchiver', 'MTCamera',
     'MTDomeTrajectory', 'MTEEC', 'MTGuider', 'MTHeaderService',
     'MTLaserTracker', 'MTM1M3', 'MTM1M3TS', 'MTM2', 'MTMount', 'MTPtg', 'MTTCS',
-    'MTVMS', 'PointingComponent', 'PromptProcessing', 'Rotator',
+    'MTVMS', 'NewMTMount', 'PointingComponent', 'PromptProcessing', 'Rotator',
     'Scheduler', 'Script', 'ScriptQueue', 'SummitFacility', 'Test',
     'TunableLaser', 'Watcher',
 ]

--- a/sal_interfaces/NewMTMount/NewMTMount_Commands.xml
+++ b/sal_interfaces/NewMTMount/NewMTMount_Commands.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://lsst-sal.tuc.noao.edu/schema/SALCommandSet.xsl"?>
+<SALCommandSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://lsst-sal.tuc.noao.edu/schema/SALCommandSet.xsd">
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_closeMirrorCover</EFDB_Topic>
+ <Alias>closeMirrorCover</Alias>
+ <Device>mirrorCover</Device>
+ <Property>position</Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_closeMirrorCover.html</Explanation>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>Ignored.</Description>
+       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_configure</EFDB_Topic>
+ <Alias>configure</Alias>
+ <Device>configure</Device>
+ <Property></Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_configure.html</Explanation>
+    <item>
+      <EFDB_Name>spec_id</EFDB_Name>
+      <Description>Configuration identifier.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_disableCamWrap</EFDB_Topic>
+ <Alias>disableCamWrap</Alias>
+ <Device>wrap</Device>
+ <Property>mode</Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_disableCamWrap.html</Explanation>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>Ignored</Description>
+       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_enableCamWrap</EFDB_Topic>
+ <Alias>enableCamWrap</Alias>
+ <Device>wrap</Device>
+ <Property>mode</Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_enableCamWrap.html</Explanation>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>Ignored</Description>
+       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_moveToTarget</EFDB_Topic>
+ <Alias>moveToTarget</Alias>
+ <Device>target</Device>
+ <Property>position</Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_moveToTarget.html</Explanation>
+    <item>
+      <EFDB_Name>az_angle</EFDB_Name>
+      <Description>Azimuth angle</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>el_angle</EFDB_Name>
+      <Description>Elevation angle</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cablewrap_orientation</EFDB_Name>
+      <Description>Cable Wrap orientation: Clockwise(CW), Counterclockwise(CCW)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_openMirrorCover</EFDB_Topic>
+ <Alias>openMirrorCover</Alias>
+ <Device>mirrorCover</Device>
+ <Property>position</Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_openMirrorCover.html</Explanation>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>Ignored</Description>
+       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_trackTarget</EFDB_Topic>
+ <Alias>trackTarget</Alias>
+ <Device>target</Device>
+ <Property>position</Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_trackTarget.html</Explanation>
+    <item>
+      <EFDB_Name>az_angle</EFDB_Name>
+      <Description>Azimuth angle</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>az_velocity</EFDB_Name>
+      <Description>Azimuth velocity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree/second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>el_angle</EFDB_Name>
+      <Description> Elevation angle</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>el_velocity</EFDB_Name>
+      <Description> Elevation velocity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree/second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>time</EFDB_Name>
+      <Description>Time</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cablewrap_orientation</EFDB_Name>
+      <Description>Cable Wrap orientation: Clockwise(CW), Counterclockwise(CCW)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+
+
+<SALCommand>
+ <Subsystem>NewMTMount</Subsystem>
+ <Version>3.1</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_command_clearerror</EFDB_Topic>
+ <Alias>clearerror</Alias>
+ <Device></Device>
+ <Property></Property>
+ <Action></Action>
+ <Value></Value>
+ <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_clearerror.html</Explanation>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>Ignored</Description>
+       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALCommand>
+<SALCommand>
+    <Subsystem>NewMTMount</Subsystem>
+    <Version>3.1</Version>
+    <Author>Ander Ansuategi</Author>
+    <EFDB_Topic>NewMTMount_command_stop</EFDB_Topic>
+    <Alias>stop</Alias>
+    <Device></Device>
+    <Property></Property>
+    <Action></Action>
+    <Value></Value>
+    <Explanation>http://sal.lsst.org/SAL/Commands/NewMTMount_command_stop.html</Explanation>
+    <item>
+        <EFDB_Name>value</EFDB_Name>
+        <Description>Not used</Description>
+        <IDL_Type>boolean</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALCommand>
+</SALCommandSet>

--- a/sal_interfaces/NewMTMount/NewMTMount_Events.xml
+++ b/sal_interfaces/NewMTMount/NewMTMount_Events.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsl"?>
+<SALEventSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsd">
+
+<SALEvent>
+ <Subsystem>NewMTMount</Subsystem>
+<Version>3.2.0</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_logevent_mountState</EFDB_Topic>
+ <Alias>mountState</Alias>
+ <Explanation>http://sal.lsst.org/SAL/Events/NewMTMount_mountState.html</Explanation>
+    <item>
+      <EFDB_Name>id</EFDB_Name>
+      <Description>Identifier of the state</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>text</EFDB_Name>
+      <Description>The state of the state machine</Description>
+       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALEvent>
+
+<SALEvent>
+ <Subsystem>NewMTMount</Subsystem>
+<Version>3.2.0</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_logevent_mountWarning</EFDB_Topic>
+ <Alias>mountWarning</Alias>
+ <Explanation>http://sal.lsst.org/SAL/Events/NewMTMount_mountWarning.html</Explanation>
+    <item>
+      <EFDB_Name>id</EFDB_Name>
+      <Description>Identifier of the warning</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>text</EFDB_Name>
+      <Description>The warning info</Description>
+       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALEvent>
+
+<SALEvent>
+ <Subsystem>NewMTMount</Subsystem>
+<Version>3.2.0</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_logevent_mountError</EFDB_Topic>
+ <Alias>mountError</Alias>
+ <Explanation>http://sal.lsst.org/SAL/Events/NewMTMount_mountError.html</Explanation>
+    <item>
+      <EFDB_Name>id</EFDB_Name>
+      <Description>Identifier of the error</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>text</EFDB_Name>
+      <Description>The error info</Description>
+       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALEvent>
+
+<SALEvent>
+ <Subsystem>NewMTMount</Subsystem>
+<Version>3.2.0</Version>
+ <Author>Ander Ansuategi</Author>
+ <EFDB_Topic>NewMTMount_logevent_mountInPosition</EFDB_Topic>
+ <Alias>mountInPosition</Alias>
+ <Explanation>http://sal.lsst.org/SAL/Events/NewMTMount_mountInPosition.html</Explanation>
+    <item>
+      <EFDB_Name>inposition</EFDB_Name>
+      <Description>Whether the mount is in position or not</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+</SALEvent>
+</SALEventSet>

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -55,13 +55,36 @@
   <Generics>yes</Generics>
   <Version></Version>
   <Author></Author>
-  <ActiveDevelopers>Andrew Heyer</ActiveDevelopers>
+  <ActiveDevelopers>Russell Owen</ActiveDevelopers>
+  <PrincipalCSCOwner>Tiago Ribeiro</PrincipalCSCOwner>
+  <Github>https://github.com/lsst-ts/ts_MTMount</Github>
+  <JenkinsTestResults>NA</JenkinsTestResults>
+  <LSSTPoC>Shawn Calahan</LSSTPoC>
+  <CSCDocs>https://ts-mtmount.lsst.io</CSCDocs>
+  <ProductOwner>Sandrine Thomas</ProductOwner>
+  <RelatedDocuments>LTS-150</RelatedDocuments>
+  <SoftwareLanguage>Labview</SoftwareLanguage>
+  <RuntimeLanguages>CPP,LabVIEW,Java,PyDDS,Python</RuntimeLanguages>
+  <VendorPoC>Teknikar</VendorPoC>
+  <ErrorCode></ErrorCode>
+  <Simulator>No</Simulator>
+  <Configurable>No</Configurable>
+</SALSubsystem>
+
+<SALSubsystem>
+  <Name>NewMTMount</Name>
+  <Description>Temporary version of MTMount for use with salobj. Once the Tekniker code stops trying to handle commands and events we can get rid of this and use the MTMount (after updating the metadata). Note that Tekniker low-level code will probably continue to output telemetry.</Description>
+  <Enumeration></Enumeration>
+  <Generics>yes</Generics>
+  <Version></Version>
+  <Author></Author>
+  <ActiveDevelopers>Russell Owen</ActiveDevelopers>
   <PrincipalCSCOwner>Tiago Ribeiro</PrincipalCSCOwner>
   <Github>No public Repo available</Github>
   <JenkinsTestResults>NA</JenkinsTestResults>
   <LSSTPoC>Shawn Calahan</LSSTPoC>
   <CSCDocs>No public access currently</CSCDocs>
-  <ProductOwner>Sandrine </ProductOwner>
+  <ProductOwner>Sandrine Thomas</ProductOwner>
   <RelatedDocuments>LTS-150</RelatedDocuments>
   <SoftwareLanguage>Labview</SoftwareLanguage>
   <RuntimeLanguages>CPP,LabVIEW,Java,PyDDS,Python</RuntimeLanguages>
@@ -774,7 +797,7 @@
   <JenkinsTestResults>NA</JenkinsTestResults>
   <LSSTPoC>German</LSSTPoC>
   <CSCDocs>NA</CSCDocs>
-  <ProductOwner>Sandrine </ProductOwner>
+  <ProductOwner>Sandrine Thomas</ProductOwner>
   <RelatedDocuments>German knows</RelatedDocuments>
   <SoftwareLanguage>LabVIEW</SoftwareLanguage>
   <RuntimeLanguages>CPP,LabVIEW,Java,PyDDS,Python</RuntimeLanguages>

--- a/tests/test_NoReservedWords.py
+++ b/tests/test_NoReservedWords.py
@@ -35,7 +35,7 @@ def check_for_issues(csc, topic, language):
     elif (csc == "CCCamera" and topic == "Commands" and
             language == "optional"):
         jira = "CAP-402"
-    elif (csc == "MTMount" and topic == "Commands" and
+    elif (csc in ("MTMount", "NewMTMount") and topic == "Commands" and
             language == "critical"):
         jira = "DM-22622"
     elif (csc == "PromptProcessing" and topic in ("Telemetry", "Events") and


### PR DESCRIPTION
This is a temporary change. Tekniker's code currently tries to handle
MTMount commands and events, so the salobj CSC needs a separate SAL component
to avoid conflicts.