### PR TITLE
DM-35663: remove most unused DIMM events and telemetry

### DIFF
--- a/sal_interfaces/DIMM/DIMM_Events.xml
+++ b/sal_interfaces/DIMM/DIMM_Events.xml
@@ -1,30 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsl"?>
 <SALEventSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsd">
-  <Enumeration>DetailedState_DisabledState,DetailedState_EnabledState,DetailedState_FaultState,DetailedState_OfflineState,DetailedState_StandbyState</Enumeration>
-  <SALEvent>
-    <Subsystem>DIMM</Subsystem>
-    <EFDB_Topic>DIMM_logevent_detailedState</EFDB_Topic>
-    <item>
-      <EFDB_Name>detailedState</EFDB_Name>
-      <Description>The substate of the CSC.</Description>
-      <!-- Enumeration: DetailedState -->
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <SALEvent>
-    <Subsystem>DIMM</Subsystem>
-    <EFDB_Topic>DIMM_logevent_internalCommand</EFDB_Topic>
-    <item>
-      <EFDB_Name>commandObject</EFDB_Name>
-      <Description>The error code being published.</Description>
-      <IDL_Type>byte</IDL_Type>
-      <Units>unitless</Units>
-      <Count>800</Count>
-    </item>
-  </SALEvent>
   <SALEvent>
     <Subsystem>DIMM</Subsystem>
     <EFDB_Topic>DIMM_logevent_moduleStatus</EFDB_Topic>
@@ -59,17 +35,6 @@
     <item>
       <EFDB_Name>dimmStatus</EFDB_Name>
       <Description>Subsystem status for DIMM processing module.</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <SALEvent>
-    <Subsystem>DIMM</Subsystem>
-    <EFDB_Topic>DIMM_logevent_loopTimeOutOfRange</EFDB_Topic>
-    <item>
-      <EFDB_Name>loopTimeOutOfRange</EFDB_Name>
-      <Description>Whether the loop time is out of range.</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>

--- a/sal_interfaces/DIMM/DIMM_Telemetry.xml
+++ b/sal_interfaces/DIMM/DIMM_Telemetry.xml
@@ -3,17 +3,6 @@
 <SALTelemetrySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://lsst-sal.tuc.noao.edu/schema/SALTelemetrySet.xsd">
   <SALTelemetry>
     <Subsystem>DIMM</Subsystem>
-    <EFDB_Topic>DIMM_timestamp</EFDB_Topic>
-    <item>
-      <EFDB_Name>timestamp</EFDB_Name>
-      <Description>The system time (TAI).</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>second</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <SALTelemetry>
-    <Subsystem>DIMM</Subsystem>
     <EFDB_Topic>DIMM_sky</EFDB_Topic>
     <item>
       <EFDB_Name>status</EFDB_Name>
@@ -67,17 +56,6 @@
       <Description>The wind direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>deg</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <SALTelemetry>
-    <Subsystem>DIMM</Subsystem>
-    <EFDB_Topic>DIMM_loopTime</EFDB_Topic>
-    <item>
-      <EFDB_Name>loopTime</EFDB_Name>
-      <Description>The actual loop time is milliseconds.</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>

--- a/sal_interfaces/SALSubsystems.xml
+++ b/sal_interfaces/SALSubsystems.xml
@@ -186,7 +186,7 @@
     <Description>CSC for the DIMM (Differential Image Motion Monitor) telescope</Description>
     <IndexEnumeration>any</IndexEnumeration>
     <AddedGenerics>csc, configurable</AddedGenerics>
-    <ActiveDevelopers>Dave Mills</ActiveDevelopers>
+    <ActiveDevelopers>Dave Mills, Russell Owen</ActiveDevelopers>
     <Github>https://github.com/lsst-ts/ts_dimm</Github>
     <JenkinsTestResults>Not Available</JenkinsTestResults>
     <RubinObsContact>Brian Stalder</RubinObsContact>


### PR DESCRIPTION
This change is backward compatible because ts_dimm does not write any of those topics.
We should also remove the commands, but that has to be carefully scheduled, because it is not backwards compatible.