### PR TITLE
Cleanup auto-generated XML prior to camera changes

### DIFF
--- a/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -885,10 +885,11 @@
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1999895231L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -923,10 +924,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Ccd_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4151740477L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1159,10 +1161,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Ccd_RaftsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2538589901L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1179,10 +1182,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
-  <!--==============================================================================================================================================================-->
+  <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 462997926L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1206,10 +1210,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 145840325L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1254,10 +1259,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration using level 1 for category Instrument-->
-  <!--================================================================================================================================================================-->
+  <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 931959526L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1288,10 +1294,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--=======================================================================================================================================================-->
+  <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2894028502L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1343,10 +1350,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 579141703L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1398,10 +1406,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--====================================================================================================================================================-->
+  <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Raft_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3926285547L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1427,10 +1436,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration using level 1 for category RaftTempControl-->
-  <!--==============================================================================================================================================================-->
+  <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4133472458L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1564,10 +1574,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration using level 1 for category RaftTempControlStatus-->
-  <!--==========================================================================================================================================================================-->
+  <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2438003286L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1593,10 +1604,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 195009230L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1634,10 +1646,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_DevicesConfiguration using level 1 for category Devices-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1036526110L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1663,10 +1676,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 380473643L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1692,10 +1706,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2232731179L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2900,10 +2915,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3622275020L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3037,10 +3053,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration using level 1 for category RaftsLimits-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3195072898L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3237,10 +3254,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration using level 1 for category RaftsPower-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 832633820L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3806,10 +3824,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_timersConfiguration using level 1 for category timers-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1268300520L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3925,10 +3944,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration using level 1 for category DAQ-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 947187568L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3966,10 +3986,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration using level 1 for category Sequencer-->
-  <!--=============================================================================================================================================================-->
+  <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4112623107L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4168,10 +4189,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration using level 1 for category Visualization-->
-  <!--====================================================================================================================================================================-->
+  <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2530037792L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4188,10 +4210,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--=======================================================================================================================================================-->
+  <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1214896848L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4229,10 +4252,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2317372607L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4298,10 +4322,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration using level 1 for category Statistics-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1384850593L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4381,10 +4406,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_StoreConfiguration using level 1 for category Store-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_StoreConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 934933523L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4408,10 +4434,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_DevicesConfiguration using level 1 for category Devices-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Store_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1755898606L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4428,10 +4455,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_LimitsConfiguration using level 1 for category Limits-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Store_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3227808222L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4525,10 +4553,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_StoreConfiguration using level 1 for category Store-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Store_StoreConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2879348445L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4566,10 +4595,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Analog_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Analog_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3263351699L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4607,10 +4637,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Analog_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Analog_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2732905341L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4648,10 +4679,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Aux_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Aux_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2517148510L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4689,10 +4721,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Aux_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Aux_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4134452144L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4730,10 +4763,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkHigh_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3271489191L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4771,10 +4805,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkHigh_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2727931465L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4812,10 +4847,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkLow_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3725800645L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4853,10 +4889,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkLow_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3195350059L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4894,10 +4931,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_DPHI_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 732772257L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4935,10 +4973,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_DPHI_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1271607119L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4976,10 +5015,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Digital_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Digital_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 340132556L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5017,10 +5057,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Digital_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Digital_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1948260898L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5058,10 +5099,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Fan_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Fan_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3146808836L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5099,10 +5141,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Fan_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Fan_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3690358506L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5140,10 +5183,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_HVBias_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1458416643L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5181,10 +5225,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_HVBias_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 915125485L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5222,10 +5267,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg1_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2468661842L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5242,10 +5288,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_PowerConfiguration using level 1 for category Power-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg1_PowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2216190387L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5360,10 +5407,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg2_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1886223856L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5380,10 +5428,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_PowerConfiguration using level 1 for category Power-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg2_PowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 272422401L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5498,10 +5547,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg3_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2558192977L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5518,10 +5568,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_PowerConfiguration using level 1 for category Power-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg3_PowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1515990302L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5636,10 +5687,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_DevicesConfiguration using level 1 for category Devices-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Keithley_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2286950710L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5656,10 +5708,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_PowerConfiguration using level 1 for category Power-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Keithley_PowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1173451930L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5718,10 +5771,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OD_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OD_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2693541552L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5759,10 +5813,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OD_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OD_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3236574814L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5800,10 +5855,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OTM_I_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OTM_I_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3329983717L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5841,10 +5897,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OTM_V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OTM_V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2786958347L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5882,10 +5939,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2602586973L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5923,10 +5981,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 785864288L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5985,10 +6044,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DeviceConfiguration using level 1 for category Device-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_CryoCon_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4153392157L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6005,10 +6065,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DevicesConfiguration using level 1 for category Devices-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_CryoCon_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 897533576L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6025,10 +6086,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3433939485L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6066,10 +6128,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1188361967L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6128,10 +6191,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_Pfeiffer_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1442941572L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6148,10 +6212,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DevicesConfiguration using level 1 for category Devices-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_Pfeiffer_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2265226990L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6168,10 +6233,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCCDSetPoint_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempCCDSetPoint_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 877906658L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6209,10 +6275,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCCD_LimitsConfiguration using level 1 for category Limits-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempCCD_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3466789953L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6250,10 +6317,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempColdPlate_LimitsConfiguration using level 1 for category Limits-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempColdPlate_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2224871970L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6291,10 +6359,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCryoHead_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempCryoHead_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4209597592L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6332,10 +6401,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Vacuum_LimitsConfiguration using level 1 for category Limits-->
-  <!--======================================================================================================================================-->
+  <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_Vacuum_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1447408296L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6373,10 +6443,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_DevicesConfiguration using level 1 for category Devices-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_Device_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3182176033L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6393,10 +6464,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_GeneralConfiguration using level 1 for category General-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_Device_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3046614962L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6413,10 +6485,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_Device_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1496071801L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6482,10 +6555,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1882339325L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6516,10 +6590,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--========================================================================================================================================================-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4275057977L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6557,10 +6632,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--======================================================================================================================================================-->
+  <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3276326788L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6612,10 +6688,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
-  <!--===========================================================================================================================================================-->
+  <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3749482302L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6653,10 +6730,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1553212165L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6736,10 +6814,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--===================================================================================================================================================================-->
+  <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 341171740L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6805,10 +6884,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2547892980L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6832,10 +6912,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--========================================================================================================================================================-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1044283836L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6866,10 +6947,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_Reb_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_Reb_FitsHandlingConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2673458276L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6895,10 +6977,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_Reb_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3698070690L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>

