### PR TITLE
DM-41590: Fix type SAL-long type to AVRO-int

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -4,12 +4,31 @@
 Version History
 ===============
 
-v20.1.0
+v21.0.0
 -------
 
 * Added GPLv3 license file.
+
 * Added .gitattributes and .gitarchive to support getting version information from setuptools_scm for a git tarball.
+
 * Updated the contents of the README.
+
+* In ``get_component_info.py``:
+
+  * Copy the component xml files alongside the avro schema files and also generate the generics xml file.
+  * Write a file with the list of revcodes.
+  * Update path to where avro schema is written to add the component name to the path.
+
+* In ``tests/test_component_info.py``, small patch to support running the tests now that float/double can also be "null".
+
+* In ``field_info.py``:
+
+  * Add support for floating point values to be set as ``None``.
+  * Fix SAL to AVRO type conversion for SAL-long type.
+    According to AVRO documentation SAL-long is actually AVRO-int.
+
+* Fix style violation in ``enums/LEDProjector.py``.
+
 * Interface updates:
 
   * MTRotator

--- a/python/lsst/ts/xml/enums/LEDProjector.py
+++ b/python/lsst/ts/xml/enums/LEDProjector.py
@@ -33,10 +33,12 @@ class LEDBasicState(enum.IntEnum):
     * UNKNOWN: no connection to the labjack controller.
     * OFF: LED is off.
     * ON: LED is on.
-    * ERROR: Any kind of error happening with either switching the LEDs or Labjack communication.
+    * ERROR: Any kind of error happening with either switching the LEDs or
+        Labjack communication.
     * LABJACK_CONNECTED: Connection established with Labjack.
     * LABJACK_DISCONNECTED: Connection terminated with Labjack.
     """
+
     UNKNOWN = 0
     OFF = 1
     ON = 2

--- a/python/lsst/ts/xml/field_info.py
+++ b/python/lsst/ts/xml/field_info.py
@@ -45,12 +45,16 @@ PYTHON_TYPES = {
 }
 
 # Dict of SAL type: Avro type
+# SAL-long (this is 4 byte integer) -> AVRO-int: 32-bit signed integer
+# SAL-long long (8 byte integer) -> AVRO-long: 64-bit signed integer
+# AVRO has no unsigned types so all unsigned values are converted to the
+# signed equivalent.
 AVRO_TYPES = {
     "boolean": "boolean",
     "byte": "int",
     "short": "int",
     "int": "int",
-    "long": "long",
+    "long": "int",
     "long long": "long",
     "unsigned short": "int",
     "unsigned int": "long",

--- a/python/lsst/ts/xml/field_info.py
+++ b/python/lsst/ts/xml/field_info.py
@@ -58,8 +58,8 @@ AVRO_TYPES = {
     "long long": "long",
     "unsigned short": "int",
     "unsigned int": "long",
-    "float": "float",
-    "double": "double",
+    "float": ["float", "null"],
+    "double": ["double", "null"],
     "string": "string",
 }
 

--- a/python/lsst/ts/xml/get_component_info.py
+++ b/python/lsst/ts/xml/get_component_info.py
@@ -112,8 +112,12 @@ def generate_component_info(name: str, output_dir: pathlib.PosixPath) -> None:
         "global_enums": [info.as_tuple() for info in global_enums],
     }
 
+    component_output_dir = output_dir / name
+    if not component_output_dir.exists():
+        component_output_dir.mkdir(parents=True)
+
     for topic in result["topics"]:
-        schema_path = output_dir / f"{name}_{topic}.json"
+        schema_path = component_output_dir / f"{name}_{topic}.json"
         print(f"Writing {schema_path} ...")
         with open(schema_path, "w") as fp:
             assert isinstance(result["topics"], dict)
@@ -130,7 +134,7 @@ def generate_component_info(name: str, output_dir: pathlib.PosixPath) -> None:
             field_enums_dict[topic_name] = field_enum_value
 
     if field_enums_dict:
-        field_enums_path = output_dir / f"{name}_field_enums.json"
+        field_enums_path = component_output_dir / f"{name}_field_enums.json"
         print(f"Writing {field_enums_path} ...")
         with open(field_enums_path, "w") as fp:
             fp.write(json.dumps(field_enums_dict, indent=4))
@@ -139,7 +143,7 @@ def generate_component_info(name: str, output_dir: pathlib.PosixPath) -> None:
 
     global_enums_dict: dict[str, str] = dict(result["global_enums"])  # type: ignore
     if global_enums_dict:
-        global_enums_path = output_dir / f"{name}_global_enums.json"
+        global_enums_path = component_output_dir / f"{name}_global_enums.json"
 
         print(f"Writing {global_enums_path} ...")
         with open(global_enums_path, "w") as fp:

--- a/python/lsst/ts/xml/get_component_info.py
+++ b/python/lsst/ts/xml/get_component_info.py
@@ -110,6 +110,10 @@ def generate_component_info(name: str, output_dir: pathlib.PosixPath) -> None:
         },
         "field_enums": [info.as_tuple() for info in field_enums],
         "global_enums": [info.as_tuple() for info in global_enums],
+        "hash_table": {
+            topic_info.sal_name: topic_info.get_revcode()
+            for topic_info in component_info.topics.values()
+        },
     }
 
     component_output_dir = output_dir / name
@@ -150,3 +154,10 @@ def generate_component_info(name: str, output_dir: pathlib.PosixPath) -> None:
             fp.write(json.dumps(global_enums_dict, indent=4))
     else:
         print(f"No global enumerations for {name}.")
+
+    # Generate the hash table (table with the rev_code for all topics).
+    hash_table_path = component_output_dir / f"{name}_hash_table.json"
+    print(f"Writing {hash_table_path} ...")
+
+    with open(hash_table_path, "w") as fp:
+        fp.write(json.dumps(result["hash_table"], indent=4))

--- a/tests/test_component_info.py
+++ b/tests/test_component_info.py
@@ -243,7 +243,7 @@ class ComponentInfoTestCase(unittest.TestCase):
                 expected_item_default = dict(
                     string="",
                     boolean=False,
-                ).get(expected_avro_item_type, 0)
+                ).get(field_info.sal_type, 0)
                 if isarray and field_name.endswith("0"):
                     expected_type = dict(type="array", items=expected_avro_item_type)
                     expected_default: typing.Any = [expected_item_default] * 5


### PR DESCRIPTION
Changes involves:

- Fix type mapping SAL-long -> AVRO-int
- Add support for floating point values to be set as ``None``.
- Write a file with the list of revcodes.
- Copy the component xml files alongside the avro schema files and also generate the generics xml file.
