### PR TITLE
Update RuntimeLanguages field for Script and Test

### DIFF
--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -956,7 +956,7 @@
   <ProductOwner>Russell Owen</ProductOwner>
   <RelatedDocuments></RelatedDocuments>
   <SoftwareLanguage>Python</SoftwareLanguage>
-  <RuntimeLanguages>IDL</RuntimeLanguages>
+  <RuntimeLanguages>IDL,CPP,SALPY</RuntimeLanguages>
   <VendorContact>Not Applicable</VendorContact>
   <Simulator>Not Required</Simulator>
   <Configuration>Not Configurable</Configuration>
@@ -1070,7 +1070,7 @@
   <ProductOwner>Russell Owen</ProductOwner>
   <RelatedDocuments></RelatedDocuments>
   <SoftwareLanguage>Python</SoftwareLanguage>
-  <RuntimeLanguages>IDL</RuntimeLanguages>
+  <RuntimeLanguages>IDL,CPP,SALPY,Java,LabVIEW</RuntimeLanguages>
   <VendorContact>Not Applicable</VendorContact>
   <Simulator>Not Required</Simulator>
   <Configuration>https://github.com/lsst-ts/ts_config_ocs</Configuration>


### PR DESCRIPTION
* Added CPP and SALPY to the RuntimeLanguages field for the Script CSC.  SALPY is needed for the SAL python unit tests, and C++ is needed to create the SALPY library. 
* Added CPP, SALPY, Java and LabVIEW to the RuntimeLanguages list for the Test CSC. Since Test is for testing SAL, it should probably build all the libraries, and C++ and SALPY are required to run the unit tests, anyway.