### PR TITLE
Tickets/cap 1006

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -97,6 +97,7 @@ v20.0.0
   * ATCamera/CCCamera/MTCamera
 
     * Add DAQ monitoring statistics (CAP-703)
+    * Fix for image_handling configuration (CAP-1006)
 
 v19.0.0
 -------

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -7030,6 +7030,27 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--===========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>ATCamera</Subsystem>
+    <EFDB_Topic>ATCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3104697549L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>patternConfigList</EFDB_Name>
+      <Description>List of patterns that describe which data is to be aggregated and how.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!-- ENDCONFIGURATION Do not remove this line -->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -6687,12 +6687,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
-  <!--=========================================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_FitsService_GeneralConfiguration using level 1 for category General-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
-    <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3749482302L -->
+    <EFDB_Topic>ATCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2436812217L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6701,29 +6701,71 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>guider_headerFilesList</EFDB_Name>
+      <Description>List of spec files to be read by this FITS service</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>science_headerFilesList</EFDB_Name>
+      <Description>List of spec files to be read by this FITS service</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
+  <!--=========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>ATCamera</Subsystem>
+    <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3328040053L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_additionalFileCommands</EFDB_Name>
+      <Description>Commands to issue on additional (non FITS) files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_additionalFileFilter</EFDB_Name>
+      <Description>Filter to apply to additional files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>imagehandlingconfig_commands</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Commands to be issued after FITS files written</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_currentDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current directory to set when issuing FITS file commands</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_environment</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Environment variables to set when issuing FITS file commands</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_logDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Directory in which it write log files for FITS file commands</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6744,70 +6786,70 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelAlarmLevel</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of bad pixels above which an alarm is generated</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelHighThreshold</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Threshold above which DAQ pixels are considered bad</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelLowThreshold</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Threashold below which DAQ pixelse are considered bad</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelWarningLevel</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of bad pixels above which a warning is generated</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_checkForBadPixels</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to check the DAQ data for bad (possibly corrupt) pixels</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqFolder</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The folder in the DAQ partition to monitor for new science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqPartition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The DAQ partition to use for science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The number of thread to allow to simulateously pull data from the 2-day store</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_locations</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The locations to monitor for new science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_useStreaming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to stream the DAQ science data to FITS files as it arrives</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6818,7 +6860,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 341171740L -->
+    <!--CCS: Dictionary_Checksum: 3545217339L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6828,56 +6870,98 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSAutoSave</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether FITS files should always be saved</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSDirectoryPattern</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pattern used to generate folders below FITSRootDirectory</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSFilePattern</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pattern used to generte FITS file names</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSRootDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Root directory where FITS files are written</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>imagehandlingconfig_raiseAlertOnMissingOrBadHeaderServiceData</EFDB_Name>
+      <Description>Whether to raise an alert if the fits header data does not arrive</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>imagehandlingconfig_subsystemsToClearOnNewRun</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_tempFileRelativeLocation</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Relative loction of temporary files (if written)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_useTempFile</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether FITS files should first be written with a temporary name and then renamed on success</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_waitForHeaderService</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to wait for header service data before finalizing FITS files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration using level 1 for category Guider-->
+  <!--=====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>ATCamera</Subsystem>
+    <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4265689238L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderFITSFilePattern</EFDB_Name>
+      <Description>FITS file pattern to use for writting guider FITS files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderLocations</EFDB_Name>
+      <Description>Locations to monitor for guider data</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderPartition</EFDB_Name>
+      <Description>DAQ partition to monitor for guider data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6898,14 +6982,14 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6926,83 +7010,23 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_Reb_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--========================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>ATCamera</Subsystem>
-    <EFDB_Topic>ATCamera_logevent_image_handling_Reb_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2673458276L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <!--CCSMETA: Array enabled indexed by location-->
-    <item>
-      <EFDB_Name>enabled</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-      <IsJavaArray>yes</IsJavaArray>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>reb location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--==============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>ATCamera</Subsystem>
-    <EFDB_Topic>ATCamera_logevent_image_handling_Reb_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3698070690L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <!--CCSMETA: Array fitsservice_headerFilesList indexed by location-->
-    <item>
-      <EFDB_Name>fitsservice_headerFilesList</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-      <IsJavaArray>yes</IsJavaArray>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>reb location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -11884,12 +11884,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
-  <!--=========================================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_FitsService_GeneralConfiguration using level 1 for category General-->
+  <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3122666733L -->
+    <EFDB_Topic>CCCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3143876673L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11898,29 +11898,71 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>guider_headerFilesList</EFDB_Name>
+      <Description>List of spec files to be read by this FITS service</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>science_headerFilesList</EFDB_Name>
+      <Description>List of spec files to be read by this FITS service</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
+  <!--=========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 843025526L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_additionalFileCommands</EFDB_Name>
+      <Description>Commands to issue on additional (non FITS) files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_additionalFileFilter</EFDB_Name>
+      <Description>Filter to apply to additional files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>imagehandlingconfig_commands</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Commands to be issued after FITS files written</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_currentDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current directory to set when issuing FITS file commands</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_environment</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Environment variables to set when issuing FITS file commands</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_logDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Directory in which it write log files for FITS file commands</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11941,70 +11983,70 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelAlarmLevel</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of bad pixels above which an alarm is generated</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelHighThreshold</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Threshold above which DAQ pixels are considered bad</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelLowThreshold</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Threashold below which DAQ pixelse are considered bad</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelWarningLevel</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of bad pixels above which a warning is generated</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_checkForBadPixels</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to check the DAQ data for bad (possibly corrupt) pixels</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqFolder</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The folder in the DAQ partition to monitor for new science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqPartition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The DAQ partition to use for science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The number of thread to allow to simulateously pull data from the 2-day store</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_locations</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The locations to monitor for new science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_useStreaming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to stream the DAQ science data to FITS files as it arrives</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -12015,7 +12057,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1815404753L -->
+    <!--CCS: Dictionary_Checksum: 2066138206L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12025,56 +12067,98 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSAutoSave</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether FITS files should always be saved</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSDirectoryPattern</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pattern used to generate folders below FITSRootDirectory</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSFilePattern</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pattern used to generte FITS file names</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSRootDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Root directory where FITS files are written</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>imagehandlingconfig_raiseAlertOnMissingOrBadHeaderServiceData</EFDB_Name>
+      <Description>Whether to raise an alert if the fits header data does not arrive</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>imagehandlingconfig_subsystemsToClearOnNewRun</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_tempFileRelativeLocation</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Relative loction of temporary files (if written)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_useTempFile</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether FITS files should first be written with a temporary name and then renamed on success</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_waitForHeaderService</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to wait for header service data before finalizing FITS files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration using level 1 for category Guider-->
+  <!--=====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 966374854L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderFITSFilePattern</EFDB_Name>
+      <Description>FITS file pattern to use for writting guider FITS files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderLocations</EFDB_Name>
+      <Description>Locations to monitor for guider data</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderPartition</EFDB_Name>
+      <Description>DAQ partition to monitor for guider data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -12095,14 +12179,14 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -12123,81 +12207,23 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_Reb_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--========================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_image_handling_Reb_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2378689932L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <!--CCSMETA: Array enabled indexed by location-->
-    <item>
-      <EFDB_Name>enabled</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>3</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>reb location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--==============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_image_handling_Reb_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3063459254L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <!--CCSMETA: Array fitsservice_headerFilesList indexed by location-->
-    <item>
-      <EFDB_Name>fitsservice_headerFilesList</EFDB_Name>
-      <Description>MISSING (colon delimited array)</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>reb location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -12227,6 +12227,27 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--===========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1829680725L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>patternConfigList</EFDB_Name>
+      <Description>List of patterns that describe which data is to be aggregated and how.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
   <!--=============================================================================================================================================-->
   <SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -20488,12 +20488,96 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_FitsService_GeneralConfiguration using level 1 for category General-->
