### PR TITLE
Tickets/cap 505

### DIFF
--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -862,7 +862,10 @@
      settingsApplied events</Description>
     <item>
         <EFDB_Name>ccdLocation</EFDB_Name>
-        <Description>CCD location in focal-plane (e.g. R22S01) (: delimited)</Description>
+        <Description>CCD location in focal-plane (e.g. R22S01) (: delimited). 
+             This should be considered the key for all the remaining items, which will be in the same order 
+             as the locations, whether they are arrays or : delimited strings.
+        <Description>
         <IDL_Type>string</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -863,9 +863,8 @@
     <item>
         <EFDB_Name>ccdLocation</EFDB_Name>
         <Description>CCD location in focal-plane (e.g. R22S01) (: delimited). 
-             This should be considered the key for all the remaining items, which will be in the same order 
-             as the locations, whether they are arrays or : delimited strings.
-        <Description>
+        This should be considered the key for all the remaining items, which will be in the same order as the locations,
+	whether they are arrays or : delimited strings.</Description>
         <IDL_Type>string</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -731,7 +731,7 @@
         <Count>1</Count>
     </item>
     <item>
-        <EFDB_Name>ccdLocations</EFDB_Name>
+        <EFDB_Name>ccdLocation</EFDB_Name>
         <Description>A list of all ccds currently configured, of the form RnnSnn, : delimited (empty if entry not used)</Description>
         <IDL_Type>string</IDL_Type>
         <IDL_Size>1</IDL_Size>
@@ -853,16 +853,124 @@
         <Count>1</Count>
     </item>
 </SALEvent>
