### PR TITLE
adding file path to MTMount simiulator software

### DIFF
--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -93,7 +93,7 @@
   <SoftwareLanguage>Labview</SoftwareLanguage>
   <RuntimeLanguages>IDL</RuntimeLanguages>
   <VendorContact>Tekniker</VendorContact>
-  <Simulator>No</Simulator>
+  <Simulator>LaSerenaPDM/TSS-Share/TMA</Simulator>
   <Configuration>Not Configurable</Configuration>
 </SALSubsystem>
 

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -93,7 +93,7 @@
   <SoftwareLanguage>Labview</SoftwareLanguage>
   <RuntimeLanguages>IDL</RuntimeLanguages>
   <VendorContact>Tekniker</VendorContact>
-  <Simulator>https://tstn-008.lsst.io/</Simulator>
+  <Simulator>https://github.com/lsst-ts/ts_tma</Simulator>
   <Configuration>Not Configurable</Configuration>
 </SALSubsystem>
 

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -93,7 +93,7 @@
   <SoftwareLanguage>Labview</SoftwareLanguage>
   <RuntimeLanguages>IDL</RuntimeLanguages>
   <VendorContact>Tekniker</VendorContact>
-  <Simulator>LaSerenaPDM/TSS-Share/TMA</Simulator>
+  <Simulator>https://tstn-008.lsst.io/</Simulator>
   <Configuration>Not Configurable</Configuration>
 </SALSubsystem>
 


### PR DESCRIPTION
Because some simulator software does not exist on their gitlap repos I compiled all the simulators into a zip file in the La Serena PDM server.