### PR TITLE
DM-25739: Fix a few entries that I missed the first time.

### DIFF
--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -321,7 +321,7 @@
   <SoftwareLanguage>LabVIEW</SoftwareLanguage>
   <RuntimeLanguages>IDL</RuntimeLanguages>
   <VendorContact>CTIO</VendorContact>
-  <Simulator>ts_ATMCSSimulator</Simulator>
+  <Simulator>https://github.com/lsst-ts/ts_ATMCSSimulator</Simulator>
   <Configuration>Not Configurable</Configuration>
 </SALSubsystem>
 
@@ -340,7 +340,7 @@
   <SoftwareLanguage>LabVIEW, or maybe python?</SoftwareLanguage>
   <RuntimeLanguages>IDL</RuntimeLanguages>
   <VendorContact>CTIO</VendorContact>
-  <Simulator>ts_ATPneumaticsSimulator</Simulator>
+  <Simulator>https://github.com/lsst-ts/ts_ATPneumaticsSimulator</Simulator>
   <Configuration>Not Configurable</Configuration>
 </SALSubsystem>
 

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -753,9 +753,7 @@
   <IndexEnumeration>CameraHexapod,m2msHexapod</IndexEnumeration>
   <Generics>yes</Generics>
   <ActiveDevelopers>Te-Wei Tsai, Russell Owen</ActiveDevelopers>
-  <Github>https://github.com/lsst-ts/M2_Hexapod_Rotator_Moog (private)
-    https://github.com/lsst-ts/ts_mt_hexRot_middleware (private)
-    https://github.com/lsst-ts/ts_hexapod</Github>
+  <Github>https://github.com/lsst-ts/ts_hexapod</Github>
   <JenkinsTestResults>https://tssw-ci.lsst.org/job/ts_mt_hexRot_middleware</JenkinsTestResults>
   <RubinObsContact>Te-Wei Tsai</RubinObsContact>
   <CSCDocs></CSCDocs>
@@ -946,9 +944,7 @@
   <IndexEnumeration>no</IndexEnumeration>
   <Generics>yes</Generics>
   <ActiveDevelopers>Tei-Wei Tsai, Russell Owen</ActiveDevelopers>
-  <Github>https://github.com/lsst-ts/M2_Hexapod_Rotator_Moog
-    https://github.com/lsst-ts/ts_mt_hexRot_middleware
-    https://github.com/lsst-ts/ts_rotator</Github>
+  <Github>https://github.com/lsst-ts/ts_rotator</Github>
   <JenkinsTestResults>https://tssw-ci.lsst.org/job/ts_mt_hexRot_middleware/</JenkinsTestResults>
   <RubinObsContact>Te-Wei Tsai</RubinObsContact>
   <CSCDocs>https://ts-rotator.lsst.io/</CSCDocs>


### PR DESCRIPTION
I missed two important comments made by @rbovill in the first review of DM-25739: change Simulator tag to a URL to the dedicated simulator packages for ATMCS and ATPneumatics.

I also updated the Github entries for Hexapod and Rotator to remove links to vendor code for the low-level controllers, based on Michael R's recommendation.