### PR TITLE
DM-36189 (and DM-36672): Add prereq_jobs and output_dataset_types parameters.

### DIFF
--- a/sal_interfaces/OCPS/OCPS_Commands.xml
+++ b/sal_interfaces/OCPS/OCPS_Commands.xml
@@ -37,6 +37,22 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>prereq_jobs</EFDB_Name>
+      <Description>Comma-separated list of jobs that must complete before this job executes.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>output_dataset_types</EFDB_Name>
+      <Description>Comma-separated list of glob patterns for dataset types that are to be captured as outputs from the job.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALCommand>
   <SALCommand>
     <Subsystem>OCPS</Subsystem>


### PR DESCRIPTION
prereq_jobs allows a comma-separated list of job ids to be provided; this job will not start until those jobs have completed. (DM-31689)

output_dataset_types allows a comma-separated list of glob patterns specifying dataset types to be provided.  Datasets matching those types will be captured by the UWS back-end system, and URIs pointing to those datasets will be included in the job result event. (DM-36672)