+<!-- Special settingsApplied event for use by header service. All of the information in this event is redundant (i,e. also supplied in
+     other settingsApplied events), but the information in this event is formatted for ease-of-use of the header service, specifically
+     information which is REB or Raft specific is repeated for each CCD. -->
+<SALEvent>
+    <EFDB_Topic>CCCamera_logevent_focalPlaneHeaderServiceSettingsApplied</EFDB_Topic>
+    <item>
+        <EFDB_Name>ccdLocation</EFDB_Name>
+        <Description>CCD location in focal-plane (e.g. R22S01) (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>  
+    <item>
+        <EFDB_Name>raftBay</EFDB_Name>
+        <Description>The raft bay for each CCD listed above, of the form Rnn : delimited</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdSlot</EFDB_Name>
+        <Description>The CCD slot for each CCD listed above, of the form SXn : delimited</Description>
+        <IDL_Type>string</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>rebSerialNumber</EFDB_Name>
+        <Description>REB hardware serial number (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>rebLSSTName</EFDB_Name>
+        <Description>REB LSST identifier (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdLSSTName</EFDB_Name>
+        <Description>CCD LSST identifier (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>    
+    <item>
+        <EFDB_Name>raftLSSTName</EFDB_Name>
+        <Description>Raft LSST identifier (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>    
+    <item>
+        <EFDB_Name>ccdManSerNum</EFDB_Name>
+        <Description>Sensor manufacturer's serial number (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdManufacturer</EFDB_Name>
+        <Description>Sensor manufacturer E2V or ITL (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdType</EFDB_Name>
+        <Description>The type of each CCD</Description>
+        <IDL_Type>int</IDL_Type>
+        <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>9</Count>
+        <Enumeration>E2V, ITL</Enumeration>
+    </item>
+    <item>
+        <EFDB_Name>ccdTempSetPoint</EFDB_Name>
+        <Description>Sensor temperature set point</Description>
+        <IDL_Type>double</IDL_Type>
+        <Units>unitless</Units>
+        <Count>9</Count>
+    </item>
+    <item>
+        <EFDB_Name>sequencerKey</EFDB_Name>
+        <Description>The name of the CCD sequencer loaded (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>sequencerChecksum</EFDB_Name>
+        <Description>The checksum of the CCD sequencer loaded (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
 <!-- ComCam settingsApplied events for focal-plane subsystem -->
 <SALEvent>
     <EFDB_Topic>CCCamera_logevent_focalPlaneHardwareIdSettingsApplied</EFDB_Topic>
+    <item>
+        <EFDB_Name>version</EFDB_Name>
+        <Description>Version number of these settings.</Description>
+        <IDL_Type>long</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
     <item>
         <EFDB_Name>rebLocation</EFDB_Name>
         <Description>REB location in focal-plane (e.g. R22RebX) (: delimited)</Description>
         <IDL_Type>string</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>
-    </item>    
+    </item>
     <item>
         <EFDB_Name>rebSerialNumber</EFDB_Name>
         <Description>REB hardware serial number (: delimited)</Description>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -731,7 +731,7 @@
         <Count>1</Count>
     </item>
     <item>
-        <EFDB_Name>ccdNames</EFDB_Name>
+        <EFDB_Name>ccdLocations</EFDB_Name>
         <Description>A list of all ccds currently configured, of the form RnnSnn, : delimited (empty if entry not used)</Description>
         <IDL_Type>string</IDL_Type>
         <IDL_Size>1</IDL_Size>
@@ -849,6 +849,52 @@
         <Description>Annotation sent to DAQ</Description>
         <IDL_Type>string</IDL_Type>
         <IDL_Size>1</IDL_Size>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+</SALEvent>
+<!-- ComCam settingsApplied events for focal-plane subsystem -->
+<SALEvent>
+    <EFDB_Topic>CCCamera_logevent_focalPlaneHardwareIdSettingsApplied</EFDB_Topic>
+    <item>
+        <EFDB_Name>rebLocation</EFDB_Name>
+        <Description>REB location in focal-plane (e.g. R22RebX) (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>    
+    <item>
+        <EFDB_Name>rebSerialNumber</EFDB_Name>
+        <Description>REB hardware serial number (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>rebLSSTName</EFDB_Name>
+        <Description>REB LSST identifier (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdLocation</EFDB_Name>
+        <Description>CCD location in focal-plane (e.g. R22Snn) (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>
+    <item>
+        <EFDB_Name>ccdLSSTNum</EFDB_Name>
+        <Description>CCD LSST identifier (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
+        <Units>unitless</Units>
+        <Count>1</Count>
+    </item>    
+    <item>
+        <EFDB_Name>ccdManSerNum</EFDB_Name>
+        <Description>Sensor manufacturer's serial number (: delimited)</Description>
+        <IDL_Type>string</IDL_Type>
         <Units>unitless</Units>
         <Count>1</Count>
     </item>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -857,7 +857,8 @@
      other settingsApplied events), but the information in this event is formatted for ease-of-use of the header service, specifically
      information which is REB or Raft specific is repeated for each CCD. -->
 <SALEvent>
-    <EFDB_Topic>CCCamera_logevent_focalPlaneHeaderServiceSettingsApplied</EFDB_Topic>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_logevent_focalPlaneHeaderServiceSettingsAppliedSummary</EFDB_Topic>
     <item>
         <EFDB_Name>ccdLocation</EFDB_Name>
         <Description>CCD location in focal-plane (e.g. R22S01) (: delimited)</Description>
@@ -956,6 +957,7 @@
 </SALEvent>
 <!-- ComCam settingsApplied events for focal-plane subsystem -->
 <SALEvent>
+    <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focalPlaneHardwareIdSettingsApplied</EFDB_Topic>
     <item>
         <EFDB_Name>version</EFDB_Name>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -853,12 +853,13 @@
         <Count>1</Count>
     </item>
 </SALEvent>
-<!-- Special settingsApplied event for use by header service. All of the information in this event is redundant (i,e. also supplied in
-     other settingsApplied events), but the information in this event is formatted for ease-of-use of the header service, specifically
-     information which is REB or Raft specific is repeated for each CCD. -->
 <SALEvent>
     <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_focalPlaneHeaderServiceSettingsAppliedSummary</EFDB_Topic>
+    <EFDB_Topic>CCCamera_logevent_focalPlaneSummaryInfo</EFDB_Topic>
+    <Description>Special event for use by header service. All of the information in this event is redundant (i,e. also supplied in
+     other settingsApplied events), but the information in this event is formatted for ease-of-use of the header service, specifically
+     information which is REB or Raft specific is repeated for each CCD. This event will be sent at the same time as other 
+     settingsApplied events</Description>
     <item>
         <EFDB_Name>ccdLocation</EFDB_Name>
         <Description>CCD location in focal-plane (e.g. R22S01) (: delimited)</Description>


### PR DESCRIPTION
This change creates a new focalPlaneSummaryInfo event, with all of the information required by the header service in a format that is easy for it to use. It also adds the first subset of more generic focalPlaneSettingsApplied events (CAP-505), sufficient to test the new generic CCS->OCS configuration event processing, and to allow the remainder of the settingsApplied events to be defined in ts_xml 5.2.