### PR TITLE
DM-37113: MTMount_Events: fix cameraCableWrapControllerSettings

### DIFF
--- a/python/lsst/ts/xml/data/sal_interfaces/MTMount/MTMount_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTMount/MTMount_Events.xml
@@ -410,15 +410,29 @@
     <EFDB_Topic>MTMount_logevent_cameraCableWrapControllerSettings</EFDB_Topic>
     <Description>A selection of low-level controller settings for the camera cable wrap.</Description>
     <item>
-      <EFDB_Name>l1LimitsEnabled</EFDB_Name>
-      <Description>L1 (software) position limits enabled?</Description>
+      <EFDB_Name>minl1LimitEnabled</EFDB_Name>
+      <Description>Is the minimum L1 (software) position limit enabled?</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>l2LimitsEnabled</EFDB_Name>
-      <Description>L2 (direction inhibit) limit switches enabled?</Description>
+      <EFDB_Name>maxl1LimitEnabled</EFDB_Name>
+      <Description>Is the maximum L1 (software) position limit enabled?</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minl2LimitEnabled</EFDB_Name>
+      <Description>Is the minimum L2 (direction inhibit) limit switch enabled?</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxl2LimitEnabled</EFDB_Name>
+      <Description>Is the maximum` L2 (direction inhibit) limit switch enabled?</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>


### PR DESCRIPTION
The limits enabled fields did not match the information available from the TMA.