### PR TITLE
DM-34357: MTMount: fix LimitsMask enum values.

### DIFF
--- a/sal_interfaces/MTMount/MTMount_Events.xml
+++ b/sal_interfaces/MTMount/MTMount_Events.xml
@@ -23,16 +23,18 @@
         DeployableMotionState_Lost=4
     </Enumeration>
   <Enumeration>
-        LimitsMask_L1Min=0x01,
-        LimitsMask_L1Max=0x02,
-        LimitsMask_L2Min=0x03,
-        LimitsMask_L2Max=0x04,
-        LimitsMask_L3Min=0x05,
-        LimitsMask_L3Max=0x06,
-        LimitsMask_AdjustableL1Min=0x07,
-        LimitsMask_AdjustableL1Max=0x08,
-        LimitsMask_OperationalL1Min=0x09,
-        LimitsMask_OperationalL1Max=0x10
+        LimitsMask_L1Min=0x1,
+        LimitsMask_L1Max=0x2,
+        LimitsMask_L2Min=0x4,
+        LimitsMask_L2Max=0x8,
+        LimitsMask_L3Min=0x10,
+        LimitsMask_L3Max=0x20,
+        LimitsMask_AdjustableL1Min=0x40,
+        LimitsMask_AdjustableL1Max=0x80,
+        LimitsMask_OperationalL2Min=0x100,
+        LimitsMask_OperationalL2Max=0x200,
+        LimitsMask_CameraCableWrapFollowL3Min=0x400,
+        LimitsMask_CameraCableWrapFollowL3Max=0x800
     </Enumeration>
   <Enumeration>
         ElevationLockingPinMotionState_Locked=0,


### PR DESCRIPTION
There is no hurry on this. It can wait for ts_xml 12.

I do want the ts_idl update to be in cycle 25 build so INRIA can use it, but I doubt any C++ or Java code will be using the MTMount enum values defined here in ts_xml.