### PR TITLE
DM-38542: ESS: simplify acceleration and accelerationPSD

### DIFF
--- a/python/lsst/ts/xml/data/sal_interfaces/ESS/ESS_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ESS/ESS_Telemetry.xml
@@ -386,7 +386,7 @@
     </item>
     <item>
       <EFDB_Name>interval</EFDB_Name>
-      <Description>Data collection time interval. N-th (starting from 0) sample is assumed to be taken at "timestamp" + ("interval"/200) * N.</Description>
+      <Description>Data collection time interval. N-th (starting from 0) sample is assumed to be taken at "timestamp" + "interval" * N.</Description>
       <IDL_Type>double</IDL_Type>
       <Units>second</Units>
       <Count>1</Count>
@@ -396,21 +396,21 @@
       <Description>Acceleration in x direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>m/s2</Units>
-      <Count>200</Count>
+      <Count>400</Count>
     </item>
     <item>
       <EFDB_Name>accelerationY</EFDB_Name>
       <Description>Acceleration in y direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>m/s2</Units>
-      <Count>200</Count>
+      <Count>400</Count>
     </item>
     <item>
       <EFDB_Name>accelerationZ</EFDB_Name>
       <Description>Acceleration in Z direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>m/s2</Units>
-      <Count>200</Count>
+      <Count>400</Count>
     </item>
     <item>
       <EFDB_Name>location</EFDB_Name>
@@ -438,20 +438,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>interval</EFDB_Name>
-      <Description>Time interval over which PSDs were calculated beginning from the starting time.</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>second</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>minPSDFrequency</EFDB_Name>
-      <Description>PSD minimum frequency.</Description>
-      <IDL_Type>float</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>maxPSDFrequency</EFDB_Name>
       <Description>PSD maximum frequency.</Description>
       <IDL_Type>float</IDL_Type>
@@ -459,32 +445,25 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>numDataPoints</EFDB_Name>
-      <Description>Number of valid frequencies. PSD array elements with index greater than or equal to numDataPoints are invalid and can contain any value (0 preferred).</Description>
-      <IDL_Type>int</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>accelerationPSDX</EFDB_Name>
       <Description>Acceleration PSD in x direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>m2 / (Hz2 s4)</Units>
-      <Count>200</Count>
+      <Count>201</Count>
     </item>
     <item>
       <EFDB_Name>accelerationPSDY</EFDB_Name>
       <Description>Acceleration PSD in y direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>m2 / (Hz2 s4)</Units>
-      <Count>200</Count>
+      <Count>201</Count>
     </item>
     <item>
       <EFDB_Name>accelerationPSDZ</EFDB_Name>
       <Description>Acceleration PSD in z direction.</Description>
       <IDL_Type>float</IDL_Type>
       <Units>m2 / (Hz2 s4)</Units>
-      <Count>200</Count>
+      <Count>201</Count>
     </item>
     <item>
       <EFDB_Name>location</EFDB_Name>


### PR DESCRIPTION
telemetry topics:

* accelerationPSD:

  * change array length from 200 to 201. This gives nicer frequencies for round values of maxPSDFrequency.
  * eliminate interval: it was irrelevant.
  * eliminate  minPSDFrequency: it is now always 0.
  * eliminate numDataPoints: it is now always 201 (all array elements).

* acceleration:

  * change array length from 200 to 400. This allows publishing acceleration once for each time we publish acccelerationPSD.