--- a/sal_interfaces/ATCamera/ATCamera_Telemetry.xml
+++ b/sal_interfaces/ATCamera/ATCamera_Telemetry.xml
@@ -5,6 +5,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_Ccd</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3323840614L -->
     <!--CCSMETA: Array gDV indexed by location-->
     <item>
       <EFDB_Name>gDV</EFDB_Name>
@@ -72,6 +73,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_Reb</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3470282761L -->
     <!--CCSMETA: Array anaI indexed by location-->
     <item>
       <EFDB_Name>anaI</EFDB_Name>
@@ -382,6 +384,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_RebTotalPower</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2608570576L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
       <Description>Reb Total Power</Description>
@@ -395,6 +398,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_daq_monitor_Store</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1170090743L -->
     <item>
       <EFDB_Name>capacity</EFDB_Name>
       <Description>total disk space</Description>
@@ -422,6 +426,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_power</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1269524998L -->
     <item>
       <EFDB_Name>analog_I</EFDB_Name>
       <Description>Analog current</Description>
@@ -568,6 +573,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_vacuum</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1376639655L -->
     <item>
       <EFDB_Name>tempCCD</EFDB_Name>
       <Description>CCD temperature</Description>
@@ -609,6 +615,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_bonn_shutter_Device</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1759124350L -->
     <item>
       <EFDB_Name>bonn_V36</EFDB_Name>
       <Description>BonnShutter 5-volt reading</Description>

