### PR TITLE
DM-37834: Script and ScriptQueue doc tweak

### DIFF
--- a/python/lsst/ts/xml/data/sal_interfaces/Script/Script_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/Script/Script_Events.xml
@@ -136,7 +136,7 @@
     </item>
     <item>
       <EFDB_Name>instrument</EFDB_Name>
-      <Description>Instrument name, if relevant.</Description>
+      <Description>Instrument name (the short name used by middleware) used to take the data; blank if unknown or not relevant.</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>

--- a/python/lsst/ts/xml/data/sal_interfaces/ScriptQueue/ScriptQueue_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ScriptQueue/ScriptQueue_Events.xml
@@ -139,7 +139,7 @@
     </item>
     <item>
       <EFDB_Name>instrument</EFDB_Name>
-      <Description>Instrument name, if relevant.</Description>
+      <Description>Instrument name (the short name used by middleware) used to take the data; blank if unknown or not relevant.</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>


### PR DESCRIPTION
Expand the description of the "instrument" field in the Script.metadata and ScriptQueue.nextVisit events.