### PR TITLE
Implement CAP-870

### DIFF
--- a/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -493,6 +493,24 @@
       <Units>second</Units>
       <Count>1</Count>
     </item>
+    <!-- Items added for CAP-870 -->
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>The camera data taking mode (normal/calibration/(TBD in future))</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeout</EFDB_Name>
+      <Description>The timeout (in seconds) after which the header service should assume something has gone wrong. For
+          calibration mode the timeout will be set to the argument passed to startImage,
+          for normal mode the timeout will be set to expTime.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
@@ -514,7 +532,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT</Enumeration>
+      <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT,DISCARDING</Enumeration>
     </item>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -603,6 +603,24 @@
       <Units>second</Units>
       <Count>1</Count>
     </item>
+    <!-- Items added for CAP-870 -->
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>The camera data taking mode (normal/calibration/(TBD in future))</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeout</EFDB_Name>
+      <Description>The timeout (in seconds) after which the header service should assume something has gone wrong. For
+          calibration mode the timeout will be set to the argument passed to startImage,
+          for normal mode the timeout will be set to expTime.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
@@ -673,7 +691,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT</Enumeration>
+      <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT,DISCARDING</Enumeration>
     </item>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>

--- a/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -610,6 +610,24 @@
       <Units>second</Units>
       <Count>1</Count>
     </item>
+    <!-- Items added for CAP-870 -->
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>The camera data taking mode (normal/calibration/(TBD in future))</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeout</EFDB_Name>
+      <Description>The timeout (in seconds) after which the header service should assume something has gone wrong. For
+          calibration mode the timeout will be set to the argument passed to startImage,
+          for normal mode the timeout will be set to expTime.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
@@ -680,7 +698,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT</Enumeration>
+      <Enumeration>NEEDS_CLEAR,CLEARING,INTEGRATING,READING_OUT,QUIESCENT,DISCARDING</Enumeration>
     </item>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>


### PR DESCRIPTION
Additions to support Calibration mode, see discussion at https://lsstc.slack.com/archives/CLQ63T89L/p1647278833410459 and https://jira.lsstcorp.org/browse/CAP-870

It particular this change adds two new items to startIntegration event, and adds an additional state (DISCARDING) to raftsDetailedState.

@menanteau Note that the intention is that the header service starts using the new timeout item in startIntegration to determine the header service timeout, instead of the current behavior of using expTime. 