--- a/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -1063,10 +1063,11 @@
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_GeneralConfiguration using level 1 for category General-->
-  <!--=================================================================================================================================-->
+  <!--===============================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 177498527L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1153,10 +1154,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_DevicesConfiguration using level 1 for category Devices-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_LinearEncoder_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 402932488L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1173,10 +1175,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_GeneralConfiguration using level 1 for category General-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_LinearEncoder_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1177922513L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1193,10 +1196,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_LimitsConfiguration using level 1 for category Limits-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_LinearEncoder_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1091399202L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1234,10 +1238,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4049810286L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1275,10 +1280,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3281060040L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1330,10 +1336,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 129012656L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1350,10 +1357,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_GeneralConfiguration using level 1 for category General-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2863423268L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1370,10 +1378,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2287609295L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1439,10 +1448,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_MotorConfiguration using level 1 for category Motor-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_MotorConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 656342921L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1550,10 +1560,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_DevicesConfiguration using level 1 for category Devices-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_Device_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1899674305L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1570,10 +1581,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_GeneralConfiguration using level 1 for category General-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_Device_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1964148534L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1590,10 +1602,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_Device_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1369580573L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1659,10 +1672,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 718269393L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1693,10 +1707,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--========================================================================================================================================================-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2858353959L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1734,10 +1749,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--======================================================================================================================================================-->
+  <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3814009004L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1789,10 +1805,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--=======================================================================================================================================================-->
+  <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 420408614L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1830,10 +1847,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3019136670L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1899,10 +1917,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Stats_StatisticsConfiguration using level 1 for category Statistics-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1197481613L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1982,10 +2001,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_StoreConfiguration using level 1 for category Store-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_StoreConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2888189970L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2009,10 +2029,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_DevicesConfiguration using level 1 for category Devices-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Store_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1030676591L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2029,10 +2050,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_LimitsConfiguration using level 1 for category Limits-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Store_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1191467396L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2126,10 +2148,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_StoreConfiguration using level 1 for category Store-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Store_StoreConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2176996133L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2167,10 +2190,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration using level 1 for category General-->
-  <!--===============================================================================================================================================================-->
+  <!--=============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3935330107L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2187,10 +2211,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_GeneralConfiguration using level 1 for category General-->
-  <!--======================================================================================================================================-->
+  <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2305091023L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2221,10 +2246,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--====================================================================================================================================================-->
+  <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2548607147L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2262,10 +2288,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--==================================================================================================================================================-->
+  <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3064338596L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2324,10 +2351,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Reb_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2327678282L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2352,10 +2380,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Reb_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2734755624L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3492,10 +3521,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_DevicesConfiguration using level 1 for category Devices-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1287318876L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3521,10 +3551,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_GeneralConfiguration using level 1 for category General-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4105572892L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3550,10 +3581,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1342477388L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3858,10 +3890,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_PowerConfiguration using level 1 for category Power-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_PowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4095085868L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3896,10 +3929,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_buildConfiguration using level 1 for category build-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_buildConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3504572576L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3925,10 +3959,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_CryoconConfiguration using level 1 for category Cryocon-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold1_CryoconConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3096116489L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3959,10 +3994,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_DevicesConfiguration using level 1 for category Devices-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold1_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2962678614L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3979,10 +4015,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold1_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3536441556L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4230,10 +4267,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_CryoconConfiguration using level 1 for category Cryocon-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold2_CryoconConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1394652596L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4264,10 +4302,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_DevicesConfiguration using level 1 for category Devices-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold2_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1407145204L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4284,10 +4323,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold2_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 57321546L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4535,10 +4575,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_CryoconConfiguration using level 1 for category Cryocon-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cryo_CryoconConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 504527416L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4569,10 +4610,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_DevicesConfiguration using level 1 for category Devices-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cryo_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2797631718L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4589,10 +4631,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_LimitsConfiguration using level 1 for category Limits-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cryo_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4228367874L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4840,10 +4883,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_CryoConfiguration using level 1 for category Cryo-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_IonPumps_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2731350552L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4881,10 +4925,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_DevicesConfiguration using level 1 for category Devices-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_IonPumps_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 162968392L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4901,10 +4946,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_IonPumps_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2595718281L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4970,10 +5016,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--==================================================================================================================================================-->
+  <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 302302131L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5011,10 +5058,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3610869269L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5073,10 +5121,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DeviceConfiguration using level 1 for category Device-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Rtds_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4091982545L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5100,10 +5149,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DevicesConfiguration using level 1 for category Devices-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Rtds_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 959829602L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5120,10 +5170,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_LimitsConfiguration using level 1 for category Limits-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Rtds_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1372314865L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5217,10 +5268,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_DevicesConfiguration using level 1 for category Devices-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1485792936L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5237,10 +5289,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2761092564L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5306,10 +5359,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2269819399L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5571,10 +5625,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_CryoConfiguration using level 1 for category Cryo-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VQMonitor_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3602168792L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5605,10 +5660,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2969595748L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5625,10 +5681,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VQMonitor_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4106696061L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5666,10 +5723,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DeviceConfiguration using level 1 for category Device-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VacPluto_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3444967668L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5686,10 +5744,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DevicesConfiguration using level 1 for category Devices-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VacPluto_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3095500826L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5706,10 +5765,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacuumConfiguration using level 1 for category Vacuum-->
-  <!--==================================================================================================================================-->
+  <!--================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VacuumConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3027969638L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5768,10 +5828,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_DevicesConfiguration using level 1 for category Devices-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_BFR_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3602386531L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5788,10 +5849,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_LimitsConfiguration using level 1 for category Limits-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_BFR_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1388589038L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6025,10 +6087,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_BFR_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1073754593L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6045,10 +6108,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1394263366L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6065,10 +6129,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2496062068L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6890,10 +6955,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2302178379L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6910,10 +6976,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration using level 1 for category Devices-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2800696546L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6930,10 +6997,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4213993875L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7139,10 +7207,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1277575729L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7159,10 +7228,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_DevicesConfiguration using level 1 for category Devices-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_48V_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 901519920L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7179,10 +7249,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_48V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3535542928L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7556,10 +7627,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2075951956L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7576,10 +7648,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_DevicesConfiguration using level 1 for category Devices-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 638908239L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7596,10 +7669,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2731550322L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7721,10 +7795,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3342013421L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7741,10 +7816,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 951203098L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7782,10 +7858,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2062114513L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7837,10 +7914,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration using level 1 for category Devices-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3702309194L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7857,10 +7935,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3641335563L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7877,10 +7956,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 870842743L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7913,10 +7993,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Ccd_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1282336460L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8093,10 +8174,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Ccd_RaftsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 432390802L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8113,10 +8195,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
-  <!--==============================================================================================================================================================-->
+  <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3966880200L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8140,10 +8223,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1820292887L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8188,10 +8272,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration using level 1 for category Instrument-->
-  <!--================================================================================================================================================================-->
+  <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2262490442L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8222,10 +8307,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--=======================================================================================================================================================-->
+  <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2558579456L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8277,10 +8363,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1582128896L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8332,10 +8419,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--====================================================================================================================================================-->
+  <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Raft_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4170714371L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8361,10 +8449,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration using level 1 for category RaftTempControl-->
-  <!--==============================================================================================================================================================-->
+  <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 663431800L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8498,10 +8587,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration using level 1 for category RaftTempControlStatus-->
-  <!--==========================================================================================================================================================================-->
+  <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1317421370L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8527,10 +8617,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 958204913L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8568,10 +8659,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_DevicesConfiguration using level 1 for category Devices-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1232484397L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8596,10 +8688,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1058351474L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8624,10 +8717,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1292968762L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10020,10 +10114,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2936887366L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10224,10 +10319,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration using level 1 for category RaftsLimits-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 698001149L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10532,10 +10628,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration using level 1 for category RaftsPower-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 542347311L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11344,10 +11441,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_timersConfiguration using level 1 for category timers-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2280700147L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11375,7 +11473,7 @@
       <EFDB_Name>periodictasks_monitor_publish_aspicTemp_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>3</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_biasVolt_taskPeriodMillis indexed by location-->
@@ -11468,10 +11566,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Segment_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Segment_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3464766984L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11520,10 +11619,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration using level 1 for category DAQ-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3678083191L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11561,10 +11661,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration using level 1 for category Sequencer-->
-  <!--=============================================================================================================================================================-->
+  <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 247729283L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11763,10 +11864,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration using level 1 for category Visualization-->
-  <!--====================================================================================================================================================================-->
+  <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 223538209L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11783,10 +11885,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
-  <!--===========================================================================================================================================================-->
+  <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3122666733L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11824,10 +11927,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3508616947L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11907,10 +12011,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--===================================================================================================================================================================-->
+  <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1815404753L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11976,10 +12081,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3197235453L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12003,10 +12109,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--========================================================================================================================================================-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3929922340L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12037,10 +12144,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_Reb_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_Reb_FitsHandlingConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2378689932L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12065,10 +12173,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_Reb_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3063459254L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12093,10 +12202,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3752204175L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12134,10 +12244,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1363999428L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12196,10 +12307,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DeviceConfiguration using level 1 for category Device-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_Pluto_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 538856650L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12216,10 +12328,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DevicesConfiguration using level 1 for category Devices-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_Pluto_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1617359185L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>

--- a/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -5,6 +5,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_fcs</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3032430353L -->
     <item>
       <EFDB_Name>linearencoder_LinearPosition</EFDB_Name>
       <Description>linear encoder value converted to mm</Description>
@@ -32,6 +33,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_bonn_shutter_Device</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 470595085L -->
     <item>
       <EFDB_Name>bonn_V36</EFDB_Name>
       <Description>BonnShutter 5-volt reading</Description>
