### PR TITLE
Tickets/dm 36708: Strictly enforce the <*ItemType> attribute ordering 

### DIFF
--- a/sal_interfaces/DIMM/DIMM_Telemetry.xml
+++ b/sal_interfaces/DIMM/DIMM_Telemetry.xml
@@ -7,10 +7,10 @@
     <item>
       <EFDB_Name>status</EFDB_Name>
       <Description>The current sky status.</Description>
-      <Enumeration>clear=0,lightcoverage=1,cloudy=2,rain=3,snow=4</Enumeration>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
+      <Enumeration>clear=0,lightcoverage=1,cloudy=2,rain=3,snow=4</Enumeration>
     </item>
   </SALTelemetry>
   <SALTelemetry>

--- a/sal_interfaces/MTEEC/MTEEC_Events.xml
+++ b/sal_interfaces/MTEEC/MTEEC_Events.xml
@@ -6,12 +6,12 @@
     <EFDB_Topic>MTEEC_logevent_detailedState</EFDB_Topic>
     <item>
       <EFDB_Name>detailedState</EFDB_Name>
-      <Enumeration>NotSetState,DaySetState,NightSetState</Enumeration>
       <Description>Detailed state.</Description>
       <!-- Enumeration: DetailedState -->
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
+      <Enumeration>NotSetState,DaySetState,NightSetState</Enumeration>
     </item>
   </SALEvent>
 </SALEventSet>

--- a/sal_interfaces/MTM1M3/MTM1M3_Commands.xml
+++ b/sal_interfaces/MTM1M3/MTM1M3_Commands.xml
@@ -108,6 +108,7 @@
         If true, slew flag will be set - booster valve will be activated.
       </Description>
       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALCommand>

--- a/schema/SALCommandSet.xsd
+++ b/schema/SALCommandSet.xsd
@@ -8,7 +8,7 @@
   <xsd:element name="SALCommand" type="commandType"/>
   <xsd:element name="SALCommandItem" type="commandItemType"/>
   <xsd:complexType name="commandItemType">
-    <xsd:choice maxOccurs="unbounded">
+    <xsd:sequence maxOccurs="unbounded">
       <xsd:element name="EFDB_Name" type="xsd:string"/>
       <xsd:element name="Description" type="xsd:string"/>
       <xsd:element name="IDL_Type" type="xsd:string"/>
@@ -17,7 +17,7 @@
       <xsd:element name="Count" type="xsd:positiveInteger"/>
       <xsd:element maxOccurs="1" minOccurs="0" name="Enumeration" type="xsd:string"/>
       <xsd:element maxOccurs="1" minOccurs="0" name="IsJavaArray" type="xsd:string"/>
-    </xsd:choice>
+    </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="commandType">
     <xsd:choice maxOccurs="unbounded">

--- a/schema/SALEventSet.xsd
+++ b/schema/SALEventSet.xsd
@@ -9,7 +9,7 @@
   <xsd:element name="SALEventItem" type="eventItemType"/>
   <xsd:element name="SALEventFileRef" type="eventFileRefType"/>
   <xsd:complexType name="eventItemType">
-    <xsd:choice maxOccurs="unbounded">
+    <xsd:sequence maxOccurs="unbounded">
       <xsd:element name="EFDB_Name" type="xsd:string"/>
       <xsd:element name="Description" type="xsd:string"/>
       <xsd:element name="IDL_Type" type="xsd:string"/>
@@ -18,7 +18,7 @@
       <xsd:element name="Count" type="xsd:positiveInteger"/>
       <xsd:element maxOccurs="1" minOccurs="0" name="Enumeration" type="xsd:string"/>
       <xsd:element maxOccurs="1" minOccurs="0" name="IsJavaArray" type="xsd:string"/>
-    </xsd:choice>
+    </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="eventType">
     <xsd:sequence>

--- a/schema/SALTelemetrySet.xsd
+++ b/schema/SALTelemetrySet.xsd
@@ -11,7 +11,7 @@
     <xsd:annotation>
       <xsd:documentation>Telemetry items parameters and values</xsd:documentation>
     </xsd:annotation>
-    <xsd:choice maxOccurs="unbounded">
+    <xsd:sequence maxOccurs="unbounded">
       <xsd:element name="EFDB_Name" type="xsd:string"/>
       <xsd:element name="Description" type="xsd:string"/>
       <xsd:element name="IDL_Type" type="xsd:string"/>
@@ -20,7 +20,7 @@
       <xsd:element name="Count" type="xsd:positiveInteger"/>
       <xsd:element maxOccurs="1" minOccurs="0" name="Enumeration" type="xsd:string"/>
       <xsd:element maxOccurs="1" minOccurs="0" name="IsJavaArray" type="xsd:string"/>
-    </xsd:choice>
+    </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="telemetryType">
     <xsd:choice maxOccurs="unbounded">

--- a/tests/test_CSC_XML_Valid.py
+++ b/tests/test_CSC_XML_Valid.py
@@ -5,6 +5,18 @@ from lxml import etree
 import lsst.ts.xml as ts_xml
 
 
+def check_for_issues(csc, topic):
+    if csc == "WeatherForecast":
+        jira = "DM-36801"
+    elif csc == "ATCamera" and topic != "Commands":
+        jira = "CAP-944"
+    elif csc == "CCCamera" and topic != "Commands":
+        jira = "CAP-944"
+    else:
+        jira = ""
+    return jira
+
+
 def get_xml_schema(saltype):
     pkgroot = ts_xml.get_pkg_root()
     xmlschema_doc = etree.parse(f"{pkgroot}/schema/{saltype}Set.xsd")
@@ -29,6 +41,9 @@ def test_csc_xml_valid(xmlfile, csc, topic):
     """
     saltype = "SAL" + topic.rstrip("s")
     xmlschema = get_xml_schema(saltype)
+    jira = check_for_issues(csc, topic)
+    if jira:
+        pytest.skip(f"{jira}: {xmlfile.name} Does not conform to XML schema.")
     with open(str(xmlfile), "r", encoding="utf-8") as f:
         tree = etree.parse(f)
     try:


### PR DESCRIPTION
* Changed the <*ItemType> property from choice to sequence.
* Updated a few XML files with minimal changes needed to conform to the schema.
* Added skip tags for ATCamera, CCCamera and WeatherForecast CSCs.