### PR TITLE
Add new item to endOfImageTelemetry: emulatedImage

### DIFF
--- a/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -307,6 +307,14 @@
       <Units>second</Units>
       <Count>1</Count>
     </item>
+    <!-- CAP-759 -->
+    <item>
+      <EFDB_Name>emulatedImage</EFDB_Name>
+      <Description>When using emulated DAQ, this is the name of the image read from the 2-day store (otherwise an empty string)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -343,6 +343,14 @@
       <Units>second</Units>
       <Count>1</Count>
     </item>
+    <!-- CAP-759 -->
+    <item>
+      <EFDB_Name>emulatedImage</EFDB_Name>
+      <Description>When using emulated DAQ, this is the name of the image read from the 2-day store (otherwise an empty string)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>

--- a/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -350,6 +350,14 @@
       <Units>second</Units>
       <Count>1</Count>
     </item>
+    <!-- CAP-759 -->
+    <item>
+      <EFDB_Name>emulatedImage</EFDB_Name>
+      <Description>When using emulated DAQ, this is the name of the image read from the 2-day store (otherwise an empty string)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>


### PR DESCRIPTION
When using emulated DAQ, add emulatedImage name to the end of image telemetry, to make it possible for @menanteau to add it to header service if desired.