### PR TITLE
DM-34771: rename "salIndex" public ScriptQueue fields to "scriptSalIndex"

### DIFF
--- a/python/lsst/ts/xml/testutils.py
+++ b/python/lsst/ts/xml/testutils.py
@@ -379,6 +379,11 @@ db_optional_reserved = [
     "WRITE",
 ]
 
+# Field names used by SAL, and so forbidden in ts_xml
+sal_reserved = [
+    "SALINDEX",
+]
+
 """Define string attributes that are NOT unitless"""
 strings_with_units = [
     "azPositions",

--- a/sal_interfaces/ScriptQueue/ScriptQueue_Commands.xml
+++ b/sal_interfaces/ScriptQueue/ScriptQueue_Commands.xml
@@ -37,7 +37,7 @@
     <EFDB_Topic>ScriptQueue_command_showScript</EFDB_Topic>
     <Description>Output script event for a specified script.</Description>
     <item>
-      <EFDB_Name>salIndex</EFDB_Name>
+      <EFDB_Name>scriptSalIndex</EFDB_Name>
       <Description>SAL index of Script for which you want information.</Description>
       <IDL_Type>int</IDL_Type>
       <Units>unitless</Units>
@@ -132,7 +132,7 @@
     <EFDB_Topic>ScriptQueue_command_move</EFDB_Topic>
     <Description>Move a script elsewhere in the queue. This will fail if the script is already running.</Description>
     <item>
-      <EFDB_Name>salIndex</EFDB_Name>
+      <EFDB_Name>scriptSalIndex</EFDB_Name>
       <Description>Index of Script SAL component to move.</Description>
       <IDL_Type>int</IDL_Type>
       <Units>unitless</Units>
@@ -140,7 +140,7 @@
     </item>
     <item>
       <EFDB_Name>location</EFDB_Name>
-      <Description>Location in the queue; a Location enum.</Description>
+      <Description>New location in the queue; a Location enum.</Description>
       <IDL_Type>byte</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -158,7 +158,7 @@
     <EFDB_Topic>ScriptQueue_command_requeue</EFDB_Topic>
     <Description>Put a script back on the queue that has already run, is running or is queued.</Description>
     <item>
-      <EFDB_Name>salIndex</EFDB_Name>
+      <EFDB_Name>scriptSalIndex</EFDB_Name>
       <Description>Index of Script SAL component to requeue.</Description>
       <IDL_Type>int</IDL_Type>
       <Units>unitless</Units>

--- a/sal_interfaces/ScriptQueue/ScriptQueue_Events.xml
+++ b/sal_interfaces/ScriptQueue/ScriptQueue_Events.xml
@@ -56,7 +56,7 @@
     <EFDB_Topic>ScriptQueue_logevent_nextVisit</EFDB_Topic>
     <Description>Group ID and other information about the next script to be run.</Description>
     <item>
-      <EFDB_Name>salIndex</EFDB_Name>
+      <EFDB_Name>scriptSalIndex</EFDB_Name>
       <Description>Index of Script SAL component.</Description>
       <IDL_Type>int</IDL_Type>
       <Units>unitless</Units>
@@ -158,7 +158,7 @@
     <EFDB_Topic>ScriptQueue_logevent_nextVisitCanceled</EFDB_Topic>
     <Description>The group ID reported by a nextVisit event will not be used, because the script that was next to be run has been cancelled or rescheduled.</Description>
     <item>
-      <EFDB_Name>salIndex</EFDB_Name>
+      <EFDB_Name>scriptSalIndex</EFDB_Name>
       <Description>Index of Script SAL component.</Description>
       <IDL_Type>int</IDL_Type>
       <Units>unitless</Units>
@@ -185,7 +185,7 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>salIndex</EFDB_Name>
+      <EFDB_Name>scriptSalIndex</EFDB_Name>
       <Description>Index of Script SAL component.</Description>
       <IDL_Type>int</IDL_Type>
       <Units>unitless</Units>

--- a/tests/test_NoReservedWords.py
+++ b/tests/test_NoReservedWords.py
@@ -1,49 +1,81 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import enum
+
 import pytest
 import xml.etree.ElementTree as et
 import lsst.ts.xml as ts_xml
 
 
-def check_for_issues(csc, topic, language):
-    if csc == "ATAOS" and topic == "Commands" and language == "optional":
+class Restriction(enum.Enum):
+    """Field naming restriction categories."""
+
+    IDL = enum.auto()
+    SAL = enum.auto()
+    DB_CRITICAL = enum.auto()
+    DB_OPTIONAL = enum.auto()
+
+
+def check_for_issues(csc, topic, restriction):
+    restriction = Restriction(restriction)  # check the argument
+    if (
+        csc == "ATAOS"
+        and topic == "Commands"
+        and restriction is Restriction.DB_OPTIONAL
+    ):
         jira = "DM-22612"
-    elif csc == "ATMCS" and topic in ("Commands", "Events") and language == "critical":
+    elif (
+        csc == "ATMCS"
+        and topic in ("Commands", "Events")
+        and restriction is Restriction.DB_CRITICAL
+    ):
         jira = "DM-22613"
     elif (
         csc == "ATSpectrograph"
         and topic in ("Commands", "Events")
-        and language == "optional"
+        and restriction is Restriction.DB_OPTIONAL
     ):
         jira = "DM-22614"
     elif (
         csc == "CatchupArchiver"
         and topic in ("Telemetry", "Events")
-        and language == "optional"
+        and restriction is Restriction.DB_OPTIONAL
     ):
         jira = "CAP-399"
-    elif csc == "FiberSpectrograph" and topic == "Commands" and language == "optional":
+    elif (
+        csc == "FiberSpectrograph"
+        and topic == "Commands"
+        and restriction is Restriction.DB_OPTIONAL
+    ):
         jira = "DM-22616"
-    elif csc == "LOVE" and topic == "Events" and language == "optional":
+    elif csc == "LOVE" and topic == "Events" and restriction is Restriction.DB_OPTIONAL:
         jira = "DM-22617"
-    elif csc == "ATCamera" and language == "optional":
+    elif csc == "ATCamera" and restriction is Restriction.DB_OPTIONAL:
         jira = "CAP-793"
-    elif csc == "MTCamera" and language == "optional":
+    elif csc == "MTCamera" and restriction is Restriction.DB_OPTIONAL:
         jira = "CAP-397"
-    elif csc == "CCCamera" and language == "optional":
+    elif csc == "CCCamera" and restriction is Restriction.DB_OPTIONAL:
         jira = "CAP-402"
-    elif csc == "Scheduler" and topic == "Telemetry" and language == "optional":
+    elif (
+        csc == "Scheduler"
+        and topic == "Telemetry"
+        and restriction is Restriction.DB_OPTIONAL
+    ):
         jira = "DM-22625"
     elif (
         csc in ("Script", "ScriptQueue")
         and topic == "Events"
-        and language == "optional"
+        and restriction is Restriction.DB_OPTIONAL
     ):
         jira = "DM-22626"
-    elif csc == "Test" and topic == "Commands" and language == "optional":
+    elif (
+        csc == "Test" and topic == "Commands" and restriction is Restriction.DB_OPTIONAL
+    ):
         jira = "DM-22627"
     elif (
-        csc == "Watcher" and topic in ("Commands", "Events") and language == "optional"
+        csc == "Watcher"
+        and topic in ("Commands", "Events")
+        and restriction is Restriction.DB_OPTIONAL
     ):
         jira = "DM-22628"
     else:
@@ -56,8 +88,8 @@ def test_reserved_words(xmlfile, csc, topic):
     """Control function to execute the IDL, and
     database reserved words tests.
     """
-    for restriction in ("idl", "critical", "optional"):
-        reserved_words(xmlfile, csc, topic, restriction)
+    for restriction in Restriction:
+        reserved_words(xmlfile=xmlfile, csc=csc, topic=topic, restriction=restriction)
 
 
 def reserved_words(xmlfile, csc, topic, restriction):
@@ -71,31 +103,34 @@ def reserved_words(xmlfile, csc, topic, restriction):
         Name of the CSC
     topic : `xmlfile.stem`
         One of ['Commands', 'Events', 'Telemetry']
-    restriction : `test_reserved_words.restriction`
-        One of ['idl', 'critical', 'optional']
+    restriction : `Restriction`
+        Category of prohibited field names.
     """
+    restriction = Restriction(restriction)  # check the argument
     saltype = "SAL" + topic.rstrip("s")
-    # Check for known issues.
-    jira = check_for_issues(csc, topic, restriction)
-    if jira:
-        pytest.skip(
-            f"{jira}: {xmlfile.name} <EFDB_Name> uses {restriction.upper()} reserved word."
-        )
+    # Check for known issues with database reserved words.
+    # The IDL and SAL reserved words are non-negotiable.
+    if restriction in {Restriction.DB_CRITICAL, Restriction.DB_OPTIONAL}:
+        jira = check_for_issues(csc, topic, restriction)
+        if jira:
+            pytest.skip(
+                f"{jira}: {xmlfile.name} <EFDB_Name> uses {restriction.name} reserved word."
+            )
     # Test the <EFDB_Name> fields do not use Reserved Words.
     with open(str(xmlfile), "r", encoding="utf-8") as f:
         tree = et.parse(f)
     root = tree.getroot()
     bad_names = []
     # Set the list based on the restriction type.
-    if restriction == "idl":
-        word_list = ts_xml.idl_reserved
-    elif restriction == "critical":
-        word_list = ts_xml.db_critical_reserved
-    else:
-        word_list = ts_xml.db_optional_reserved
+    word_list = {
+        Restriction.IDL: ts_xml.idl_reserved,
+        Restriction.SAL: ts_xml.sal_reserved,
+        Restriction.DB_CRITICAL: ts_xml.db_critical_reserved,
+        Restriction.DB_OPTIONAL: ts_xml.db_optional_reserved,
+    }[restriction]
     for name in root.findall(f"./{saltype}/item/EFDB_Name"):
         if name.text.upper() in word_list:
             bad_names.append(name.text.upper())
     assert (
         bad_names == []
-    ), f"{restriction.upper()} Reserved Words used one or more times: {(bad_names)}"
+    ), f"{restriction.name} Reserved Words used one or more times: {(bad_names)}"


### PR DESCRIPTION
And update the test of reserved words to catch use of "salIndex".