+  <!--======================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1361000410L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>guider_headerFilesList</EFDB_Name>
+      <Description>List of spec files to be read by this FITS service</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>science_headerFilesList</EFDB_Name>
+      <Description>List of spec files to be read by this FITS service</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
+  <!--=========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2880697553L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_additionalFileCommands</EFDB_Name>
+      <Description>Commands to issue on additional (non FITS) files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_additionalFileFilter</EFDB_Name>
+      <Description>Filter to apply to additional files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_commands</EFDB_Name>
+      <Description>Commands to be issued after FITS files written</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_currentDirectory</EFDB_Name>
+      <Description>Current directory to set when issuing FITS file commands</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_environment</EFDB_Name>
+      <Description>Environment variables to set when issuing FITS file commands</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_logDirectory</EFDB_Name>
+      <Description>Directory in which it write log files for FITS file commands</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2833262260L -->
+    <!--CCS: Dictionary_Checksum: 2869337463L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20503,70 +20587,70 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelAlarmLevel</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of bad pixels above which an alarm is generated</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelHighThreshold</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Threshold above which DAQ pixels are considered bad</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelLowThreshold</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Threashold below which DAQ pixelse are considered bad</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_badPixelWarningLevel</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of bad pixels above which a warning is generated</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_checkForBadPixels</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to check the DAQ data for bad (possibly corrupt) pixels</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqFolder</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The folder in the DAQ partition to monitor for new science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqPartition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The DAQ partition to use for science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_daqThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The number of thread to allow to simulateously pull data from the 2-day store</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_locations</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>The locations to monitor for new science data</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_useStreaming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether to stream the DAQ science data to FITS files as it arrives</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20577,7 +20661,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3192345231L -->
+    <!--CCS: Dictionary_Checksum: 2375022998L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20587,50 +20671,99 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSAutoSave</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether FITS files should always be saved</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSDirectoryPattern</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pattern used to generate folders below FITSRootDirectory</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSFilePattern</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pattern used to generte FITS file names</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_FITSRootDirectory</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Root directory where FITS files are written</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>imagehandlingconfig_raiseAlertOnMissingOrBadHeaderServiceData</EFDB_Name>
+      <Description>Whether to raise an alert if the fits header data does not arrive</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>imagehandlingconfig_subsystemsToClearOnNewRun</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_tempFileRelativeLocation</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Relative loction of temporary files (if written)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_useTempFile</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Whether FITS files should first be written with a temporary name and then renamed on success</Description>
       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_waitForHeaderService</EFDB_Name>