@@ -52,6 +54,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_daq_monitor_Store</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 822096068L -->
     <item>
       <EFDB_Name>capacity</EFDB_Name>
       <Description>total disk space</Description>
@@ -79,6 +82,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_Reb</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4145174168L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO</EFDB_Name>
@@ -372,6 +376,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_Rebps</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 258615373L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
       <EFDB_Name>boardTemp0</EFDB_Name>
@@ -457,6 +462,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Cold1</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3866169720L -->
     <item>
       <EFDB_Name>autoOffEnabled</EFDB_Name>
       <Description>Cooler auto shutoff state (1 = auto off)</Description>
@@ -519,6 +525,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Cold2</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2590548572L -->
     <item>
       <EFDB_Name>autoOffEnabled</EFDB_Name>
       <Description>Cooler auto shutoff state (1 = auto off)</Description>
@@ -581,6 +588,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Cryo</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1660760227L -->
     <item>
       <EFDB_Name>autoOffEnabled</EFDB_Name>
       <Description>Cooler auto shutoff state (1 = auto off)</Description>
@@ -643,6 +651,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_IonPumps</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1305365654L -->
     <item>
       <EFDB_Name>current</EFDB_Name>
       <Description>Cryo ion pump current</Description>
@@ -663,6 +672,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Rtds</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 197947832L -->
     <item>
       <EFDB_Name>temperatureCold1</EFDB_Name>
       <Description>Cold Plate B Temperature</Description>
@@ -690,6 +700,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Turbo</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 228701385L -->
     <item>
       <EFDB_Name>cntrlrAirTemperature</EFDB_Name>
       <Description>TurboPump controller air temp.</Description>
@@ -759,6 +770,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_VQMonitor</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3797016354L -->
     <item>
       <EFDB_Name>vqmpressure</EFDB_Name>
       <Description>Pressure Reading</Description>
@@ -772,6 +784,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_BFR</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4234786309L -->
     <item>
       <EFDB_Name>clean_5_24V_I</EFDB_Name>
       <Description>Clean 5 and 24V current</Description>
@@ -834,6 +847,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_24VC</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2262228976L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
       <Description>24V Clean PDU board temperature</Description>
@@ -1043,6 +1057,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_24VD</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1578563142L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
       <Description>24V Dirty PDU board temperature</Description>
@@ -1098,6 +1113,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_48V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 745874751L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
       <Description>48V PDU board temperature</Description>
@@ -1195,6 +1211,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_5V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2825509309L -->
     <item>
       <EFDB_Name>otm_3_A_I</EFDB_Name>
       <Description>OTM 3-A current</Description>
@@ -1229,6 +1246,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_Ccd</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 441659878L -->
     <!--CCSMETA: Array gDV indexed by location-->
     <item>
       <EFDB_Name>gDV</EFDB_Name>
@@ -1282,6 +1300,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_Reb</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4091643716L -->
     <!--CCSMETA: Array anaI indexed by location-->
     <item>
       <EFDB_Name>anaI</EFDB_Name>
@@ -1639,6 +1658,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_RebTotalPower</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 886963829L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
       <Description>Reb Total Power</Description>
@@ -1652,6 +1672,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_Segment</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 49742677L -->
     <!--CCSMETA: Array i indexed by location-->
     <item>
       <EFDB_Name>i</EFDB_Name>

