### PR TITLE
DM-31017: Test: remove char and octet fields

### DIFF
--- a/sal_interfaces/Test/Test_Commands.xml
+++ b/sal_interfaces/Test/Test_Commands.xml
@@ -20,13 +20,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>char0</EFDB_Name>
-      <Description>A char, which is a synonym for string.</Description>
-      <IDL_Type>char</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>short0</EFDB_Name>
       <Description>A short.</Description>
       <IDL_Type>short</IDL_Type>
@@ -51,13 +44,6 @@
       <EFDB_Name>longLong0</EFDB_Name>
       <Description>A long long.</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>octet0</EFDB_Name>
-      <Description>A octet.</Description>
-      <IDL_Type>octet</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -148,13 +134,6 @@
       <EFDB_Name>longLong0</EFDB_Name>
       <Description>Array of long long.</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>5</Count>
-    </item>
-    <item>
-      <EFDB_Name>octet0</EFDB_Name>
-      <Description>Array of octet.</Description>
-      <IDL_Type>octet</IDL_Type>
       <Units>unitless</Units>
       <Count>5</Count>
     </item>

--- a/sal_interfaces/Test/Test_Events.xml
+++ b/sal_interfaces/Test/Test_Events.xml
@@ -22,13 +22,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>char0</EFDB_Name>
-      <Description>A char, which is a synonym for string.</Description>
-      <IDL_Type>char</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>short0</EFDB_Name>
       <Description>A short.</Description>
       <IDL_Type>short</IDL_Type>
@@ -54,13 +47,6 @@
       <EFDB_Name>longLong0</EFDB_Name>
       <Description>A long long.</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>octet0</EFDB_Name>
-      <Description>An octet.</Description>
-      <IDL_Type>octet</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -152,13 +138,6 @@
       <EFDB_Name>longLong0</EFDB_Name>
       <Description>Array of long long.</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>5</Count>
-    </item>
-    <item>
-      <EFDB_Name>octet0</EFDB_Name>
-      <Description>Array of octet.</Description>
-      <IDL_Type>octet</IDL_Type>
       <Units>unitless</Units>
       <Count>5</Count>
     </item>

--- a/sal_interfaces/Test/Test_Telemetry.xml
+++ b/sal_interfaces/Test/Test_Telemetry.xml
@@ -21,13 +21,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>char0</EFDB_Name>
-      <Description>A char, which is a synonym for string.</Description>
-      <IDL_Type>char</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>short0</EFDB_Name>
       <Description>A short.</Description>
       <IDL_Type>short</IDL_Type>
@@ -52,13 +45,6 @@
       <EFDB_Name>longLong0</EFDB_Name>
       <Description>A long long.</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>octet0</EFDB_Name>
-      <Description>A octet.</Description>
-      <IDL_Type>octet</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -149,13 +135,6 @@
       <EFDB_Name>longLong0</EFDB_Name>
       <Description>Array of long long.</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>5</Count>
-    </item>
-    <item>
-      <EFDB_Name>octet0</EFDB_Name>
-      <Description>Array of octet.</Description>
-      <IDL_Type>octet</IDL_Type>
       <Units>unitless</Units>
       <Count>5</Count>
     </item>


### PR DESCRIPTION
Note that no other SAL components use either of these two data types.