### PR TITLE
DM-24838: Removed M1M3's shutdown command

### DIFF
--- a/sal_interfaces/MTM1M3/MTM1M3_Commands.xml
+++ b/sal_interfaces/MTM1M3/MTM1M3_Commands.xml
@@ -220,19 +220,6 @@
 </SALCommand>
 <SALCommand>
    <Subsystem>MTM1M3</Subsystem>
-   <EFDB_Topic>MTM1M3_command_shutdown</EFDB_Topic>
-    <Alias>shutdown</Alias>
-    <Explanation>http://sal.lsst.org</Explanation>
-    <item>
-      <EFDB_Name>shutdown</EFDB_Name>
-      <Description>Dummy placeholder</Description>
-        <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-        <Count>1</Count>
-    </item>
-</SALCommand>
-<SALCommand>
-   <Subsystem>MTM1M3</Subsystem>
    <EFDB_Topic>MTM1M3_command_translateM1M3</EFDB_Topic>
     <Alias>translateM1M3</Alias>
     <Explanation>http://sal.lsst.org</Explanation>


### PR DESCRIPTION
Shutdown functionality shall be provided by generic exitControl command.