--- a/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -1072,10 +1072,11 @@
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_LimitsConfiguration using level 1 for category Limits-->
-  <!--=======================================================================================================================================-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_BFR_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3064950597L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1393,10 +1394,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_BFR_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3714909306L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1413,10 +1415,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1265394131L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1902,10 +1905,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1828439805L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1922,10 +1926,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2110500092L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2187,10 +2192,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--==============================================================================================================================================-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2850418823L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2207,10 +2213,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2029192248L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2416,10 +2423,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1840265369L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2436,10 +2444,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 119701711L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3121,10 +3130,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2806487858L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3141,10 +3151,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasksConfiguration using level 1-->
-  <!--======================================================================================================================-->
+  <!--====================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasksConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2216843222L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3182,10 +3193,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2594221307L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3197,50 +3209,51 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1843493753L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3614,10 +3627,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3427238524L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3634,10 +3648,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpowerConfiguration using level 1-->
-  <!--=========================================================================================================-->
+  <!--=======================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2712771743L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3654,10 +3669,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_EmergencyResponseManagerConfiguration using level 1-->
-  <!--==================================================================================================================================-->
+  <!--================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_EmergencyResponseManagerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1256937700L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3674,10 +3690,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasksConfiguration using level 1-->
-  <!--=======================================================================================================================-->
+  <!--=====================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasksConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3091209472L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3729,10 +3746,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--==================================================================================================================================================-->
+  <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4275217324L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3744,309 +3762,310 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P00_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P01_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P02_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P03_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P04_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P05_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P06_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P07_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P08_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P09_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P10_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P11_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P12_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P00_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P01_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P02_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P03_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P04_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P05_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P06_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P07_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P08_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P09_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P10_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P11_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P12_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P00_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P01_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P02_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P03_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P04_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P05_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P06_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P07_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P08_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P09_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P10_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P11_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P12_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_power_state_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_RebConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_RebConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2466710988L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4079,10 +4098,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 450027541L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5379,10 +5399,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2726424202L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5623,10 +5644,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_PowerConfiguration using level 1 for category Power-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_PowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1165343399L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5659,10 +5681,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hexConfiguration using level 1-->
-  <!--====================================================================================================-->
+  <!--==================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hexConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3671333100L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5679,10 +5702,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold1_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cold1_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3652020044L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5916,10 +5940,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold2_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cold2_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1089908958L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6153,10 +6178,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo1_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo1_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2994916924L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6418,10 +6444,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo2_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo2_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1191924002L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6683,10 +6710,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo3_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo3_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2728601111L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6948,10 +6976,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo4_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo4_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2003396959L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7213,10 +7242,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo5_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo5_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2462129770L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7478,10 +7508,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo6_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo6_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1732804980L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7743,10 +7774,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Maq20_DeviceConfiguration using level 1 for category Device-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Maq20_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2604156242L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7770,10 +7802,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Maq20x_DeviceConfiguration using level 1 for category Device-->
-  <!--======================================================================================================================================-->
+  <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Maq20x_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1715543595L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7797,10 +7830,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasksConfiguration using level 1-->
-  <!--==================================================================================================================-->
+  <!--================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_PeriodicTasksConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1936853337L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7838,10 +7872,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 955176667L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7853,50 +7888,51 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cold1_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cold1_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1071532662L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8053,10 +8089,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cold1_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cold1_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2093579281L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8108,10 +8145,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cold1_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cold1_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2748093977L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8821,10 +8859,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cold2_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cold2_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1005779102L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8981,10 +9020,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cold2_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cold2_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3085288798L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -9036,10 +9076,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cold2_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cold2_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 693956940L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -9749,10 +9790,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_CoolMaq20_DeviceConfiguration using level 1 for category Device-->
-  <!--============================================================================================================================================-->
+  <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_CoolMaq20_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2658802452L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -9776,10 +9818,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1503120619L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -9936,10 +9979,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4127351797L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -9970,10 +10014,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3288743760L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10459,10 +10504,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo2_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1572568579L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10619,10 +10665,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo2_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4153088675L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10653,10 +10700,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo2_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 235720406L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11142,10 +11190,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1583288411L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11302,10 +11351,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1104990126L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11336,10 +11386,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2869634980L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11881,10 +11932,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo4_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1440881619L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12041,10 +12093,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo4_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4103727119L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12075,10 +12128,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo4_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1097345947L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12564,10 +12618,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1443263883L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12724,10 +12779,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1120812290L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12758,10 +12814,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3884437576L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13303,10 +13360,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_CompLimitsConfiguration using level 1 for category CompLimits-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo6_CompLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1378535267L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13463,10 +13521,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DeviceConfiguration using level 1 for category Device-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo6_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1128744020L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13497,10 +13556,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_LimitsConfiguration using level 1 for category Limits-->
-  <!--========================================================================================================================================-->
+  <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo6_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3445918367L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13986,10 +14046,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasksConfiguration using level 1-->
-  <!--=====================================================================================================================-->
+  <!--===================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_PeriodicTasksConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3042325238L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14027,10 +14088,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3863816641L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14042,92 +14104,93 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cold1_FanCtrl_timer_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cold2_FanCtrl_timer_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>compressor_state_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo3_FanCtrl_timer_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo5_FanCtrl_timer_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>update_time_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_AgentMonitorServiceConfiguration using level 1-->
-  <!--===========================================================================================================================-->
+  <!--=========================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_AgentMonitorServiceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1975764444L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14139,15 +14202,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP1CConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP1CConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3517391561L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14178,10 +14242,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP1_IConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP1_IConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3382180514L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14219,10 +14284,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP1_VConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP1_VConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3439028630L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14260,10 +14326,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP2CConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP2CConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3080976377L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14294,10 +14361,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP2_IConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP2_IConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 369472580L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14335,10 +14403,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP2_VConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP2_VConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 325658480L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14376,10 +14445,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP3CConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP3CConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2510308585L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14410,10 +14480,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP3_IConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP3_IConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3931861977L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14451,10 +14522,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP3_VConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP3_VConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4013416685L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14492,10 +14564,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP4CConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP4CConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2074762649L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14526,10 +14599,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP4_IConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP4_IConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1917857737L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14567,10 +14641,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP4_VConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP4_VConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2000469245L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14608,10 +14683,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP5CConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP5CConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1504308873L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14642,10 +14718,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP5_IConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP5_IConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2383341652L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14683,10 +14760,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP5_VConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP5_VConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2338487136L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14724,10 +14802,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP6CConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--===========================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP6CConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1068317625L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14758,10 +14837,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP6_IConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP6_IConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1369220786L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14799,10 +14879,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP6_VConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CIP6_VConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1425028486L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14840,10 +14921,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacConfiguration using level 1-->
-  <!--===============================================================================================================-->
+  <!--=============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2040504869L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14881,10 +14963,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGaugeConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--==================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacGaugeConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3522155330L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14908,10 +14991,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_ForelineVacConfiguration using level 1-->
-  <!--===================================================================================================================-->
+  <!--=================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_ForelineVacConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2224017076L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14949,10 +15033,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_ForelineVacGaugeConfiguration using level 1-->
-  <!--========================================================================================================================-->
+  <!--======================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_ForelineVacGaugeConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1093686369L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14976,10 +15061,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HeartbeatConfiguration using level 1-->
-  <!--=================================================================================================================-->
+  <!--===============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HeartbeatConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2814612902L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -14991,15 +15077,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex1VacConfiguration using level 1-->
-  <!--===============================================================================================================-->
+  <!--=============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Hex1VacConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3952218636L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15037,10 +15124,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex1VacGaugeConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--==================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Hex1VacGaugeConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3365582924L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15064,10 +15152,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex2VacConfiguration using level 1-->
-  <!--===============================================================================================================-->
+  <!--=============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Hex2VacConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2720319247L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15105,10 +15194,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex2VacGaugeConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--==================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Hex2VacGaugeConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1274243215L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15132,10 +15222,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumpsConfiguration using level 1-->
-  <!--================================================================================================================-->
+  <!--==============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_IonPumpsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 257903416L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15152,10 +15243,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Monitor_checkConfiguration using level 1-->
-  <!--=====================================================================================================================-->
+  <!--===================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Monitor_checkConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 146159701L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15167,15 +15259,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Monitor_publishConfiguration using level 1-->
-  <!--=======================================================================================================================-->
+  <!--=====================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Monitor_publishConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3807876751L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15187,15 +15280,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Monitor_updateConfiguration using level 1-->
-  <!--======================================================================================================================-->
+  <!--====================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Monitor_updateConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2172642838L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15207,15 +15301,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_RuntimeInfoConfiguration using level 1-->
-  <!--===================================================================================================================-->
+  <!--=================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_RuntimeInfoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3521620670L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15227,15 +15322,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_SchedulersConfiguration using level 1-->
-  <!--==================================================================================================================-->
+  <!--================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_SchedulersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 442894600L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15273,10 +15369,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboCurrentConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--==================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboCurrentConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1381291899L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15314,10 +15411,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboPowerConfiguration using level 1-->
-  <!--==================================================================================================================-->
+  <!--================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboPowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 456247826L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15355,10 +15453,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboPumpConfiguration using level 1-->
-  <!--=================================================================================================================-->
+  <!--===============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboPumpConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 954683946L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15424,10 +15523,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboPumpTempConfiguration using level 1-->
-  <!--=====================================================================================================================-->
+  <!--===================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboPumpTempConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1548588294L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15465,10 +15565,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboSpeedConfiguration using level 1-->
-  <!--==================================================================================================================-->
+  <!--================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboSpeedConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2024039986L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15506,10 +15607,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboVacConfiguration using level 1-->
-  <!--================================================================================================================-->
+  <!--==============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboVacConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3546757781L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15547,10 +15649,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboVacGaugeConfiguration using level 1-->
-  <!--=====================================================================================================================-->
+  <!--===================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboVacGaugeConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1890580242L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15574,10 +15677,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboVoltageConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--==================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_TurboVoltageConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3834301238L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15615,10 +15719,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPlutoConfiguration using level 1-->
-  <!--================================================================================================================-->
+  <!--==============================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_VacPlutoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2262206422L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15635,10 +15740,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Vacuum_stateConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--==================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Vacuum_stateConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2977675454L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15650,15 +15756,16 @@
       <EFDB_Name>taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasksConfiguration using level 1-->
