### PR TITLE
Use the string to replace the unsigned long and unsigned long long.

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -100,6 +100,10 @@ v20.0.0
     * Add DAQ monitoring statistics (CAP-703)
     * Fix for image_handling configuration (CAP-1006)
 
+  * MTM2
+
+    * Use the ``string`` data type to replace the ``unsigned long`` and ``unsigned long long`` data types.
+
 v19.0.0
 -------
 * Remove the unrecognized pytest flags in **pyproject.toml**.

--- a/python/lsst/ts/xml/data/sal_interfaces/MTM2/MTM2_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTM2/MTM2_Events.xml
@@ -182,8 +182,8 @@
     <Description>Processed digital input as a 32-bit value. The power-breaker related values will be adjusted based on the comparision between the measured voltage and nominal voltage to see the reading input is real or not. See the enum.py in ts_m2com for the details.</Description>
     <item>
       <EFDB_Name>value</EFDB_Name>
-      <Description>Digital input.</Description>
-      <IDL_Type>unsigned long</IDL_Type>
+      <Description>Digital input in hexadecimal format.</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -390,8 +390,8 @@
     <Description>Summary faults status of the controller as a 64-bit value.</Description>
     <item>
       <EFDB_Name>status</EFDB_Name>
-      <Description>Summary faults status. Each bit means different error/warning. See the error_code.tsv in ts_config_mttcs/MTM2 for the details.</Description>
-      <IDL_Type>unsigned long long</IDL_Type>
+      <Description>Summary faults status in hexadecimal format. Each bit means different error/warning. See the error_code.tsv in ts_config_mttcs/MTM2 for the details.</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -402,8 +402,8 @@
     <Description>Enabled faults mask of the controller as a 64-bit value.</Description>
     <item>
       <EFDB_Name>mask</EFDB_Name>
-      <Description>Enabled faults mask. Each bit means different error/warning. See the error_code.tsv in ts_config_mttcs/MTM2 for the details.</Description>
-      <IDL_Type>unsigned long long</IDL_Type>
+      <Description>Enabled faults mask in hexadecimal format. Each bit means different error/warning. See the error_code.tsv in ts_config_mttcs/MTM2 for the details.</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>

--- a/python/lsst/ts/xml/field_info.py
+++ b/python/lsst/ts/xml/field_info.py
@@ -55,7 +55,7 @@ AVRO_TYPES = {
     "long": "long",
     "long long": "long",
     "unsigned short": "int",
-    "unsigned int": "int",
+    "unsigned int": "long",
     "unsigned long": "long",
     "unsigned long long": "long",
     "float": "float",


### PR DESCRIPTION
Remove `unsigned long` and `unsigned long long` in MTM2.