### PR TITLE
Remove duplicate names

### DIFF
--- a/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -3568,7 +3568,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3189649012L -->
+    <!--CCS: Dictionary_Checksum: 3985590553L -->
     <item>
       <EFDB_Name>acAF0b</EFDB_Name>
       <Description>MISSING</Description>
@@ -7603,20 +7603,6 @@
     </item>
     <item>
       <EFDB_Name>loaderTcpProxy</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LFD</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LFS</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>


### PR DESCRIPTION
Same as before but with duplicate names:

loader_LFD
loader_LFS

removed.