-  <!--==========================================================================================================================-->
+  <!--========================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_PeriodicTasksConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2862678436L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15696,10 +15803,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1513603246L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15711,64 +15819,65 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>publishstats_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purgedaq_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration using level 1 for category Statistics-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3891351454L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15848,10 +15957,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Stats_buildConfiguration using level 1 for category build-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Stats_buildConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1621187726L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15868,10 +15978,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_StoreConfiguration using level 1 for category Store-->
-  <!--=====================================================================================================================================-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_StoreConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 292694152L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15888,10 +15999,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_LimitsConfiguration using level 1 for category Limits-->
-  <!--=============================================================================================================================================-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Store_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1095131729L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -15985,10 +16097,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_StoreConfiguration using level 1 for category Store-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Store_StoreConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 835696483L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16026,10 +16139,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2249685560L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16062,10 +16176,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Ccd_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2220864086L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16274,10 +16389,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Ccd_RaftsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2502921873L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16294,10 +16410,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageDatabaseServiceConfiguration using level 1-->
-  <!--=================================================================================================================================-->
+  <!--===============================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_ImageDatabaseServiceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 104097607L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16321,10 +16438,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageNameServiceConfiguration using level 1-->
-  <!--=============================================================================================================================-->
+  <!--===========================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_ImageNameServiceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3359778144L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16369,10 +16487,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration using level 1 for category Instrument-->
-  <!--================================================================================================================================================================-->
+  <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3735281910L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16403,10 +16522,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasksConfiguration using level 1-->
-  <!--==========================================================================================================================-->
+  <!--========================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_PeriodicTasksConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3326147298L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16458,10 +16578,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3214895136L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16473,218 +16594,219 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R00_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R01_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R02_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R03_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R04_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R10_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R11_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R12_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R13_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R14_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R20_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R21_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R22_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R23_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R24_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R30_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R31_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R32_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R33_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R34_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R40_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R41_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R42_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R43_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tempcontrol_R44_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--====================================================================================================================================================-->
+  <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Raft_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2411177375L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16709,10 +16831,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration using level 1 for category RaftTempControl-->
-  <!--==============================================================================================================================================================-->
+  <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 124194515L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16833,10 +16956,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration using level 1 for category RaftTempControlStatus-->
-  <!--==========================================================================================================================================================================-->
+  <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1630683015L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16861,10 +16985,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2077671636L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16902,10 +17027,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_HardwareIdConfiguration using level 1 for category HardwareId-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_HardwareIdConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 395125619L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16930,10 +17056,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3954334785L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18582,10 +18709,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=========================================================================================================================================-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3030793537L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18786,10 +18914,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration using level 1 for category RaftsLimits-->
-  <!--=====================================================================================================================================================-->
+  <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1662452324L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -19094,10 +19223,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration using level 1 for category RaftsPower-->
-  <!--===================================================================================================================================================-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3733685657L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -19906,10 +20036,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_timersConfiguration using level 1 for category timers-->
-  <!--===========================================================================================================================================-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3116175901L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -19929,7 +20060,7 @@
       <EFDB_Name>periodictasks_monitor_check_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_aspicTemp_taskPeriodMillis indexed by location-->
@@ -19937,7 +20068,7 @@
       <EFDB_Name>periodictasks_monitor_publish_aspicTemp_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_biasVolt_taskPeriodMillis indexed by location-->
@@ -19945,7 +20076,7 @@
       <EFDB_Name>periodictasks_monitor_publish_biasVolt_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_boardPower_taskPeriodMillis indexed by location-->
@@ -19953,7 +20084,7 @@
       <EFDB_Name>periodictasks_monitor_publish_boardPower_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_ccdCurrent_taskPeriodMillis indexed by location-->
@@ -19961,7 +20092,7 @@
       <EFDB_Name>periodictasks_monitor_publish_ccdCurrent_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_crVolt_taskPeriodMillis indexed by location-->
