### PR TITLE
removed setThermalSetpoint

### DIFF
--- a/sal_interfaces/MTM1M3/MTM1M3_Commands.xml
+++ b/sal_interfaces/MTM1M3/MTM1M3_Commands.xml
@@ -766,19 +766,6 @@
 </SALCommand>
 <SALCommand>
    <Subsystem>MTM1M3</Subsystem>
-   <EFDB_Topic>MTM1M3_command_setThermalSetpoint</EFDB_Topic>
-    <Alias>setThermalSetpoint</Alias>
-    <Explanation>http://sal.lsst.org</Explanation>
-    <item>
-      <EFDB_Name>setpoint</EFDB_Name>
-      <Description>Temperature set point</Description>
-        <IDL_Type>float</IDL_Type>
-      <Units>unitless</Units>
-        <Count>1</Count>
-    </item>
-</SALCommand>
-<SALCommand>
-   <Subsystem>MTM1M3</Subsystem>
    <EFDB_Topic>MTM1M3_command_programILC</EFDB_Topic>
     <Alias>programILC</Alias>
     <Explanation>http://sal.lsst.org</Explanation>


### PR DESCRIPTION
Thermal system is controlled by Thermal Subsystem. Its commands are
defined in MTM1M3TS. SS (Support System) cannot control thermal
subsystem.