+      <Description>Whether to wait for header service data before finalizing FITS files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration using level 1 for category Guider-->
+  <!--=====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1304924133L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderFITSFilePattern</EFDB_Name>
+      <Description>FITS file pattern to use for writting guider FITS files</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderLocations</EFDB_Name>
+      <Description>Locations to monitor for guider data</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_guiderPartition</EFDB_Name>
+      <Description>DAQ partition to monitor for guider data</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -20640,7 +20773,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 245874300L -->
+    <!--CCS: Dictionary_Checksum: 1213664806L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20650,14 +20783,14 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20668,7 +20801,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1124810080L -->
+    <!--CCS: Dictionary_Checksum: 1357975535L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20678,85 +20811,26 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_Reb_FitsHandlingConfiguration using level 1 for category FitsHandling-->
-  <!--========================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_image_handling_Reb_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4209526032L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <!--CCSMETA: Array enabled indexed by location-->
-    <item>
-      <EFDB_Name>enabled</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>8</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>reb location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_Reb_GeneralConfiguration using level 1 for category General-->
-  <!--==============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_image_handling_Reb_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2247502848L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <!--CCSMETA: Array fitsservice_headerFilesList indexed by location-->
-    <item>
-      <EFDB_Name>fitsservice_headerFilesList</EFDB_Name>
-      <Description>MISSING (colon delimited array)</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>reb location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
+  </SALEvent>  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -20831,6 +20831,27 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--===========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3292024849L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>patternConfigList</EFDB_Name>
+      <Description>List of patterns that describe which data is to be aggregated and how.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
   <!--====================================================================================================================================-->
   <SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -20830,7 +20830,8 @@
       <Units>ms</Units>
       <Count>1</Count>
     </item>
-  </SALEvent>  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>


### PR DESCRIPTION
During testing of the last XML release Rob noticed some inconsistencies between the list of configurations expected, and what was actually published. This was due to updates to image-handling configuration to handle guiding which was not reflected in the XML release. This pull request updates the image-handling XML for ATCamera/CCCamera/MTCamera to address this, and also fixes many missing descriptions.