@@ -19969,7 +20100,7 @@
       <EFDB_Name>periodictasks_monitor_publish_crVolt_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_rebTemp_taskPeriodMillis indexed by location-->
@@ -19977,7 +20108,7 @@
       <EFDB_Name>periodictasks_monitor_publish_rebTemp_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_publish_taskPeriodMillis indexed by location-->
@@ -19985,7 +20116,7 @@
       <EFDB_Name>periodictasks_monitor_publish_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_aspicTemp_taskPeriodMillis indexed by location-->
@@ -19993,7 +20124,7 @@
       <EFDB_Name>periodictasks_monitor_update_aspicTemp_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_biasVolt_taskPeriodMillis indexed by location-->
@@ -20001,7 +20132,7 @@
       <EFDB_Name>periodictasks_monitor_update_biasVolt_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_boardPower_taskPeriodMillis indexed by location-->
@@ -20009,7 +20140,7 @@
       <EFDB_Name>periodictasks_monitor_update_boardPower_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_ccdCurrent_taskPeriodMillis indexed by location-->
@@ -20017,7 +20148,7 @@
       <EFDB_Name>periodictasks_monitor_update_ccdCurrent_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_crVolt_taskPeriodMillis indexed by location-->
@@ -20025,7 +20156,7 @@
       <EFDB_Name>periodictasks_monitor_update_crVolt_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_rebTemp_taskPeriodMillis indexed by location-->
@@ -20033,7 +20164,7 @@
       <EFDB_Name>periodictasks_monitor_update_rebTemp_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array periodictasks_monitor_update_taskPeriodMillis indexed by location-->
@@ -20041,15 +20172,16 @@
       <EFDB_Name>periodictasks_monitor_update_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>71</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Segment_LimitsConfiguration using level 1 for category Limits-->
-  <!--===============================================================================================================================================-->
+  <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Segment_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3281313740L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20098,10 +20230,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration using level 1 for category DAQ-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1186480143L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20132,10 +20265,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration using level 1 for category Sequencer-->
-  <!--=============================================================================================================================================================-->
+  <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1247479346L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20334,10 +20468,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration using level 1 for category Visualization-->
-  <!--====================================================================================================================================================================-->
+  <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 919408884L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20354,10 +20489,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
-  <!--=================================================================================================================================================-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2833262260L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20437,10 +20573,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--===================================================================================================================================================================-->
+  <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3192345231L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20499,10 +20636,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 245874300L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20526,10 +20664,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration using level 1 for category timers-->
-  <!--========================================================================================================================================================-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1124810080L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20541,29 +20680,30 @@
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>millisecond</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_Reb_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--==========================================================================================================================================================-->
+  <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_Reb_FitsHandlingConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4209526032L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20588,10 +20728,11 @@
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--================================================================================================================================================-->
+  <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_Reb_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2247502848L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>

--- a/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -5,6 +5,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_BFR</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2878214622L -->
     <item>
       <EFDB_Name>clean_5_24V_I</EFDB_Name>
       <Description>Clean 5 and 24V current</Description>
@@ -88,6 +89,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_24VC</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1459569460L -->
     <item>
       <EFDB_Name>n_24vc_Board_T</EFDB_Name>
       <Description>24V Clean PDU board temperature</Description>
@@ -213,6 +215,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_24VD</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 185595877L -->
     <item>
       <EFDB_Name>n_24vd_Board_T</EFDB_Name>
       <Description>24V Dirty PDU board temperature</Description>
@@ -282,6 +285,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_48V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 844609743L -->
     <item>
       <EFDB_Name>n_48v_Board_T</EFDB_Name>
       <Description>48V PDU board temperature</Description>
@@ -337,6 +341,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_5V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 764407982L -->
     <item>
       <EFDB_Name>otm_0_A_I</EFDB_Name>
       <Description>OTM 0-A current</Description>
@@ -511,6 +516,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_REB_Bulk_PS</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1457295069L -->
     <item>
       <EFDB_Name>rebbulkps_0_2_I</EFDB_Name>
       <Description>REB Bulk PS 0-2 current</Description>
@@ -608,6 +614,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Reb</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 72957452L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO</EFDB_Name>
@@ -941,6 +948,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Rebps</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 283005396L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
       <EFDB_Name>boardTemp0</EFDB_Name>
@@ -1010,6 +1018,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cold1</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 50803903L -->
     <item>
       <EFDB_Name>evapExitTmp</EFDB_Name>
       <Description>Evap Exit Temperature</Description>
@@ -1072,6 +1081,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cold2</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2330002407L -->
     <item>
       <EFDB_Name>evapExitTmp</EFDB_Name>
       <Description>Evap Exit Temperature</Description>
@@ -1134,6 +1144,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo1</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 581887221L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
       <Description>C3 Exit Temperature</Description>
@@ -1203,6 +1214,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo2</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3041049894L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
       <Description>C3 Exit Temperature</Description>
@@ -1272,6 +1284,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo3</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1899394984L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
       <Description>C3 Exit Temperature</Description>
@@ -1341,6 +1354,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo4</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1105922241L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
       <Description>C3 Exit Temperature</Description>
@@ -1410,6 +1424,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo5</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2241839695L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
       <Description>C3 Exit Temperature</Description>
@@ -1479,6 +1494,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo6</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 309566364L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
       <Description>C3 Exit Temperature</Description>
@@ -1548,6 +1564,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cold1</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3552735140L -->
     <item>
       <EFDB_Name>ambientTmp</EFDB_Name>
       <Description>Ambient Temperature</Description>
@@ -1729,6 +1746,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cold2</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2238247767L -->
     <item>
       <EFDB_Name>ambientTmp</EFDB_Name>
       <Description>Ambient Temperature</Description>
@@ -1910,6 +1928,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo1</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 869246017L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
@@ -2035,6 +2054,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo2</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2572091680L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
@@ -2160,6 +2180,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo3</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 773606185L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
@@ -2299,6 +2320,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo4</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 390024611L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
@@ -2424,6 +2446,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo5</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2308100150L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
@@ -2563,6 +2586,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo6</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3686822941L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
@@ -2688,6 +2712,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP1_I</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3377731400L -->
     <item>
       <EFDB_Name>cip1_I</EFDB_Name>
       <Description>Cryo ion pump 1 current</Description>
@@ -2701,6 +2726,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP1_V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3445606188L -->
     <item>
       <EFDB_Name>cip1_V</EFDB_Name>
       <Description>Cryo ion pump 1 voltage</Description>
@@ -2714,6 +2740,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP2_I</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1700513562L -->
     <item>
       <EFDB_Name>cip2_I</EFDB_Name>
       <Description>Cryo ion pump 2 current</Description>
@@ -2727,6 +2754,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP2_V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1632638846L -->
     <item>
       <EFDB_Name>cip2_V</EFDB_Name>
       <Description>Cryo ion pump 2 voltage</Description>
@@ -2740,6 +2768,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP3_I</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 22972628L -->
     <item>
       <EFDB_Name>cip3_I</EFDB_Name>
       <Description>Cryo ion pump 3 current</Description>
@@ -2753,6 +2782,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP3_V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 89479344L -->
     <item>
       <EFDB_Name>cip3_V</EFDB_Name>
       <Description>Cryo ion pump 3 voltage</Description>
@@ -2766,6 +2796,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP4_I</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3862258175L -->
     <item>
       <EFDB_Name>cip4_I</EFDB_Name>
       <Description>Cryo ion pump 4 current</Description>
@@ -2779,6 +2810,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP4_V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3795759515L -->
     <item>
       <EFDB_Name>cip4_V</EFDB_Name>
       <Description>Cryo ion pump 4 voltage</Description>
@@ -2792,6 +2824,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP5_I</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2184195633L -->
     <item>
       <EFDB_Name>cip5_I</EFDB_Name>
       <Description>Cryo ion pump 5 current</Description>
@@ -2805,6 +2838,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP5_V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2252078677L -->
     <item>
       <EFDB_Name>cip5_V</EFDB_Name>
       <Description>Cryo ion pump 5 voltage</Description>
@@ -2818,6 +2852,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP6_I</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 775945827L -->
     <item>
       <EFDB_Name>cip6_I</EFDB_Name>
       <Description>Cryo ion pump 6 current</Description>
@@ -2831,6 +2866,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CIP6_V</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 708062727L -->
     <item>
       <EFDB_Name>cip6_V</EFDB_Name>
       <Description>Cryo ion pump 6 voltage</Description>
@@ -2844,6 +2880,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_CryoVac</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3986274856L -->
     <item>
       <EFDB_Name>cryoVac</EFDB_Name>
       <Description>Cryostat vacuum</Description>
@@ -2857,6 +2894,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_ForelineVac</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3015630784L -->
     <item>
       <EFDB_Name>forelineVac</EFDB_Name>
       <Description>Foreline pump vacuum</Description>
@@ -2870,6 +2908,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_Hex1Vac</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3004044124L -->
     <item>
       <EFDB_Name>hex1Vac</EFDB_Name>
       <Description>Heat exchanger 1 vacuum</Description>
@@ -2883,6 +2922,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_Hex2Vac</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1996811375L -->
     <item>
       <EFDB_Name>hex2Vac</EFDB_Name>
       <Description>Heat exchanger 2 vacuum</Description>
@@ -2896,6 +2936,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_TurboCurrent</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 712557024L -->
     <item>
       <EFDB_Name>turboCurrent</EFDB_Name>
       <Description>TurboPump current</Description>
@@ -2909,6 +2950,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_TurboPower</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 276285080L -->
     <item>
       <EFDB_Name>turboPower</EFDB_Name>
       <Description>TurboPump power</Description>
@@ -2922,6 +2964,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_TurboPumpTemp</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3365989911L -->
     <item>
       <EFDB_Name>turboPumpTemp</EFDB_Name>
       <Description>TurboPump pump temperature</Description>
@@ -2935,6 +2978,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_TurboSpeed</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3054233021L -->
     <item>
       <EFDB_Name>turboSpeed</EFDB_Name>
       <Description>Turbo pump speed (RPM)</Description>
@@ -2948,6 +2992,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_TurboVac</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1282131722L -->
     <item>
       <EFDB_Name>turboVac</EFDB_Name>
       <Description>Turbo pump vacuum</Description>
@@ -2961,6 +3006,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_TurboVoltage</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3029650990L -->
     <item>
       <EFDB_Name>turboVoltage</EFDB_Name>
       <Description>TurboPump voltage</Description>
@@ -2974,6 +3020,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_daq_monitor_Store</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1179110280L -->
     <item>
       <EFDB_Name>capacity</EFDB_Name>
       <Description>total disk space</Description>
@@ -3001,6 +3048,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_Ccd</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 165558076L -->
     <!--CCSMETA: Array gDV indexed by location-->
     <item>
       <EFDB_Name>gDV</EFDB_Name>
@@ -3062,6 +3110,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_Reb</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4128750188L -->
     <!--CCSMETA: Array anaI indexed by location-->
     <item>
       <EFDB_Name>anaI</EFDB_Name>
@@ -3483,6 +3532,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_RebTotalPower</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3939455426L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
       <Description>Reb Total Power</Description>
@@ -3496,6 +3546,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_Segment</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3706039522L -->
     <!--CCSMETA: Array i indexed by location-->
     <item>
       <EFDB_Name>i</EFDB_Name>


### PR DESCRIPTION
This pull request cleanup XML prior to add new camera XML for filter changer and shutter. See CAP-932:

There are 3 changes, all hopefully innocuous

Change length of ===== commands to match text
Add a new comment: CCS: Dictionary_Checksum: 4128750188L for each computer generated topic. This has no effect on the generated SAL code, but will allow us to do cross checks when running CCS to find outdated XML
Correct a few units (in partcular some unitless->milliseconds that I missed when I fixed them up by hand before.
These changes are just cleanup before more substantive changes to follow