### PR TITLE
Update to new camera XML. New NONSTANDARD_UNITS added.

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -52,6 +52,12 @@ v21.0.0
     * Reuse the enum **BumpTest** in MTM1M3.
     * Add the topics: ``MTM2_logevent_actuatorBumpTestStatus``, ``MTM2_command_killActuatorBumpTest``, and ``MTM2_command_setHardpointList``.
 
+  * ATCamera/CCCamera/MTCamera
+    * Full refresh of camera Events/Telemetry XML based on currently installed CCS subsystems
+    * XML now based derived from https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml
+    * Current release: https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml/releases/tag/org-lsst-ccs-camera-sal-xml-parent-1.0.1
+    * Reviewing changes for individual CCS subsystem is possible by comparing to previous XML release., e.g. https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml/compare/refactor_XML_20...org-lsst-ccs-camera-sal-xml-parent-1.0.1#diff
+
 v20.0.0
 -------
 

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -4378,28 +4378,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -4420,58 +4420,58 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>publishstats_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task publishStats</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purgedaq_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task purgeDAQ</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -4693,28 +4693,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -4735,28 +4735,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Analog voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -4777,28 +4777,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -4819,28 +4819,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Aux voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -4861,28 +4861,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -4903,28 +4903,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock high voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -4945,28 +4945,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -4987,28 +4987,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clock low voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -5029,28 +5029,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -5071,28 +5071,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>DPHI voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -5113,28 +5113,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -5155,28 +5155,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Digital voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -5197,28 +5197,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -5239,28 +5239,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Fan voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -5281,28 +5281,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -5323,28 +5323,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>HV bias voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -5869,28 +5869,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -5911,28 +5911,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OD voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -5953,28 +5953,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -5995,28 +5995,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -6037,28 +6037,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6079,51 +6079,51 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_state_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task power-state</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -6184,28 +6184,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6226,51 +6226,51 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>basic_state_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task basic-state</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -6331,28 +6331,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Setpoint temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Setpoint temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Setpoint temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Setpoint temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -6373,28 +6373,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CCD temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CCD temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CCD temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CCD temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -6415,28 +6415,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold plate temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold plate temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold plate temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold plate temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -6457,28 +6457,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo head temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo head temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo head temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo head temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -6499,28 +6499,28 @@
     </item>
     <item>
       <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo vacuum high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo vacuum low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo vacuum high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo vacuum low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
@@ -6583,56 +6583,56 @@
     </item>
     <item>
       <EFDB_Name>bonn_V36_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V36_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V36_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V36_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -6688,28 +6688,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6730,44 +6730,44 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -7021,7 +7021,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4265689238L -->
+    <!--CCS: Dictionary_Checksum: 3453225660L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7047,6 +7047,13 @@
       <EFDB_Name>imagehandlingconfig_guiderPartition</EFDB_Name>
       <Description>DAQ partition to monitor for guider data</Description>
       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_includeRawStamps</EFDB_Name>
+      <Description>Whether to write raw stamps to FITS file</Description>
+      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Telemetry.xml
@@ -1266,7 +1266,7 @@
     <!--CCS: Dictionary_Checksum: 1759124350L -->
     <item>
       <EFDB_Name>bonn_V36</EFDB_Name>
-      <Description>BonnShutter 5-volt reading</Description>
+      <Description>BonnShutter 36-volt reading</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -1195,48 +1195,6 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_LimitsConfiguration using level 1 for category Limits-->
-  <!--===========================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_fcs_LinearEncoder_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1091399202L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>linearposition_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mm</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>linearposition_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mm</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>linearposition_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mm</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>linearposition_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mm</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
   <!--=============================================================================================================================================-->
   <SALEvent>
@@ -1252,28 +1210,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -1294,44 +1252,44 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -1382,7 +1340,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2287609295L -->
+    <!--CCS: Dictionary_Checksum: 587810611L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1391,57 +1349,15 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>motorencoder_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>motorencoder_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>motorencoder_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>motorencoder_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>motortemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>motortemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>motor temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>motortemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>motortemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>motor temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -1616,56 +1532,56 @@
     </item>
     <item>
       <EFDB_Name>bonn_V36_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V36_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V36_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V36_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 36-volt reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bonn_V5_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>BonnShutter 5-volt reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -1721,28 +1637,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -1763,44 +1679,44 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -1819,28 +1735,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -1861,58 +1777,58 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>publishstats_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task publishStats</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purgedaq_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task purgeDAQ</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -2180,7 +2096,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2548607147L -->
+    <!--CCS: Dictionary_Checksum: 508712045L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2190,28 +2106,42 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_check_scheduler_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_check_scheduler_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -2222,7 +2152,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3064338596L -->
+    <!--CCS: Dictionary_Checksum: 4147396540L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2232,51 +2162,107 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>monitor_check_RebPS_P00_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/RebPS/P00</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P00_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P00</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P00_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P00</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_power_state_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task reb-power-state</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3592222472L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>Reb Total Power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnLo</EFDB_Name>
+      <Description>Reb Total Power low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>Reb Total Power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitLo</EFDB_Name>
+      <Description>Reb Total Power low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -2299,7 +2285,7 @@
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <item>
       <EFDB_Name>location</EFDB_Name>
@@ -2314,7 +2300,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2734755624L -->
+    <!--CCS: Dictionary_Checksum: 1541745519L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2325,898 +2311,866 @@
     <!--CCSMETA: Array analog_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO2_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO2_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO2_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO2_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array hvbias_IbefSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_IbefSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_IbefSwch_warnLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_IbefSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array hvbias_IbefSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_IbefSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_IbefSwch_limitLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_IbefSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array hvbias_VbefSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_VbefSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_VbefSwch_warnLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_VbefSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array hvbias_VbefSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_VbefSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_VbefSwch_limitLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_VbefSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <item>
       <EFDB_Name>location</EFDB_Name>
@@ -3228,226 +3182,226 @@
     <!--CCSMETA: Array od_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO2_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO2_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO2_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO2_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array power_warnHi indexed by location-->
     <item>
       <EFDB_Name>power_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array power_warnLo indexed by location-->
     <item>
       <EFDB_Name>power_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array power_limitHi indexed by location-->
     <item>
       <EFDB_Name>power_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array power_limitLo indexed by location-->
     <item>
       <EFDB_Name>power_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_DevicesConfiguration using level 1 for category Devices-->
@@ -3526,7 +3480,7 @@
     <!--CCSMETA: Array boardtemp0_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3535,7 +3489,7 @@
     <!--CCSMETA: Array boardtemp0_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3544,7 +3498,7 @@
     <!--CCSMETA: Array boardtemp0_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3553,7 +3507,7 @@
     <!--CCSMETA: Array boardtemp0_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3562,7 +3516,7 @@
     <!--CCSMETA: Array boardtemp1_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3571,7 +3525,7 @@
     <!--CCSMETA: Array boardtemp1_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3580,7 +3534,7 @@
     <!--CCSMETA: Array boardtemp1_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3589,7 +3543,7 @@
     <!--CCSMETA: Array boardtemp1_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3598,7 +3552,7 @@
     <!--CCSMETA: Array boardtemp2_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3607,7 +3561,7 @@
     <!--CCSMETA: Array boardtemp2_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3616,7 +3570,7 @@
     <!--CCSMETA: Array boardtemp2_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3625,7 +3579,7 @@
     <!--CCSMETA: Array boardtemp2_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3634,7 +3588,7 @@
     <!--CCSMETA: Array boardtemp3_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3643,7 +3597,7 @@
     <!--CCSMETA: Array boardtemp3_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3652,7 +3606,7 @@
     <!--CCSMETA: Array boardtemp3_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3661,7 +3615,7 @@
     <!--CCSMETA: Array boardtemp3_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3670,7 +3624,7 @@
     <!--CCSMETA: Array boardtemp4_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3679,7 +3633,7 @@
     <!--CCSMETA: Array boardtemp4_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3688,7 +3642,7 @@
     <!--CCSMETA: Array boardtemp4_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3697,7 +3651,7 @@
     <!--CCSMETA: Array boardtemp4_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3706,7 +3660,7 @@
     <!--CCSMETA: Array boardtemp5_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3715,7 +3669,7 @@
     <!--CCSMETA: Array boardtemp5_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3724,7 +3678,7 @@
     <!--CCSMETA: Array boardtemp5_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3733,7 +3687,7 @@
     <!--CCSMETA: Array boardtemp5_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3742,7 +3696,7 @@
     <!--CCSMETA: Array boardtemp6_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3751,7 +3705,7 @@
     <!--CCSMETA: Array boardtemp6_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3760,7 +3714,7 @@
     <!--CCSMETA: Array boardtemp6_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3769,7 +3723,7 @@
     <!--CCSMETA: Array boardtemp6_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3778,7 +3732,7 @@
     <!--CCSMETA: Array fpgatemp_warnHi indexed by location-->
     <item>
       <EFDB_Name>fpgatemp_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FPGA temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3787,7 +3741,7 @@
     <!--CCSMETA: Array fpgatemp_warnLo indexed by location-->
     <item>
       <EFDB_Name>fpgatemp_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FPGA temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3796,7 +3750,7 @@
     <!--CCSMETA: Array fpgatemp_limitHi indexed by location-->
     <item>
       <EFDB_Name>fpgatemp_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FPGA temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3805,7 +3759,7 @@
     <!--CCSMETA: Array fpgatemp_limitLo indexed by location-->
     <item>
       <EFDB_Name>fpgatemp_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FPGA temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3959,196 +3913,196 @@
     </item>
     <item>
       <EFDB_Name>autooffenabled_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4169,28 +4123,28 @@
     </item>
     <item>
       <EFDB_Name>temperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4267,196 +4221,196 @@
     </item>
     <item>
       <EFDB_Name>autooffenabled_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4477,28 +4431,28 @@
     </item>
     <item>
       <EFDB_Name>temperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4575,196 +4529,196 @@
     </item>
     <item>
       <EFDB_Name>autooffenabled_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autooffenabled_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff state (1 = auto off) low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoofftemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff temperature setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>autoontemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler auto shutoff cancellation temperature setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rejecttemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler reject temperature reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpower_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler power setting low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>setpoint_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler setpoint temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4785,28 +4739,28 @@
     </item>
     <item>
       <EFDB_Name>temperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cooler temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4890,56 +4844,56 @@
     </item>
     <item>
       <EFDB_Name>current_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>current_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>current_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>current_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>voltage_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>voltage_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>voltage_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>voltage_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo ion pump voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -4960,28 +4914,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5002,51 +4956,51 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>vacuum_state_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task vacuum-state</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -5072,7 +5026,7 @@
     </item>
     <item>
       <EFDB_Name>serials</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>serial numbers of MAQ20 modules</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5114,84 +5068,84 @@
     </item>
     <item>
       <EFDB_Name>temperaturecold1_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate B Temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold1_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate B Temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold1_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate B Temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold1_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate B Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate A Temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate A Temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate A Temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecold2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cold Plate A Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecryo_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo Plate Temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecryo_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo Plate Temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecryo_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo Plate Temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>temperaturecryo_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo Plate Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -5293,7 +5247,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2269819399L -->
+    <!--CCS: Dictionary_Checksum: 1219716956L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5303,254 +5257,128 @@
     </item>
     <item>
       <EFDB_Name>cntrlrairtemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller air temp. high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrairtemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller air temp. low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrairtemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller air temp. high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrairtemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller air temp. low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrsinktemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller sink temp. high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrsinktemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller sink temp. low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrsinktemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller sink temp. high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cntrlrsinktemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump controller sink temp. low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>current_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>drivefrequency_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>drivefrequency_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>drivefrequency_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>drivefrequency_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>power_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Watt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump power high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>power_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Watt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump power high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pumptemperature_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump pump temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pumptemperature_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump pump temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pumptemperature_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump pump temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pumptemperature_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump pump temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>rpm_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>rpm_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>rpm_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>rpm_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>status_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump status: 5=normal, 6=fail high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>status_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump status: 5=normal, 6=fail low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>status_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump status: 5=normal, 6=fail high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>status_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>TurboPump status: 5=normal, 6=fail low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -5625,28 +5453,28 @@
     </item>
     <item>
       <EFDB_Name>vqmpressure_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pressure Reading high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>vqmpressure_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pressure Reading low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>vqmpressure_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pressure Reading high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>vqmpressure_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Pressure Reading low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
@@ -5793,224 +5621,224 @@
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heater_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Heater current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heater_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Heater current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heater_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Heater current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heater_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Heater current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sensor_PWS_17_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>SENSOR_PWS_17 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sensor_PWS_17_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>SENSOR_PWS_17 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sensor_PWS_17_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>SENSOR_PWS_17 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sensor_PWS_17_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>SENSOR_PWS_17 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -6073,812 +5901,812 @@
     </item>
     <item>
       <EFDB_Name>board_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>body_Purge_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>bpu_Maq20_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Body purge MAQ20 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU FPGA temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU FPGA temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU FPGA temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU FPGA temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_Shu_HCU_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES/shutter HCU voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j11_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J11 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j12_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J12 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j6_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J6 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j7_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J7 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j8_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J8 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>j9_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>J9 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Clean PDU main voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>pwr_Cry_HCU_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Power/cryo HCU voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -6941,196 +6769,196 @@
     </item>
     <item>
       <EFDB_Name>board_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fes_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>FES voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU FPGA temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU FPGA temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU FPGA temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU FPGA temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>24V Dirty PDU main voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -7193,364 +7021,364 @@
     </item>
     <item>
       <EFDB_Name>board_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>board_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel0_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel0 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel1_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel1 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryotel2_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>CryoTel2 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU FPGA temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU FPGA temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU FPGA temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fpga_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU FPGA temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>48V PDU main voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_BULK_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB_BULK voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -7603,7 +7431,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2731550322L -->
+    <!--CCS: Dictionary_Checksum: 3923793477L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -7612,113 +7440,57 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>otm_3_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>otm_3_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -7760,28 +7532,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -7802,86 +7574,44 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration using level 1 for category Devices-->
-  <!--===============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3702309194L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>disabled</EFDB_Name>
-      <Description>If true, Device is diabled</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration using level 1 for category Quadbox-->
-  <!--===============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3641335563L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>node</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -12218,7 +11948,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 966374854L -->
+    <!--CCS: Dictionary_Checksum: 1728381398L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12244,6 +11974,13 @@
       <EFDB_Name>imagehandlingconfig_guiderPartition</EFDB_Name>
       <Description>DAQ partition to monitor for guider data</Description>
       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_includeRawStamps</EFDB_Name>
+      <Description>Whether to write raw stamps to FITS file</Description>
+      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -12347,28 +12084,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -12389,51 +12126,51 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_state_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task Protection-state</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -36,7 +36,7 @@
     <!--CCS: Dictionary_Checksum: 470595085L -->
     <item>
       <EFDB_Name>bonn_V36</EFDB_Name>
-      <Description>BonnShutter 5-volt reading</Description>
+      <Description>BonnShutter 36-volt reading</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -672,7 +672,7 @@
       <Description>Current after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_IbefLDO indexed by location-->
     <item>
@@ -680,7 +680,7 @@
       <Description>Current before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftLDO indexed by location-->
     <item>
@@ -688,7 +688,7 @@
       <Description>Voltage after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VaftSwch indexed by location-->
     <item>
@@ -696,7 +696,7 @@
       <Description>Voltage after switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array analog_VbefLDO indexed by location-->
     <item>
@@ -704,7 +704,7 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IaftLDO indexed by location-->
     <item>
@@ -712,7 +712,7 @@
       <Description>Current after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_IbefLDO indexed by location-->
     <item>
@@ -720,7 +720,7 @@
       <Description>Current before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftLDO indexed by location-->
     <item>
@@ -728,7 +728,7 @@
       <Description>Voltage after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VaftSwch indexed by location-->
     <item>
@@ -736,7 +736,7 @@
       <Description>Voltage after switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clockhi_VbefLDO indexed by location-->
     <item>
@@ -744,7 +744,7 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IaftLDO indexed by location-->
     <item>
@@ -752,7 +752,7 @@
       <Description>Current after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_IbefLDO indexed by location-->
     <item>
@@ -760,7 +760,7 @@
       <Description>Current before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO indexed by location-->
     <item>
@@ -768,7 +768,7 @@
       <Description>Voltage after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftLDO2 indexed by location-->
     <item>
@@ -776,7 +776,7 @@
       <Description>Voltage after LDO2</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VaftSwch indexed by location-->
     <item>
@@ -784,7 +784,7 @@
       <Description>Voltage after switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array clocklo_VbefLDO indexed by location-->
     <item>
@@ -792,7 +792,7 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IaftLDO indexed by location-->
     <item>
@@ -800,7 +800,7 @@
       <Description>Current after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_IbefLDO indexed by location-->
     <item>
@@ -808,7 +808,7 @@
       <Description>Current before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftLDO indexed by location-->
     <item>
@@ -816,7 +816,7 @@
       <Description>Voltage after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VaftSwch indexed by location-->
     <item>
@@ -824,7 +824,7 @@
       <Description>Voltage after switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array digital_VbefLDO indexed by location-->
     <item>
@@ -832,7 +832,7 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IaftLDO indexed by location-->
     <item>
@@ -840,7 +840,7 @@
       <Description>Current after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_IbefLDO indexed by location-->
     <item>
@@ -848,7 +848,7 @@
       <Description>Current before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftLDO indexed by location-->
     <item>
@@ -856,7 +856,7 @@
       <Description>Voltage after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VaftSwch indexed by location-->
     <item>
@@ -864,7 +864,7 @@
       <Description>Voltage after switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array heater_VbefLDO indexed by location-->
     <item>
@@ -872,7 +872,7 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array hvbias_IbefSwch indexed by location-->
     <item>
@@ -880,7 +880,7 @@
       <Description>Current before switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array hvbias_VbefSwch indexed by location-->
     <item>
@@ -888,7 +888,7 @@
       <Description>Voltage before switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <item>
       <EFDB_Name>location</EFDB_Name>
@@ -903,7 +903,7 @@
       <Description>Current after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_IbefLDO indexed by location-->
     <item>
@@ -911,7 +911,7 @@
       <Description>Current before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO indexed by location-->
     <item>
@@ -919,7 +919,7 @@
       <Description>Voltage after LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftLDO2 indexed by location-->
     <item>
@@ -927,7 +927,7 @@
       <Description>Voltage after LDO2</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VaftSwch indexed by location-->
     <item>
@@ -935,7 +935,7 @@
       <Description>Voltage after switch</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array od_VbefLDO indexed by location-->
     <item>
@@ -943,7 +943,7 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
     </item>
     <!--CCSMETA: Array power indexed by location-->
     <item>
@@ -951,7 +951,21 @@
       <Description>Total power</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
-      <Count>3</Count>
+      <Count>6</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_rebpower_RebTotalPower using level 1-->
+  <!--===============================================================================================-->
+  <SALTelemetry>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_rebpower_RebTotalPower</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 765746799L -->
+    <item>
+      <EFDB_Name>rebTotalPower</EFDB_Name>
+      <Description>Reb Total Power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
     </item>
   </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_rebpower_Rebps using level 1-->
@@ -1794,21 +1808,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_5V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2825509309L -->
-    <item>
-      <EFDB_Name>otm_3_A_I</EFDB_Name>
-      <Description>OTM 3-A current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>otm_3_A_V</EFDB_Name>
-      <Description>OTM 3-A voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
+    <!--CCS: Dictionary_Checksum: 577849488L -->
     <item>
       <EFDB_Name>otm_3_B_I</EFDB_Name>
       <Description>OTM 3-B current</Description>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -1071,12 +1071,33 @@
     </item>
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_DevicesConfiguration using level 1 for category Devices-->
+  <!--=======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_BFR_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1577558727L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_LimitsConfiguration using level 1 for category Limits-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_BFR_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3064950597L -->
+    <!--CCS: Dictionary_Checksum: 1940619542L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1086,308 +1107,280 @@
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clean_5_24V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Clean 5 and 24V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_24V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 24V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_28V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 28V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dirty_48V_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>heater_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>heater_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>heater_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>heater_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Dirty 48V current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>protection_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Protection system current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_2_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_2_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_2_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_0_2_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 0-2 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_3_5_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 3-5 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_3_5_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 3-5 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_3_5_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 3-5 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_3_5_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 3-5 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_6_8_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 6-8 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_6_8_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 6-8 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_6_8_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 6-8 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_6_8_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 6-8 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_9_12_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 9-12 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_9_12_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 9-12 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_9_12_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 9-12 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_9_12_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS 9-12 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_Spr_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS spare current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_Spr_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS spare current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_Spr_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS spare current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebps_Spr_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB PS spare current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -1414,12 +1407,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DeviceConfiguration using level 1 for category Device-->
+  <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1265394131L -->
+    <EFDB_Topic>MTCamera_logevent_quadbox_Maq20_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1931378380L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1428,477 +1421,771 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_Board_T_warnHi</EFDB_Name>
+      <EFDB_Name>node</EFDB_Name>
       <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_Maq20_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 664197741L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration using level 1 for category Devices-->
+  <!--============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3965252035L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration using level 1 for category Limits-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 81620535L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>board_T_warnHi</EFDB_Name>
+      <Description>24V Clean PDU board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_Board_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_warnLo</EFDB_Name>
+      <Description>24V Clean PDU board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_Board_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_limitHi</EFDB_Name>
+      <Description>24V Clean PDU board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_Board_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_limitLo</EFDB_Name>
+      <Description>24V Clean PDU board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_FPGA_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>body_Maq20_I_warnHi</EFDB_Name>
+      <Description>Body MAQ20 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_I_warnLo</EFDB_Name>
+      <Description>Body MAQ20 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_I_limitHi</EFDB_Name>
+      <Description>Body MAQ20 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_I_limitLo</EFDB_Name>
+      <Description>Body MAQ20 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_V_warnHi</EFDB_Name>
+      <Description>Body MAQ20 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_V_warnLo</EFDB_Name>
+      <Description>Body MAQ20 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_V_limitHi</EFDB_Name>
+      <Description>Body MAQ20 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_V_limitLo</EFDB_Name>
+      <Description>Body MAQ20 voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_I_warnHi</EFDB_Name>
+      <Description>Cryostat MAQ20 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_I_warnLo</EFDB_Name>
+      <Description>Cryostat MAQ20 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_I_limitHi</EFDB_Name>
+      <Description>Cryostat MAQ20 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_I_limitLo</EFDB_Name>
+      <Description>Cryostat MAQ20 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_V_warnHi</EFDB_Name>
+      <Description>Cryostat MAQ20 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_V_warnLo</EFDB_Name>
+      <Description>Cryostat MAQ20 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_V_limitHi</EFDB_Name>
+      <Description>Cryostat MAQ20 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_V_limitLo</EFDB_Name>
+      <Description>Cryostat MAQ20 voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_I_warnHi</EFDB_Name>
+      <Description>FES carouselC current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_I_warnLo</EFDB_Name>
+      <Description>FES carouselC current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_I_limitHi</EFDB_Name>
+      <Description>FES carouselC current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_I_limitLo</EFDB_Name>
+      <Description>FES carouselC current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_V_warnHi</EFDB_Name>
+      <Description>FES carouselC voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_V_warnLo</EFDB_Name>
+      <Description>FES carouselC voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_V_limitHi</EFDB_Name>
+      <Description>FES carouselC voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_V_limitLo</EFDB_Name>
+      <Description>FES carouselC voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_I_warnHi</EFDB_Name>
+      <Description>FES changerC current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_I_warnLo</EFDB_Name>
+      <Description>FES changerC current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_I_limitHi</EFDB_Name>
+      <Description>FES changerC current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_I_limitLo</EFDB_Name>
+      <Description>FES changerC current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_V_warnHi</EFDB_Name>
+      <Description>FES changerC voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_V_warnLo</EFDB_Name>
+      <Description>FES changerC voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_V_limitHi</EFDB_Name>
+      <Description>FES changerC voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_V_limitLo</EFDB_Name>
+      <Description>FES changerC voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_I_warnHi</EFDB_Name>
+      <Description>FES loaderC current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_I_warnLo</EFDB_Name>
+      <Description>FES loaderC current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_I_limitHi</EFDB_Name>
+      <Description>FES loaderC current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_I_limitLo</EFDB_Name>
+      <Description>FES loaderC current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_V_warnHi</EFDB_Name>
+      <Description>FES loaderC voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_V_warnLo</EFDB_Name>
+      <Description>FES loaderC voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_V_limitHi</EFDB_Name>
+      <Description>FES loaderC voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_V_limitLo</EFDB_Name>
+      <Description>FES loaderC voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_warnHi</EFDB_Name>
+      <Description>24V Clean PDU FPGA temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_FPGA_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fpga_T_warnLo</EFDB_Name>
+      <Description>24V Clean PDU FPGA temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_FPGA_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fpga_T_limitHi</EFDB_Name>
+      <Description>24V Clean PDU FPGA temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_FPGA_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fpga_T_limitLo</EFDB_Name>
+      <Description>24V Clean PDU FPGA temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>gauges_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Gauges voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_I_warnHi</EFDB_Name>
+      <Description>Interstitial valves current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_I_warnLo</EFDB_Name>
+      <Description>Interstitial valves current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_I_limitHi</EFDB_Name>
+      <Description>Interstitial valves current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_I_limitLo</EFDB_Name>
+      <Description>Interstitial valves current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_V_warnHi</EFDB_Name>
+      <Description>Interstitial valves voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_V_warnLo</EFDB_Name>
+      <Description>Interstitial valves voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_V_limitHi</EFDB_Name>
+      <Description>Interstitial valves voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_V_limitLo</EFDB_Name>
+      <Description>Interstitial valves voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ion_Pumps_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Ion pumps voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_I_warnHi</EFDB_Name>
+      <Description>24V Clean PDU main current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_I_warnLo</EFDB_Name>
+      <Description>24V Clean PDU main current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_I_limitHi</EFDB_Name>
+      <Description>24V Clean PDU main current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_I_limitLo</EFDB_Name>
+      <Description>24V Clean PDU main current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_T_warnHi</EFDB_Name>
+      <Description>24V Clean PDU main temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_warnLo</EFDB_Name>
+      <Description>24V Clean PDU main temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_limitHi</EFDB_Name>
+      <Description>24V Clean PDU main temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_limitLo</EFDB_Name>
+      <Description>24V Clean PDU main temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_warnHi</EFDB_Name>
+      <Description>24V Clean PDU main voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_V_warnLo</EFDB_Name>
+      <Description>24V Clean PDU main voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_V_limitHi</EFDB_Name>
+      <Description>24V Clean PDU main voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>main_V_limitLo</EFDB_Name>
+      <Description>24V Clean PDU main voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_I_warnHi</EFDB_Name>
+      <Description>Shutter PLC 1 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_I_warnLo</EFDB_Name>
+      <Description>Shutter PLC 1 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_I_limitHi</EFDB_Name>
+      <Description>Shutter PLC 1 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_I_limitLo</EFDB_Name>
+      <Description>Shutter PLC 1 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_V_warnHi</EFDB_Name>
+      <Description>Shutter PLC 1 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_V_warnLo</EFDB_Name>
+      <Description>Shutter PLC 1 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_V_limitHi</EFDB_Name>
+      <Description>Shutter PLC 1 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_V_limitLo</EFDB_Name>
+      <Description>Shutter PLC 1 voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_I_warnHi</EFDB_Name>
+      <Description>Shutter PLC 2 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_I_warnLo</EFDB_Name>
+      <Description>Shutter PLC 2 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_I_limitHi</EFDB_Name>
+      <Description>Shutter PLC 2 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_I_limitLo</EFDB_Name>
+      <Description>Shutter PLC 2 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_V_warnHi</EFDB_Name>
+      <Description>Shutter PLC 2 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_V_warnLo</EFDB_Name>
+      <Description>Shutter PLC 2 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_V_limitHi</EFDB_Name>
+      <Description>Shutter PLC 2 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_V_limitLo</EFDB_Name>
+      <Description>Shutter PLC 2 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -1925,12 +2212,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration using level 1 for category Devices-->
+  <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2110500092L -->
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 430770279L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -1939,253 +2226,554 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vd_Board_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration using level 1 for category Limits-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1522668218L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>board_T_warnHi</EFDB_Name>
+      <Description>24V Dirty PDU board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vd_Board_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_warnLo</EFDB_Name>
+      <Description>24V Dirty PDU board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vd_Board_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_limitHi</EFDB_Name>
+      <Description>24V Dirty PDU board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vd_Board_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_limitLo</EFDB_Name>
+      <Description>24V Dirty PDU board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_FPGA_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_FPGA_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_FPGA_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_FPGA_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>cryo_Turbo_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Cryo turbo pump voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>fes_Brakes_I_warnHi</EFDB_Name>
+      <Description>FES brakes current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_I_warnLo</EFDB_Name>
+      <Description>FES brakes current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_I_limitHi</EFDB_Name>
+      <Description>FES brakes current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_I_limitLo</EFDB_Name>
+      <Description>FES brakes current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_V_warnHi</EFDB_Name>
+      <Description>FES brakes voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_V_warnLo</EFDB_Name>
+      <Description>FES brakes voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_V_limitHi</EFDB_Name>
+      <Description>FES brakes voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_V_limitLo</EFDB_Name>
+      <Description>FES brakes voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_I_warnHi</EFDB_Name>
+      <Description>FES changerD current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_I_warnLo</EFDB_Name>
+      <Description>FES changerD current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_I_limitHi</EFDB_Name>
+      <Description>FES changerD current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_I_limitLo</EFDB_Name>
+      <Description>FES changerD current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_V_warnHi</EFDB_Name>
+      <Description>FES changerD voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_V_warnLo</EFDB_Name>
+      <Description>FES changerD voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_V_limitHi</EFDB_Name>
+      <Description>FES changerD voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_V_limitLo</EFDB_Name>
+      <Description>FES changerD voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_I_warnHi</EFDB_Name>
+      <Description>FES clamps current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_I_warnLo</EFDB_Name>
+      <Description>FES clamps current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_I_limitHi</EFDB_Name>
+      <Description>FES clamps current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_I_limitLo</EFDB_Name>
+      <Description>FES clamps current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_V_warnHi</EFDB_Name>
+      <Description>FES clamps voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_V_warnLo</EFDB_Name>
+      <Description>FES clamps voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_V_limitHi</EFDB_Name>
+      <Description>FES clamps voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_V_limitLo</EFDB_Name>
+      <Description>FES clamps voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_I_warnHi</EFDB_Name>
+      <Description>FES loaderD current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_I_warnLo</EFDB_Name>
+      <Description>FES loaderD current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_I_limitHi</EFDB_Name>
+      <Description>FES loaderD current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_I_limitLo</EFDB_Name>
+      <Description>FES loaderD current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_V_warnHi</EFDB_Name>
+      <Description>FES loaderD voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_V_warnLo</EFDB_Name>
+      <Description>FES loaderD voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_V_limitHi</EFDB_Name>
+      <Description>FES loaderD voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_V_limitLo</EFDB_Name>
+      <Description>FES loaderD voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_warnHi</EFDB_Name>
+      <Description>24V Dirty PDU FPGA temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_warnLo</EFDB_Name>
+      <Description>24V Dirty PDU FPGA temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_limitHi</EFDB_Name>
+      <Description>24V Dirty PDU FPGA temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_limitLo</EFDB_Name>
+      <Description>24V Dirty PDU FPGA temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>hex_Turbo_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hex_Turbo_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Hex turbo pump voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_warnHi</EFDB_Name>
+      <Description>24V Dirty PDU main current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_warnLo</EFDB_Name>
+      <Description>24V Dirty PDU main current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_limitHi</EFDB_Name>
+      <Description>24V Dirty PDU main current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_limitLo</EFDB_Name>
+      <Description>24V Dirty PDU main current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_warnHi</EFDB_Name>
+      <Description>24V Dirty PDU main temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_warnLo</EFDB_Name>
+      <Description>24V Dirty PDU main temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_limitHi</EFDB_Name>
+      <Description>24V Dirty PDU main temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_limitLo</EFDB_Name>
+      <Description>24V Dirty PDU main temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_warnHi</EFDB_Name>
+      <Description>24V Dirty PDU main voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_warnLo</EFDB_Name>
+      <Description>24V Dirty PDU main voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_limitHi</EFDB_Name>
+      <Description>24V Dirty PDU main voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_limitLo</EFDB_Name>
+      <Description>24V Dirty PDU main voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_I_warnHi</EFDB_Name>
+      <Description>Shutter brakes current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_I_warnLo</EFDB_Name>
+      <Description>Shutter brakes current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_I_limitHi</EFDB_Name>
+      <Description>Shutter brakes current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_I_limitLo</EFDB_Name>
+      <Description>Shutter brakes current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_V_warnHi</EFDB_Name>
+      <Description>Shutter brakes voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_V_warnLo</EFDB_Name>
+      <Description>Shutter brakes voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_V_limitHi</EFDB_Name>
+      <Description>Shutter brakes voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_V_limitLo</EFDB_Name>
+      <Description>Shutter brakes voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -2212,12 +2800,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration using level 1 for category Limits-->
-  <!--=========================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_DevicesConfiguration using level 1 for category Devices-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2029192248L -->
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2817100035L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2226,197 +2814,442 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Board_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration using level 1 for category Limits-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3927940510L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>board_T_warnHi</EFDB_Name>
+      <Description>48V PDU board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Board_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_warnLo</EFDB_Name>
+      <Description>48V PDU board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Board_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_limitHi</EFDB_Name>
+      <Description>48V PDU board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Board_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>board_T_limitLo</EFDB_Name>
+      <Description>48V PDU board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_FPGA_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_FPGA_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_FPGA_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_FPGA_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_Main_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_I_warnHi</EFDB_Name>
+      <Description>FES carouselD current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_I_warnLo</EFDB_Name>
+      <Description>FES carouselD current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_I_limitHi</EFDB_Name>
+      <Description>FES carouselD current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_I_limitLo</EFDB_Name>
+      <Description>FES carouselD current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_Main_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_Main_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_Main_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_48v_Main_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_V_warnHi</EFDB_Name>
+      <Description>FES carouselD voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_V_warnLo</EFDB_Name>
+      <Description>FES carouselD voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_V_limitHi</EFDB_Name>
+      <Description>FES carouselD voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>fes_CarouselD_V_limitLo</EFDB_Name>
+      <Description>FES carouselD voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_I_warnHi</EFDB_Name>
+      <Description>FES heater current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_I_warnLo</EFDB_Name>
+      <Description>FES heater current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_I_limitHi</EFDB_Name>
+      <Description>FES heater current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_I_limitLo</EFDB_Name>
+      <Description>FES heater current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_V_warnHi</EFDB_Name>
+      <Description>FES heater voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_V_warnLo</EFDB_Name>
+      <Description>FES heater voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_V_limitHi</EFDB_Name>
+      <Description>FES heater voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_V_limitLo</EFDB_Name>
+      <Description>FES heater voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_warnHi</EFDB_Name>
+      <Description>48V PDU FPGA temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_warnLo</EFDB_Name>
+      <Description>48V PDU FPGA temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_limitHi</EFDB_Name>
+      <Description>48V PDU FPGA temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T_limitLo</EFDB_Name>
+      <Description>48V PDU FPGA temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_warnHi</EFDB_Name>
+      <Description>48V PDU main current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_warnLo</EFDB_Name>
+      <Description>48V PDU main current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_limitHi</EFDB_Name>
+      <Description>48V PDU main current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_I_limitLo</EFDB_Name>
+      <Description>48V PDU main current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_warnHi</EFDB_Name>
+      <Description>48V PDU main temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_warnLo</EFDB_Name>
+      <Description>48V PDU main temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_limitHi</EFDB_Name>
+      <Description>48V PDU main temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T_limitLo</EFDB_Name>
+      <Description>48V PDU main temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_warnHi</EFDB_Name>
+      <Description>48V PDU main voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_warnLo</EFDB_Name>
+      <Description>48V PDU main voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_limitHi</EFDB_Name>
+      <Description>48V PDU main voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V_limitLo</EFDB_Name>
+      <Description>48V PDU main voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>purge_Fan_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Purge fan voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_I_warnHi</EFDB_Name>
+      <Description>Shutter motor 1 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_I_warnLo</EFDB_Name>
+      <Description>Shutter motor 1 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_I_limitHi</EFDB_Name>
+      <Description>Shutter motor 1 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_I_limitLo</EFDB_Name>
+      <Description>Shutter motor 1 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_V_warnHi</EFDB_Name>
+      <Description>Shutter motor 1 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_V_warnLo</EFDB_Name>
+      <Description>Shutter motor 1 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_V_limitHi</EFDB_Name>
+      <Description>Shutter motor 1 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_V_limitLo</EFDB_Name>
+      <Description>Shutter motor 1 voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_I_warnHi</EFDB_Name>
+      <Description>Shutter motor 2 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_I_warnLo</EFDB_Name>
+      <Description>Shutter motor 2 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_I_limitHi</EFDB_Name>
+      <Description>Shutter motor 2 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_I_limitLo</EFDB_Name>
+      <Description>Shutter motor 2 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_V_warnHi</EFDB_Name>
+      <Description>Shutter motor 2 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_V_warnLo</EFDB_Name>
+      <Description>Shutter motor 2 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_V_limitHi</EFDB_Name>
+      <Description>Shutter motor 2 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_V_limitLo</EFDB_Name>
+      <Description>Shutter motor 2 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -2443,12 +3276,33 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_DevicesConfiguration using level 1 for category Devices-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2701746051L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration using level 1 for category Limits-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 119701711L -->
+    <!--CCS: Dictionary_Checksum: 843643995L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -2458,672 +3312,672 @@
     </item>
     <item>
       <EFDB_Name>otm_0_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-A voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_0_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 0-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-A voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_1_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 1-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-A voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_2_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 2-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-A voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_3_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 3-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-A voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_4_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 4-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_A_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-A voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>otm_5_B_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>OTM 5-B voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -3150,12 +4004,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasksConfiguration using level 1-->
-  <!--====================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasksConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2216843222L -->
+    <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1137115398L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3172,6 +4026,20 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_check_scheduler_nTasks</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_check_scheduler_nThreads</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
@@ -3197,7 +4065,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2594221307L -->
+    <!--CCS: Dictionary_Checksum: 520958182L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3207,44 +4075,184 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>monitor_check_BFR_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/BFR</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>monitor_check_Maq20_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/Maq20</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>monitor_check_PDU_24VC_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/PDU_24VC</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_PDU_24VD_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/PDU_24VD</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_PDU_48V_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/PDU_48V</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_PDU_5V_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/PDU_5V</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_REB_Bulk_PS_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/REB_Bulk_PS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_BFR_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/BFR</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_PDU_24VC_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/PDU_24VC</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_PDU_24VD_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/PDU_24VD</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_PDU_48V_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/PDU_48V</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_PDU_5V_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/PDU_5V</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_REB_Bulk_PS_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/REB_Bulk_PS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_BFR_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/BFR</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_PDU_24VC_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/PDU_24VC</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_PDU_24VD_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/PDU_24VD</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_PDU_48V_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/PDU_48V</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_PDU_5V_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/PDU_5V</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_REB_Bulk_PS_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/REB_Bulk_PS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>quadbox_state_taskPeriodMillis</EFDB_Name>
+      <Description>period for task quadbox-state</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 413846485L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -3253,7 +4261,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1843493753L -->
+    <!--CCS: Dictionary_Checksum: 1214246971L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3263,364 +4271,364 @@
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_0_2_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 0-2 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_3_5_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 3-5 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_6_8_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 6-8 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_I_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 current high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_I_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 current low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_I_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 current high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_I_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 current low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_V_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 voltage high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_V_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 voltage low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_V_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 voltage high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_9_12_V_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS 9-12 voltage low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_Brd_T_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS board temperature high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_Brd_T_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS board temperature low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_Brd_T_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS board temperature high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>rebbulkps_Brd_T_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>REB Bulk PS board temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -3647,33 +4655,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpowerConfiguration using level 1-->
-  <!--=======================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration using level 1 for category General-->
+  <!--=============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_rebpowerConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2712771743L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>powerOffSleepMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_EmergencyResponseManagerConfiguration using level 1-->
-  <!--================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_rebpower_EmergencyResponseManagerConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1256937700L -->
+    <EFDB_Topic>MTCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 370200845L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3689,12 +4676,47 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasksConfiguration using level 1-->
-  <!--=====================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_GeneralConfiguration using level 1 for category General-->
+  <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasksConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3091209472L -->
+    <EFDB_Topic>MTCamera_logevent_rebpower_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 961719118L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>powerOffSleepMillis</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>psDeviceExcepNumToOffline</EFDB_Name>
+      <Description>Number of consecutive read failures (exceptions) before gonig Offline. Must be a positive number greater than zero.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>psDeviceReadTimeout</EFDB_Name>
+      <Description>Read Timeout for the underlying PS driver</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--==================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3578539392L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3750,7 +4772,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4275217324L -->
+    <!--CCS: Dictionary_Checksum: 3766908808L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3760,312 +4782,368 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P00_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P00</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P01_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P01</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P02_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P02</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P03_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P03</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P04_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P04</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P05_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P05</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P06_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P06</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P07_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P07</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P08_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P08</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P09_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P09</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P10_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P10</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P11_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P11</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_RebPS_P12_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check/RebPS/P12</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P00_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P00</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P01_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P01</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P02_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P02</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P03_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P03</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P04_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P04</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P05_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P05</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P06_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P06</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P07_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P07</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P08_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P08</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P09_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P09</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P10_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P10</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P11_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P11</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_RebPS_P12_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish/RebPS/P12</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P00_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P00</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P01_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P01</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P02_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P02</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P03_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P03</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P04_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P04</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P05_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P05</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P06_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P06</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P07_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P07</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P08_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P08</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P09_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P09</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P10_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P10</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P11_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P11</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_RebPS_P12_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update/RebPS/P12</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>reb_power_state_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task reb-power-state</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_RebConfiguration using level 1-->
-  <!--===========================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_rebpower_RebConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2466710988L -->
+    <EFDB_Topic>MTCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 33485532L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>Reb Total Power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnLo</EFDB_Name>
+      <Description>Reb Total Power low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>Reb Total Power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitLo</EFDB_Name>
+      <Description>Reb Total Power low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_GeneralConfiguration using level 1 for category General-->
+  <!--========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_Reb_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2277039115L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4102,7 +5180,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 450027541L -->
+    <!--CCS: Dictionary_Checksum: 2456616912L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4113,7 +5191,7 @@
     <!--CCSMETA: Array analog_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4121,7 +5199,7 @@
     <!--CCSMETA: Array analog_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4129,7 +5207,7 @@
     <!--CCSMETA: Array analog_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4137,7 +5215,7 @@
     <!--CCSMETA: Array analog_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4145,7 +5223,7 @@
     <!--CCSMETA: Array analog_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4153,7 +5231,7 @@
     <!--CCSMETA: Array analog_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4161,7 +5239,7 @@
     <!--CCSMETA: Array analog_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4169,7 +5247,7 @@
     <!--CCSMETA: Array analog_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4177,7 +5255,7 @@
     <!--CCSMETA: Array analog_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4185,7 +5263,7 @@
     <!--CCSMETA: Array analog_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4193,7 +5271,7 @@
     <!--CCSMETA: Array analog_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4201,7 +5279,7 @@
     <!--CCSMETA: Array analog_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4209,7 +5287,7 @@
     <!--CCSMETA: Array analog_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4217,7 +5295,7 @@
     <!--CCSMETA: Array analog_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4225,7 +5303,7 @@
     <!--CCSMETA: Array analog_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4233,7 +5311,7 @@
     <!--CCSMETA: Array analog_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4241,7 +5319,7 @@
     <!--CCSMETA: Array analog_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4249,7 +5327,7 @@
     <!--CCSMETA: Array analog_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4257,7 +5335,7 @@
     <!--CCSMETA: Array analog_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4265,7 +5343,7 @@
     <!--CCSMETA: Array analog_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>analog_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4273,7 +5351,7 @@
     <!--CCSMETA: Array clockhi_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4281,7 +5359,7 @@
     <!--CCSMETA: Array clockhi_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4289,7 +5367,7 @@
     <!--CCSMETA: Array clockhi_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4297,7 +5375,7 @@
     <!--CCSMETA: Array clockhi_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4305,7 +5383,7 @@
     <!--CCSMETA: Array clockhi_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4313,7 +5391,7 @@
     <!--CCSMETA: Array clockhi_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4321,7 +5399,7 @@
     <!--CCSMETA: Array clockhi_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4329,7 +5407,7 @@
     <!--CCSMETA: Array clockhi_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4337,7 +5415,7 @@
     <!--CCSMETA: Array clockhi_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4345,7 +5423,7 @@
     <!--CCSMETA: Array clockhi_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4353,7 +5431,7 @@
     <!--CCSMETA: Array clockhi_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4361,7 +5439,7 @@
     <!--CCSMETA: Array clockhi_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4369,7 +5447,7 @@
     <!--CCSMETA: Array clockhi_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4377,7 +5455,7 @@
     <!--CCSMETA: Array clockhi_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4385,7 +5463,7 @@
     <!--CCSMETA: Array clockhi_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4393,7 +5471,7 @@
     <!--CCSMETA: Array clockhi_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4401,7 +5479,7 @@
     <!--CCSMETA: Array clockhi_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4409,7 +5487,7 @@
     <!--CCSMETA: Array clockhi_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4417,7 +5495,7 @@
     <!--CCSMETA: Array clockhi_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4425,7 +5503,7 @@
     <!--CCSMETA: Array clockhi_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clockhi_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4433,7 +5511,7 @@
     <!--CCSMETA: Array clocklo_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4441,7 +5519,7 @@
     <!--CCSMETA: Array clocklo_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4449,7 +5527,7 @@
     <!--CCSMETA: Array clocklo_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4457,7 +5535,7 @@
     <!--CCSMETA: Array clocklo_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4465,7 +5543,7 @@
     <!--CCSMETA: Array clocklo_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4473,7 +5551,7 @@
     <!--CCSMETA: Array clocklo_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4481,7 +5559,7 @@
     <!--CCSMETA: Array clocklo_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4489,7 +5567,7 @@
     <!--CCSMETA: Array clocklo_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4497,7 +5575,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO2_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4505,7 +5583,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO2_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4513,7 +5591,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO2_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4521,7 +5599,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO2_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4529,7 +5607,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4537,7 +5615,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4545,7 +5623,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4553,7 +5631,7 @@
     <!--CCSMETA: Array clocklo_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4561,7 +5639,7 @@
     <!--CCSMETA: Array clocklo_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4569,7 +5647,7 @@
     <!--CCSMETA: Array clocklo_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4577,7 +5655,7 @@
     <!--CCSMETA: Array clocklo_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4585,7 +5663,7 @@
     <!--CCSMETA: Array clocklo_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4593,7 +5671,7 @@
     <!--CCSMETA: Array clocklo_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4601,7 +5679,7 @@
     <!--CCSMETA: Array clocklo_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4609,7 +5687,7 @@
     <!--CCSMETA: Array clocklo_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4617,7 +5695,7 @@
     <!--CCSMETA: Array clocklo_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>clocklo_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4625,7 +5703,7 @@
     <!--CCSMETA: Array digital_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4633,7 +5711,7 @@
     <!--CCSMETA: Array digital_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4641,7 +5719,7 @@
     <!--CCSMETA: Array digital_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4649,7 +5727,7 @@
     <!--CCSMETA: Array digital_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4657,7 +5735,7 @@
     <!--CCSMETA: Array digital_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4665,7 +5743,7 @@
     <!--CCSMETA: Array digital_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4673,7 +5751,7 @@
     <!--CCSMETA: Array digital_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4681,7 +5759,7 @@
     <!--CCSMETA: Array digital_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4689,7 +5767,7 @@
     <!--CCSMETA: Array digital_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4697,7 +5775,7 @@
     <!--CCSMETA: Array digital_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4705,7 +5783,7 @@
     <!--CCSMETA: Array digital_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4713,7 +5791,7 @@
     <!--CCSMETA: Array digital_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4721,7 +5799,7 @@
     <!--CCSMETA: Array digital_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4729,7 +5807,7 @@
     <!--CCSMETA: Array digital_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4737,7 +5815,7 @@
     <!--CCSMETA: Array digital_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4745,7 +5823,7 @@
     <!--CCSMETA: Array digital_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4753,7 +5831,7 @@
     <!--CCSMETA: Array digital_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4761,7 +5839,7 @@
     <!--CCSMETA: Array digital_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4769,7 +5847,7 @@
     <!--CCSMETA: Array digital_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4777,7 +5855,7 @@
     <!--CCSMETA: Array digital_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>digital_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4785,7 +5863,7 @@
     <!--CCSMETA: Array dphi_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>dphi_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4793,7 +5871,7 @@
     <!--CCSMETA: Array dphi_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>dphi_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4801,7 +5879,7 @@
     <!--CCSMETA: Array dphi_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>dphi_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4809,7 +5887,7 @@
     <!--CCSMETA: Array dphi_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>dphi_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4817,7 +5895,7 @@
     <!--CCSMETA: Array dphi_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>dphi_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4825,7 +5903,7 @@
     <!--CCSMETA: Array dphi_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>dphi_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4833,7 +5911,7 @@
     <!--CCSMETA: Array dphi_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>dphi_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4841,7 +5919,7 @@
     <!--CCSMETA: Array dphi_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>dphi_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4849,7 +5927,7 @@
     <!--CCSMETA: Array dphi_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4857,7 +5935,7 @@
     <!--CCSMETA: Array dphi_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4865,7 +5943,7 @@
     <!--CCSMETA: Array dphi_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4873,7 +5951,7 @@
     <!--CCSMETA: Array dphi_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4881,7 +5959,7 @@
     <!--CCSMETA: Array dphi_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4889,7 +5967,7 @@
     <!--CCSMETA: Array dphi_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4897,7 +5975,7 @@
     <!--CCSMETA: Array dphi_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4905,7 +5983,7 @@
     <!--CCSMETA: Array dphi_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>dphi_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4913,7 +5991,7 @@
     <!--CCSMETA: Array dphi_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>dphi_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4921,7 +5999,7 @@
     <!--CCSMETA: Array dphi_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>dphi_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4929,7 +6007,7 @@
     <!--CCSMETA: Array dphi_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>dphi_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4937,7 +6015,7 @@
     <!--CCSMETA: Array dphi_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>dphi_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -4945,7 +6023,7 @@
     <!--CCSMETA: Array heater_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4953,7 +6031,7 @@
     <!--CCSMETA: Array heater_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4961,7 +6039,7 @@
     <!--CCSMETA: Array heater_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4969,7 +6047,7 @@
     <!--CCSMETA: Array heater_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4977,7 +6055,7 @@
     <!--CCSMETA: Array heater_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4985,7 +6063,7 @@
     <!--CCSMETA: Array heater_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -4993,7 +6071,7 @@
     <!--CCSMETA: Array heater_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5001,7 +6079,7 @@
     <!--CCSMETA: Array heater_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5009,7 +6087,7 @@
     <!--CCSMETA: Array heater_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5017,7 +6095,7 @@
     <!--CCSMETA: Array heater_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5025,7 +6103,7 @@
     <!--CCSMETA: Array heater_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5033,7 +6111,7 @@
     <!--CCSMETA: Array heater_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5041,7 +6119,7 @@
     <!--CCSMETA: Array heater_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5049,7 +6127,7 @@
     <!--CCSMETA: Array heater_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5057,7 +6135,7 @@
     <!--CCSMETA: Array heater_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5065,7 +6143,7 @@
     <!--CCSMETA: Array heater_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5073,7 +6151,7 @@
     <!--CCSMETA: Array heater_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5081,7 +6159,7 @@
     <!--CCSMETA: Array heater_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5089,7 +6167,7 @@
     <!--CCSMETA: Array heater_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5097,7 +6175,7 @@
     <!--CCSMETA: Array heater_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>heater_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5105,15 +6183,7 @@
     <!--CCSMETA: Array hvbias_IbefSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_IbefSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>71</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_IbefSwch_warnLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_IbefSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5121,15 +6191,7 @@
     <!--CCSMETA: Array hvbias_IbefSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_IbefSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>71</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_IbefSwch_limitLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_IbefSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5137,15 +6199,7 @@
     <!--CCSMETA: Array hvbias_VbefSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_VbefSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>71</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_VbefSwch_warnLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_VbefSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5153,15 +6207,7 @@
     <!--CCSMETA: Array hvbias_VbefSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>hvbias_VbefSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>71</Count>
-    </item>
-    <!--CCSMETA: Array hvbias_VbefSwch_limitLo indexed by location-->
-    <item>
-      <EFDB_Name>hvbias_VbefSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5176,7 +6222,7 @@
     <!--CCSMETA: Array od_IaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5184,7 +6230,7 @@
     <!--CCSMETA: Array od_IaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5192,7 +6238,7 @@
     <!--CCSMETA: Array od_IaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5200,7 +6246,7 @@
     <!--CCSMETA: Array od_IaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_IaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5208,7 +6254,7 @@
     <!--CCSMETA: Array od_IbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5216,7 +6262,7 @@
     <!--CCSMETA: Array od_IbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5224,7 +6270,7 @@
     <!--CCSMETA: Array od_IbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5232,7 +6278,7 @@
     <!--CCSMETA: Array od_IbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_IbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Current before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>71</Count>
@@ -5240,7 +6286,7 @@
     <!--CCSMETA: Array od_VaftLDO2_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5248,7 +6294,7 @@
     <!--CCSMETA: Array od_VaftLDO2_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5256,7 +6302,7 @@
     <!--CCSMETA: Array od_VaftLDO2_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5264,7 +6310,7 @@
     <!--CCSMETA: Array od_VaftLDO2_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO2 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5272,7 +6318,7 @@
     <!--CCSMETA: Array od_VaftLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5280,7 +6326,7 @@
     <!--CCSMETA: Array od_VaftLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5288,7 +6334,7 @@
     <!--CCSMETA: Array od_VaftLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5296,7 +6342,7 @@
     <!--CCSMETA: Array od_VaftLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5304,7 +6350,7 @@
     <!--CCSMETA: Array od_VaftSwch_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5312,7 +6358,7 @@
     <!--CCSMETA: Array od_VaftSwch_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5320,7 +6366,7 @@
     <!--CCSMETA: Array od_VaftSwch_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5328,7 +6374,7 @@
     <!--CCSMETA: Array od_VaftSwch_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VaftSwch_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage after switch low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5336,7 +6382,7 @@
     <!--CCSMETA: Array od_VbefLDO_warnHi indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5344,7 +6390,7 @@
     <!--CCSMETA: Array od_VbefLDO_warnLo indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5352,7 +6398,7 @@
     <!--CCSMETA: Array od_VbefLDO_limitHi indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5360,7 +6406,7 @@
     <!--CCSMETA: Array od_VbefLDO_limitLo indexed by location-->
     <item>
       <EFDB_Name>od_VbefLDO_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Voltage before LDO low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>71</Count>
@@ -5368,7 +6414,7 @@
     <!--CCSMETA: Array power_warnHi indexed by location-->
     <item>
       <EFDB_Name>power_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>71</Count>
@@ -5376,7 +6422,7 @@
     <!--CCSMETA: Array power_warnLo indexed by location-->
     <item>
       <EFDB_Name>power_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>71</Count>
@@ -5384,7 +6430,7 @@
     <!--CCSMETA: Array power_limitHi indexed by location-->
     <item>
       <EFDB_Name>power_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>71</Count>
@@ -5392,10 +6438,68 @@
     <!--CCSMETA: Array power_limitLo indexed by location-->
     <item>
       <EFDB_Name>power_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Total power low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Watt</Units>
       <Count>71</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_DevicesConfiguration using level 1 for category Devices-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 208746333L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array disabled indexed by location-->
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>13</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>rebps location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_GeneralConfiguration using level 1 for category General-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1171629463L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>rebps location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array rebs indexed by location-->
+    <item>
+      <EFDB_Name>rebs</EFDB_Name>
+      <Description>List of Rebs powered by this PS (colon delimited array)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_LimitsConfiguration using level 1 for category Limits-->
@@ -5403,7 +6507,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2726424202L -->
+    <!--CCS: Dictionary_Checksum: 2677932763L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5414,7 +6518,7 @@
     <!--CCSMETA: Array boardtemp0_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5422,7 +6526,7 @@
     <!--CCSMETA: Array boardtemp0_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5430,7 +6534,7 @@
     <!--CCSMETA: Array boardtemp0_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5438,7 +6542,7 @@
     <!--CCSMETA: Array boardtemp0_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp0_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 0 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5446,7 +6550,7 @@
     <!--CCSMETA: Array boardtemp1_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5454,7 +6558,7 @@
     <!--CCSMETA: Array boardtemp1_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5462,7 +6566,7 @@
     <!--CCSMETA: Array boardtemp1_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5470,7 +6574,7 @@
     <!--CCSMETA: Array boardtemp1_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp1_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 1 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5478,7 +6582,7 @@
     <!--CCSMETA: Array boardtemp2_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5486,7 +6590,7 @@
     <!--CCSMETA: Array boardtemp2_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5494,7 +6598,7 @@
     <!--CCSMETA: Array boardtemp2_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5502,7 +6606,7 @@
     <!--CCSMETA: Array boardtemp2_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp2_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 2 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5510,7 +6614,7 @@
     <!--CCSMETA: Array boardtemp3_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5518,7 +6622,7 @@
     <!--CCSMETA: Array boardtemp3_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5526,7 +6630,7 @@
     <!--CCSMETA: Array boardtemp3_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5534,7 +6638,7 @@
     <!--CCSMETA: Array boardtemp3_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp3_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 3 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5542,7 +6646,7 @@
     <!--CCSMETA: Array boardtemp4_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5550,7 +6654,7 @@
     <!--CCSMETA: Array boardtemp4_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5558,7 +6662,7 @@
     <!--CCSMETA: Array boardtemp4_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5566,7 +6670,7 @@
     <!--CCSMETA: Array boardtemp4_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp4_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 4 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5574,7 +6678,7 @@
     <!--CCSMETA: Array boardtemp5_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5582,7 +6686,7 @@
     <!--CCSMETA: Array boardtemp5_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5590,7 +6694,7 @@
     <!--CCSMETA: Array boardtemp5_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5598,7 +6702,7 @@
     <!--CCSMETA: Array boardtemp5_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp5_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 5 low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5606,7 +6710,7 @@
     <!--CCSMETA: Array boardtemp6_warnHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_warnHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 high warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5614,7 +6718,7 @@
     <!--CCSMETA: Array boardtemp6_warnLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_warnLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 low warning level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5622,7 +6726,7 @@
     <!--CCSMETA: Array boardtemp6_limitHi indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_limitHi</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5630,7 +6734,39 @@
     <!--CCSMETA: Array boardtemp6_limitLo indexed by location-->
     <item>
       <EFDB_Name>boardtemp6_limitLo</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Board temperature 6 low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>13</Count>
+    </item>
+    <!--CCSMETA: Array fpgatemp_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>fpgatemp_warnHi</EFDB_Name>
+      <Description>FPGA temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>13</Count>
+    </item>
+    <!--CCSMETA: Array fpgatemp_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>fpgatemp_warnLo</EFDB_Name>
+      <Description>FPGA temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>13</Count>
+    </item>
+    <!--CCSMETA: Array fpgatemp_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>fpgatemp_limitHi</EFDB_Name>
+      <Description>FPGA temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>13</Count>
+    </item>
+    <!--CCSMETA: Array fpgatemp_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>fpgatemp_limitLo</EFDB_Name>
+      <Description>FPGA temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -5678,6 +6814,35 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>13</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_buildConfiguration using level 1 for category build-->
+  <!--======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_buildConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3235921322L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>rebps location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array switchName indexed by location-->
+    <item>
+      <EFDB_Name>switchName</EFDB_Name>
+      <Description>MISSING (colon delimited array)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold1_LimitsConfiguration using level 1 for category Limits-->
@@ -7602,6 +8767,27 @@
       <Description>period for task temp-check</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_hex_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 898812745L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>patternConfigList</EFDB_Name>
+      <Description>List of patterns that describe which data is to be aggregated and how.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -11749,12 +12935,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_AgentMonitorServiceConfiguration using level 1-->
-  <!--=========================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Cip_LimitsConfiguration using level 1 for category Limits-->
+  <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_AgentMonitorServiceConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1975764444L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_Cip_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1474920077L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11762,776 +12948,276 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <!--CCSMETA: Array cryo_I_warnHi indexed by location-->
     <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
+      <EFDB_Name>cryo_I_warnHi</EFDB_Name>
+      <Description>Cryo ion pump 1 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
     </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP1CConfiguration using level 1-->
-  <!--===========================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP1CConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3517391561L -->
+    <!--CCSMETA: Array cryo_I_warnLo indexed by location-->
     <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <EFDB_Name>cryo_I_warnLo</EFDB_Name>
+      <Description>Cryo ion pump 1 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_I_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_I_limitHi</EFDB_Name>
+      <Description>Cryo ion pump 1 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_I_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_I_limitLo</EFDB_Name>
+      <Description>Cryo ion pump 1 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Life_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Life_warnHi</EFDB_Name>
+      <Description>Cryo ion pump 1 lifetime high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Life_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Life_warnLo</EFDB_Name>
+      <Description>Cryo ion pump 1 lifetime low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Life_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Life_limitHi</EFDB_Name>
+      <Description>Cryo ion pump 1 lifetime high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Life_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Life_limitLo</EFDB_Name>
+      <Description>Cryo ion pump 1 lifetime low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Usage_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Usage_warnHi</EFDB_Name>
+      <Description>Cryo ion pump 1 usage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Usage_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Usage_warnLo</EFDB_Name>
+      <Description>Cryo ion pump 1 usage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Usage_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Usage_limitHi</EFDB_Name>
+      <Description>Cryo ion pump 1 usage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Usage_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Usage_limitLo</EFDB_Name>
+      <Description>Cryo ion pump 1 usage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_V_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_V_warnHi</EFDB_Name>
+      <Description>Cryo ion pump 1 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_V_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_V_warnLo</EFDB_Name>
+      <Description>Cryo ion pump 1 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_V_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>cryo_V_limitHi</EFDB_Name>
+      <Description>Cryo ion pump 1 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_V_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>cryo_V_limitLo</EFDB_Name>
+      <Description>Cryo ion pump 1 voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_I_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_I_warnHi</EFDB_Name>
+      <Description>HX ion pump 1 current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_I_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_I_warnLo</EFDB_Name>
+      <Description>HX ion pump 1 current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_I_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_I_limitHi</EFDB_Name>
+      <Description>HX ion pump 1 current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_I_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_I_limitLo</EFDB_Name>
+      <Description>HX ion pump 1 current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Life_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_Life_warnHi</EFDB_Name>
+      <Description>HX ion pump 1 lifetime high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Life_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_Life_warnLo</EFDB_Name>
+      <Description>HX ion pump 1 lifetime low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Life_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_Life_limitHi</EFDB_Name>
+      <Description>HX ion pump 1 lifetime high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Life_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_Life_limitLo</EFDB_Name>
+      <Description>HX ion pump 1 lifetime low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Usage_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_Usage_warnHi</EFDB_Name>
+      <Description>HX ion pump 1 usage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Usage_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_Usage_warnLo</EFDB_Name>
+      <Description>HX ion pump 1 usage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Usage_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_Usage_limitHi</EFDB_Name>
+      <Description>HX ion pump 1 usage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Usage_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_Usage_limitLo</EFDB_Name>
+      <Description>HX ion pump 1 usage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_V_warnHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_V_warnHi</EFDB_Name>
+      <Description>HX ion pump 1 voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_V_warnLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_V_warnLo</EFDB_Name>
+      <Description>HX ion pump 1 voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_V_limitHi indexed by location-->
+    <item>
+      <EFDB_Name>hx_V_limitHi</EFDB_Name>
+      <Description>HX ion pump 1 voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_V_limitLo indexed by location-->
+    <item>
+      <EFDB_Name>hx_V_limitLo</EFDB_Name>
+      <Description>HX ion pump 1 voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>6</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>cip location</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP1_IConfiguration using level 1-->
-  <!--============================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP1_IConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3382180514L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP1_VConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP1_VConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3439028630L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP2CConfiguration using level 1-->
-  <!--===========================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP2CConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3080976377L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP2_IConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP2_IConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 369472580L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP2_VConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP2_VConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 325658480L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP3CConfiguration using level 1-->
-  <!--===========================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP3CConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2510308585L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP3_IConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP3_IConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3931861977L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP3_VConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP3_VConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4013416685L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP4CConfiguration using level 1-->
-  <!--===========================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP4CConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2074762649L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP4_IConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP4_IConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1917857737L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP4_VConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP4_VConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2000469245L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP5CConfiguration using level 1-->
-  <!--===========================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP5CConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1504308873L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP5_IConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP5_IConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2383341652L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP5_VConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP5_VConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2338487136L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP6CConfiguration using level 1-->
-  <!--===========================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP6CConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1068317625L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>power</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>voltage</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP6_IConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP6_IConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1369220786L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CIP6_VConfiguration using level 1-->
-  <!--============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CIP6_VConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1425028486L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacConfiguration using level 1-->
-  <!--=============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2040504869L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGaugeConfiguration using level 1-->
-  <!--==================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacGaugeConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3522155330L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoFlineGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1440439696L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12553,13 +13239,20 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_ForelineVacConfiguration using level 1-->
-  <!--=================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_ForelineVacConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2224017076L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3707390155L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12568,40 +13261,19 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_ForelineVacGaugeConfiguration using level 1-->
-  <!--======================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_ForelineVacGaugeConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1093686369L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 615585091L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12623,13 +13295,20 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HeartbeatConfiguration using level 1-->
-  <!--===============================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_HeartbeatConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2814612902L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3197591169L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12638,19 +13317,19 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex1VacConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_DevicesConfiguration using level 1 for category Devices-->
+  <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Hex1VacConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3952218636L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboPump_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3062615108L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12659,369 +13338,19 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex1VacGaugeConfiguration using level 1-->
-  <!--==================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Hex1VacGaugeConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3365582924L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>busAddr</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>devcId</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex2VacConfiguration using level 1-->
-  <!--=============================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_GeneralConfiguration using level 1 for category General-->
+  <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Hex2VacConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2720319247L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hex2VacGaugeConfiguration using level 1-->
-  <!--==================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Hex2VacGaugeConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1274243215L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>busAddr</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>devcId</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumpsConfiguration using level 1-->
-  <!--==============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_IonPumpsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 257903416L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ipAddr</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Monitor_checkConfiguration using level 1-->
-  <!--===================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Monitor_checkConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 146159701L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Monitor_publishConfiguration using level 1-->
-  <!--=====================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Monitor_publishConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3807876751L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Monitor_updateConfiguration using level 1-->
-  <!--====================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Monitor_updateConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2172642838L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_RuntimeInfoConfiguration using level 1-->
-  <!--=================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_RuntimeInfoConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3521620670L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_SchedulersConfiguration using level 1-->
-  <!--================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_SchedulersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 442894600L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboCurrentConfiguration using level 1-->
-  <!--==================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboCurrentConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1381291899L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboPowerConfiguration using level 1-->
-  <!--================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboPowerConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 456247826L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>W</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>W</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>W</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>W</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboPumpConfiguration using level 1-->
-  <!--===============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboPumpConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 954683946L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboPump_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3965114384L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13086,138 +13415,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboPumpTempConfiguration using level 1-->
-  <!--===================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboPumpTempConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1548588294L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>deg C</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>deg C</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>deg C</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>deg C</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboSpeedConfiguration using level 1-->
-  <!--================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboSpeedConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2024039986L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING (RPM)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING (RPM)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING (RPM)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING (RPM)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboVacConfiguration using level 1-->
-  <!--==============================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboVacConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3546757781L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboVacGaugeConfiguration using level 1-->
-  <!--===================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboVacGaugeConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1890580242L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 459238043L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13239,13 +13442,20 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_TurboVoltageConfiguration using level 1-->
-  <!--==================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_TurboVoltageConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3834301238L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1011642694L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13254,40 +13464,1979 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPlutoConfiguration using level 1-->
-  <!--==============================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Cryo_LimitsConfiguration using level 1 for category Limits-->
+  <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_VacPlutoConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2262206422L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_Cryo_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1720571420L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_warnHi</EFDB_Name>
+      <Description>UT compressed air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_warnLo</EFDB_Name>
+      <Description>UT compressed air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_limitHi</EFDB_Name>
+      <Description>UT compressed air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_limitLo</EFDB_Name>
+      <Description>UT compressed air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryovac_warnHi</EFDB_Name>
+      <Description>Cryostat vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryovac_warnLo</EFDB_Name>
+      <Description>Cryostat vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryovac_limitHi</EFDB_Name>
+      <Description>Cryostat vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryovac_limitLo</EFDB_Name>
+      <Description>Cryostat vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinepower_warnHi</EFDB_Name>
+      <Description>Cryo foreline pump power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinepower_limitHi</EFDB_Name>
+      <Description>Cryo foreline pump power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_warnHi</EFDB_Name>
+      <Description>Foreline pump vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_warnLo</EFDB_Name>
+      <Description>Foreline pump vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_limitHi</EFDB_Name>
+      <Description>Foreline pump vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_limitLo</EFDB_Name>
+      <Description>Foreline pump vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_warnHi</EFDB_Name>
+      <Description>Cryostat vacuum gauge pressure dose high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_warnLo</EFDB_Name>
+      <Description>Cryostat vacuum gauge pressure dose low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_limitHi</EFDB_Name>
+      <Description>Cryostat vacuum gauge pressure dose high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_limitLo</EFDB_Name>
+      <Description>Cryostat vacuum gauge pressure dose low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_warnHi</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_warnLo</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_limitHi</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_limitLo</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_warnHi</EFDB_Name>
+      <Description>Cryostat turbo vacuum gauge pressure dose high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_warnLo</EFDB_Name>
+      <Description>Cryostat turbo vacuum gauge pressure dose low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_limitHi</EFDB_Name>
+      <Description>Cryostat turbo vacuum gauge pressure dose high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_limitLo</EFDB_Name>
+      <Description>Cryostat turbo vacuum gauge pressure dose low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_warnHi</EFDB_Name>
+      <Description>Cryo turbo pump hours high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_warnLo</EFDB_Name>
+      <Description>Cryo turbo pump hours low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_limitHi</EFDB_Name>
+      <Description>Cryo turbo pump hours high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_limitLo</EFDB_Name>
+      <Description>Cryo turbo pump hours low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopower_warnHi</EFDB_Name>
+      <Description>Cryo turbo pump power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>W</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopower_limitHi</EFDB_Name>
+      <Description>Cryo turbo pump power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>W</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumpstatus_warnHi</EFDB_Name>
+      <Description>Cryo turbo pump status high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumpstatus_limitHi</EFDB_Name>
+      <Description>Cryo turbo pump status high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_warnHi</EFDB_Name>
+      <Description>Cryo turbo pump temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_warnLo</EFDB_Name>
+      <Description>Cryo turbo pump temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_limitHi</EFDB_Name>
+      <Description>Cryo turbo pump temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_limitLo</EFDB_Name>
+      <Description>Cryo turbo pump temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_warnHi</EFDB_Name>
+      <Description>Cryo turbo pump speed high warning level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_warnLo</EFDB_Name>
+      <Description>Cryo turbo pump speed low warning level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_limitHi</EFDB_Name>
+      <Description>Cryo turbo pump speed high alarm level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_limitLo</EFDB_Name>
+      <Description>Cryo turbo pump speed low alarm level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_warnHi</EFDB_Name>
+      <Description>Turbo pump vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_warnLo</EFDB_Name>
+      <Description>Turbo pump vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_limitHi</EFDB_Name>
+      <Description>Turbo pump vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_limitLo</EFDB_Name>
+      <Description>Turbo pump vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HX_LimitsConfiguration using level 1 for category Limits-->
+  <!--===================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HX_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 260760713L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_warnHi</EFDB_Name>
+      <Description>UT compressed air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_warnLo</EFDB_Name>
+      <Description>UT compressed air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_limitHi</EFDB_Name>
+      <Description>UT compressed air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airpressure_limitLo</EFDB_Name>
+      <Description>UT compressed air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinepower_warnHi</EFDB_Name>
+      <Description>HX foreline pump power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinepower_limitHi</EFDB_Name>
+      <Description>HX foreline pump power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_warnHi</EFDB_Name>
+      <Description>HX foreline pump vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_warnLo</EFDB_Name>
+      <Description>HX foreline pump vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_limitHi</EFDB_Name>
+      <Description>HX foreline pump vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelinevac_limitLo</EFDB_Name>
+      <Description>HX foreline pump vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_warnHi</EFDB_Name>
+      <Description>HX vacuum gauge pressure dose high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_warnLo</EFDB_Name>
+      <Description>HX vacuum gauge pressure dose low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_limitHi</EFDB_Name>
+      <Description>HX vacuum gauge pressure dose high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugedose_limitLo</EFDB_Name>
+      <Description>HX vacuum gauge pressure dose low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hexvac_warnHi</EFDB_Name>
+      <Description>Heat exchanger vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hexvac_warnLo</EFDB_Name>
+      <Description>Heat exchanger vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hexvac_limitHi</EFDB_Name>
+      <Description>Heat exchanger vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hexvac_limitLo</EFDB_Name>
+      <Description>Heat exchanger vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_warnHi</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_warnLo</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_limitHi</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_limitLo</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_warnHi</EFDB_Name>
+      <Description>HX turbo vacuum gauge pressure dose high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_warnLo</EFDB_Name>
+      <Description>HX turbo vacuum gauge pressure dose low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_limitHi</EFDB_Name>
+      <Description>HX turbo vacuum gauge pressure dose high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbogaugedose_limitLo</EFDB_Name>
+      <Description>HX turbo vacuum gauge pressure dose low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_warnHi</EFDB_Name>
+      <Description>HX turbo pump hours high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_warnLo</EFDB_Name>
+      <Description>HX turbo pump hours low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_limitHi</EFDB_Name>
+      <Description>HX turbo pump hours high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbohours_limitLo</EFDB_Name>
+      <Description>HX turbo pump hours low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopower_warnHi</EFDB_Name>
+      <Description>HX turbo pump power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>W</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopower_limitHi</EFDB_Name>
+      <Description>HX turbo pump power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>W</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumpstatus_warnHi</EFDB_Name>
+      <Description>HX turbo pump status high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumpstatus_limitHi</EFDB_Name>
+      <Description>HX turbo pump status high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_warnHi</EFDB_Name>
+      <Description>HX turbo pump temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_warnLo</EFDB_Name>
+      <Description>HX turbo pump temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_limitHi</EFDB_Name>
+      <Description>HX turbo pump temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbopumptemp_limitLo</EFDB_Name>
+      <Description>HX turbo pump temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_warnHi</EFDB_Name>
+      <Description>HX turbo pump speed high warning level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_warnLo</EFDB_Name>
+      <Description>HX turbo pump speed low warning level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_limitHi</EFDB_Name>
+      <Description>HX turbo pump speed high alarm level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbospeed_limitLo</EFDB_Name>
+      <Description>HX turbo pump speed low alarm level (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_warnHi</EFDB_Name>
+      <Description>HX turbo pump vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_warnLo</EFDB_Name>
+      <Description>HX turbo pump vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_limitHi</EFDB_Name>
+      <Description>HX turbo pump vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turbovac_limitLo</EFDB_Name>
+      <Description>HX turbo pump vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexFlineGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3017857976L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>busAddr</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>devcId</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4068509213L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3263861611L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>busAddr</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>devcId</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2431488087L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboPump_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3995455558L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_GeneralConfiguration using level 1 for category General-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboPump_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4115640989L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>activeStopMode</EFDB_Name>
+      <Description>Active-Stop mode &lt;true|false&gt;, settable only if pump is stopped</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>devcId</EFDB_Name>
+      <Description>serial port</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>interlockType</EFDB_Name>
+      <Description>true/false for continuous/impulse</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lowSpeedMode</EFDB_Name>
+      <Description>true/false for low/normal speed</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>model304</EFDB_Name>
+      <Description>true/false for model 304/84 pump</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>softStartMode</EFDB_Name>
+      <Description>Soft-Start mode &lt;true|false&gt;, settable only if pump is stopped</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ventValveByCmnd</EFDB_Name>
+      <Description>true/false for manual/auto</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>waterCooling</EFDB_Name>
+      <Description>true/false for water/air cooling</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexVacGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3246876108L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>busAddr</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>devcId</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--==============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3865510223L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_InstVacGauge_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 365426368L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>busAddr</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>devcId</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>relayTrip</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 562236644L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Inst_LimitsConfiguration using level 1 for category Limits-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_Inst_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4040863154L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoflinevalvestate_warnHi</EFDB_Name>
+      <Description>Cryo Foreline Valve Limit Switches State high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoflinevalvestate_warnLo</EFDB_Name>
+      <Description>Cryo Foreline Valve Limit Switches State low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoflinevalvestate_limitHi</EFDB_Name>
+      <Description>Cryo Foreline Valve Limit Switches State high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoflinevalvestate_limitLo</EFDB_Name>
+      <Description>Cryo Foreline Valve Limit Switches State low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinepower_warnHi</EFDB_Name>
+      <Description>Inst foreline pump power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinepower_limitHi</EFDB_Name>
+      <Description>Inst foreline pump power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxflinevalvestate_warnHi</EFDB_Name>
+      <Description>HX Foreline Valve Limit Switches State high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxflinevalvestate_warnLo</EFDB_Name>
+      <Description>HX Foreline Valve Limit Switches State low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxflinevalvestate_limitHi</EFDB_Name>
+      <Description>HX Foreline Valve Limit Switches State high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxflinevalvestate_limitLo</EFDB_Name>
+      <Description>HX Foreline Valve Limit Switches State low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>instvac_warnHi</EFDB_Name>
+      <Description>Interstitial vacuum high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>instvac_warnLo</EFDB_Name>
+      <Description>Interstitial vacuum low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>instvac_limitHi</EFDB_Name>
+      <Description>Interstitial vacuum high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>instvac_limitLo</EFDB_Name>
+      <Description>Interstitial vacuum low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartcycling_warnHi</EFDB_Name>
+      <Description>Pump Cart Cycling Status high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartcycling_warnLo</EFDB_Name>
+      <Description>Pump Cart Cycling Status low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartcycling_limitHi</EFDB_Name>
+      <Description>Pump Cart Cycling Status high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartcycling_limitLo</EFDB_Name>
+      <Description>Pump Cart Cycling Status low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_warnHi</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_warnLo</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_limitHi</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartpressure_limitLo</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcarttemperature_warnHi</EFDB_Name>
+      <Description>Pump Cart Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcarttemperature_warnLo</EFDB_Name>
+      <Description>Pump Cart Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcarttemperature_limitHi</EFDB_Name>
+      <Description>Pump Cart Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcarttemperature_limitLo</EFDB_Name>
+      <Description>Pump Cart Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartventing_warnHi</EFDB_Name>
+      <Description>Pump Cart Venting Status high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartventing_warnLo</EFDB_Name>
+      <Description>Pump Cart Venting Status low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartventing_limitHi</EFDB_Name>
+      <Description>Pump Cart Venting Status high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpcartventing_limitLo</EFDB_Name>
+      <Description>Pump Cart Venting Status low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_CryoConfiguration using level 1 for category Cryo-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_IonPumps_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3589610490L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip1c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip1c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip1c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip2c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip2c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip2c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip3c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip3c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip3c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip4c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip4c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip4c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip5c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip5c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip5c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip6c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip6c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cip6c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hip1c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hip1c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hip1c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hip2c_current</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hip2c_power</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hip2c_voltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ipAddr</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_DevicesConfiguration using level 1 for category Devices-->
+  <!--===========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_IonPumps_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2615353467L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DeviceConfiguration using level 1 for category Device-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Cryo_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1173523966L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DevicesConfiguration using level 1 for category Devices-->
+  <!--============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Cryo_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 68898138L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DeviceConfiguration using level 1 for category Device-->
+  <!--========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Ut_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1790601269L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DevicesConfiguration using level 1 for category Devices-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Ut_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2434341404L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PDU_DevicesConfiguration using level 1 for category Devices-->
+  <!--======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_PDU_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3909830192L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PDU_VacuumConfiguration using level 1 for category Vacuum-->
+  <!--====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_PDU_VacuumConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3124569595L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 803926824L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_check_scheduler_nTasks</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_check_scheduler_nThreads</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--==============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1666473865L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
+      <Description>period for task agentMonitorService</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
+      <Description>period for task heartbeat</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_CryoFlineGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/CryoFlineGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_CryoTurboGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/CryoTurboGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_CryoTurboPump_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/CryoTurboPump</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_CryoVacGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/CryoVacGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_HexFlineGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/HexFlineGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_HexTurboGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/HexTurboGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_HexTurboPump_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/HexTurboPump</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_HexVacGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/HexVacGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_InstVacGauge_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/InstVacGauge</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_IonPumps_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/IonPumps</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_Maq20Cryo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/Maq20Cryo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_Maq20Ut_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/Maq20Ut</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_PDU_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/PDU</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_PumpCart_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/PumpCart</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_VacPluto_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/VacPluto</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_CryoTurboPump_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/CryoTurboPump</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_HexTurboPump_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/HexTurboPump</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_IonPumps_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/IonPumps</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_Maq20Cryo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/Maq20Cryo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_PDU_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/PDU</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_PumpCart_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/PumpCart</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_slowMon_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/slowMon</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_tts0_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/tts0</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_tts1_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/tts1</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_CryoTurboPump_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/CryoTurboPump</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_HexTurboPump_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/HexTurboPump</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_IonPumps_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/IonPumps</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_Maq20Cryo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/Maq20Cryo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_PDU_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/PDU</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_PumpCart_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/PumpCart</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_slowMon_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/slowMon</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_tts0_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/tts0</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_tts1_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/tts1</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task runtimeInfo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vacuum_state_taskPeriodMillis</EFDB_Name>
+      <Description>period for task vacuum-state</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_CryoConfiguration using level 1 for category Cryo-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_PumpCart_CryoConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2020908612L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>devcId</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxVentPressure</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minPumpPressure</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_DevicesConfiguration using level 1 for category Devices-->
+  <!--===========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_PumpCart_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2283535295L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DeviceConfiguration using level 1 for category Device-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_VacPluto_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2853580557L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13303,12 +15452,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Vacuum_stateConfiguration using level 1-->
-  <!--==================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DevicesConfiguration using level 1 for category Devices-->
+  <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_vacuum_Vacuum_stateConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2977675454L -->
+    <EFDB_Topic>MTCamera_logevent_vacuum_VacPluto_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 718539561L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -13317,10 +15466,185 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>taskPeriodMillis</EFDB_Name>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacuumConfiguration using level 1 for category Vacuum-->
+  <!--================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_vacuum_VacuumConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2122196485L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoPScale</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoPdiffFloor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>delayCCOff</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxPScale</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxPdiffFloor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pChangeStateUpdate</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pFLChangeStateUpdate</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pPCChangeStateUpdate</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pcPdiffFloor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pcPdiffScaleFactor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressCCEnable</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressCCOff</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressDiffHighMin</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressDiffLow</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressForelineLow</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressIonEnable</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressIonOff</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressRefrigOk</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressTurboLow</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pressVacuum</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>speedFractTurboLow</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tranTimeCryoGate</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tranTimeHxGate</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -18184,7 +20508,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1361000410L -->
+    <!--CCS: Dictionary_Checksum: 191767559L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18212,7 +20536,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2880697553L -->
+    <!--CCS: Dictionary_Checksum: 806749796L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18268,7 +20592,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2869337463L -->
+    <!--CCS: Dictionary_Checksum: 2833262260L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18352,7 +20676,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2375022998L -->
+    <!--CCS: Dictionary_Checksum: 3953669377L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18429,7 +20753,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1304924133L -->
+    <!--CCS: Dictionary_Checksum: 145954834L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18458,13 +20782,20 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>imagehandlingconfig_includeRawStamps</EFDB_Name>
+      <Description>Whether to write raw stamps to FITS file</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1213664806L -->
+    <!--CCS: Dictionary_Checksum: 245874300L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18492,7 +20823,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1357975535L -->
+    <!--CCS: Dictionary_Checksum: 1124810080L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18543,12 +20874,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
-  <!--====================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_LimitsConfiguration using level 1 for category Limits-->
+  <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_Loader_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1983669345L -->
+    <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3274512121L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -18557,170 +20888,5840 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf0_acAF0b_byteNumero</EFDB_Name>
+      <EFDB_Name>temperatures_tempCellXminus_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempCellXminus_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempCellXminus_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempCellXminus_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXminus_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXminus_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXminus_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXminus_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXplus_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXplus_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXplus_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorXplus_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorYminus_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorYminus_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorYminus_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempClampMotorYminus_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempFrontBox_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempFrontBox_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempFrontBox_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempFrontBox_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXminus_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXminus_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXminus_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXminus_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXplus_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXplus_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXplus_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempLinearRailMotorXplus_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempRearBox_warnHi</EFDB_Name>
+      <Description>high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempRearBox_warnLo</EFDB_Name>
+      <Description>low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempRearBox_limitHi</EFDB_Name>
+      <Description>high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_tempRearBox_limitLo</EFDB_Name>
+      <Description>low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_autochangerConfiguration using level 1 for category autochanger-->
+  <!--===================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_autochangerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2570098047L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_adjustmentFactor</EFDB_Name>
+      <Description>adjustment factor.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>micron/V</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_approachOnlinePosition</EFDB_Name>
+      <Description>approach ONLINE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_approachStandbyPosition</EFDB_Name>
+      <Description>approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_deltaPositionForAlignLenient</EFDB_Name>
+      <Description>Value in alignFollower when we want a lenient alignment : alignment of follower is done when |deltaPosition| &gt; deltaPositionForAlignLenient.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_deltaPositionForAlignStrict</EFDB_Name>
+      <Description>Value in alignFollower when we want a strict alignment : alignment of follower is done when |deltaPosition| &gt; deltaPositionForAlignStrict.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_deltaPositionForAlignStrictLoader</EFDB_Name>
+      <Description>Value in alignFollower when we want a strict alignment for interactions with Loader : alignment of follower is done when |deltaPosition| &gt; deltaPositionForAlignStrictForLoader.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_deltaPreliminaryTargetPosition</EFDB_Name>
+      <Description>proximity to preliminaryTargetPosition to allow to find the true ONLINE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_driverSide</EFDB_Name>
+      <Description>Which of the two trucks is master. Should be 'Xminus' if acTruckXminus is master, or 'Xplus' if acTruckXplus is master. Used in the build method</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_handoffPosition</EFDB_Name>
+      <Description>HANDOFF position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_highAcceleration</EFDB_Name>
+      <Description>high acceleration to approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_highDeceleration</EFDB_Name>
+      <Description>high deceleration to approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_highSpeed</EFDB_Name>
+      <Description>high speed to approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_lowAcceleration</EFDB_Name>
+      <Description>low acceleration to approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_lowDeceleration</EFDB_Name>
+      <Description>low deceleration to approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_lowSpeed</EFDB_Name>
+      <Description>low speed to approach STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_maxActualPositionValue</EFDB_Name>
+      <Description>maximal position for AC trucks</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_minActualPositionValue</EFDB_Name>
+      <Description>minimal position for AC trucks</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_minTargetPosition</EFDB_Name>
+      <Description>lowest position to be used by command moveAndClampFilterOnline.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_naturalPosition</EFDB_Name>
+      <Description>natural position at ONLINE position used by process whichmoves a filter at ONLINE position.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_onlinePosition</EFDB_Name>
+      <Description>ONLINE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_positionRangeAtHandoff</EFDB_Name>
+      <Description>position is reached at HANDOFF if |targetPosition - driverPosition| &lt; positionRangeAtOnHandoff</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_positionRangeAtOnline</EFDB_Name>
+      <Description>position is reached at ONLINE if |targetPosition - driverPosition| &lt; positionRangeAtOnline</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_positionRangeAtStandby</EFDB_Name>
+      <Description>position is reached at STANDBY if |targetPosition - driverPosition| &lt; positionRangeAtStandby</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_positionRangeInTravel</EFDB_Name>
+      <Description>position is reached in TRAVEL if |targetPosition - driverPosition| &lt; positionRangeAtOnline</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_prelimaryTargetPosition</EFDB_Name>
+      <Description>prelimary ONLINE position, used by process whichmoves a filter at ONLINE position.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_proximitySensorInput</EFDB_Name>
+      <Description>input number on the ADC where proximity sensor is plugged</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_slowMotionPosition</EFDB_Name>
+      <Description>slow motion point until online</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_standbyPosition</EFDB_Name>
+      <Description>STANDBY position to be used to store a filter on carousel</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_standbyPositionEmpty</EFDB_Name>
+      <Description>STANDBY position to be used when grabing a filter on Carousel</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_timeoutForAlignFollower</EFDB_Name>
+      <Description>time to align follower on driver controller</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_timeoutForTrucksMotion</EFDB_Name>
+      <Description>time for trucks motion from ONLINE to STANDBY</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_umax</EFDB_Name>
+      <Description>maximum value of voltage read on proximitySensor.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>V</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_umin</EFDB_Name>
+      <Description>minimum value of voltage read on proximitySensor.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>V</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_utarget</EFDB_Name>
+      <Description>voltage target on proximitySensor.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>V</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_currentToOpen</EFDB_Name>
+      <Description>current to be sent to the controller to open the latch.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_timeoutForLatchMotion</EFDB_Name>
+      <Description>timeout for opening or closing latch</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_currentToOpen</EFDB_Name>
+      <Description>current to be sent to the controller to open the latch.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_timeoutForLatchMotion</EFDB_Name>
+      <Description>timeout for opening or closing latch</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_maxClosedStrain</EFDB_Name>
+      <Description>if strain &gt;= maxClosedStrain, clamps are OPENED</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_maxLockedStrain</EFDB_Name>
+      <Description>if strain &lt; maxLockedStrain, clamps are LOCKED</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_maxTimeToCloseClampsX</EFDB_Name>
+      <Description>maximum time in milliseconds to close the 3 clamps</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_maxTimeToLockAllClamps</EFDB_Name>
+      <Description>maximum time in milliseconds to lock the 3 clamps</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_maxTimeToOpenClampsX</EFDB_Name>
+      <Description>maximum time in milliseconds to open the 3 clamps</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_maxTimeToUnlockAllClamps</EFDB_Name>
+      <Description>maximum time in milliseconds to unlock the 3 clamps</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_minLockedStrain</EFDB_Name>
+      <Description>if strain &lt; minLockedStrain, clamps may be in ERROR</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_minPeriod</EFDB_Name>
+      <Description>minimal period for current ramps. should be &gt; 50</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_currentToClamp</EFDB_Name>
+      <Description>current to clamp ONLINE clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_currentToOpen</EFDB_Name>
+      <Description>current to open ONLINE clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_deltaCurrent</EFDB_Name>
+      <Description>delta of current between target current and current read on controller. Used to know if action is completed for homing.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_finalCurrentToClose</EFDB_Name>
+      <Description>final current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_incrementCurrentToClamp</EFDB_Name>
+      <Description>increment of current to lock in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_incrementCurrentToClose</EFDB_Name>
+      <Description>increment of current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_incrementCurrentToOpen</EFDB_Name>
+      <Description>increment of current to open clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_initialCurrentToClose</EFDB_Name>
+      <Description>initial current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_targetPositionToClose</EFDB_Name>
+      <Description>absolute target position to close clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_targetPositionToOpen</EFDB_Name>
+      <Description>absolute target position to open clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_currentToClamp</EFDB_Name>
+      <Description>current to clamp ONLINE clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_currentToOpen</EFDB_Name>
+      <Description>current to open ONLINE clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_deltaCurrent</EFDB_Name>
+      <Description>delta of current between target current and current read on controller. Used to know if action is completed for homing.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_finalCurrentToClose</EFDB_Name>
+      <Description>final current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_incrementCurrentToClamp</EFDB_Name>
+      <Description>increment of current to lock in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_incrementCurrentToClose</EFDB_Name>
+      <Description>increment of current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_incrementCurrentToOpen</EFDB_Name>
+      <Description>increment of current to open clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_initialCurrentToClose</EFDB_Name>
+      <Description>initial current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_targetPositionToClose</EFDB_Name>
+      <Description>absolute target position to close clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_targetPositionToOpen</EFDB_Name>
+      <Description>absolute target position to open clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_currentToClamp</EFDB_Name>
+      <Description>current to clamp ONLINE clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_currentToOpen</EFDB_Name>
+      <Description>current to open ONLINE clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_deltaCurrent</EFDB_Name>
+      <Description>delta of current between target current and current read on controller. Used to know if action is completed for homing.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_finalCurrentToClose</EFDB_Name>
+      <Description>final current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_incrementCurrentToClamp</EFDB_Name>
+      <Description>increment of current to lock in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_incrementCurrentToClose</EFDB_Name>
+      <Description>increment of current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_incrementCurrentToOpen</EFDB_Name>
+      <Description>increment of current to open clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_initialCurrentToClose</EFDB_Name>
+      <Description>initial current to close clamp in a current ramp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_targetPositionToClose</EFDB_Name>
+      <Description>absolute target position to close clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_targetPositionToOpen</EFDB_Name>
+      <Description>absolute target position to open clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_strainGain</EFDB_Name>
+      <Description>UNDEFINED</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_timeoutForLockingClamps</EFDB_Name>
+      <Description>timeout in milliseconds : if closing the clamps last more than this amount of time, then the subsystem goes in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_timeoutForUnlockingClamps</EFDB_Name>
+      <Description>timeout in milliseconds : if unlocking the clamps last more than this amount of time, then the subsystem goes in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeToUpdateProtectionSystem</EFDB_Name>
+      <Description>time to wait until protection system signals are updated</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>waitTimeForBrakeLR</EFDB_Name>
+      <Description>time to wait between activateBrake and disableOperation for linear rails</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>waitTimeForBrakeOC</EFDB_Name>
+      <Description>time to wait between activateBrake and disableOperation for online clamps</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_readRateConfiguration using level 1 for category readRate-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_readRateConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4074586327L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_sensorConfiguration using level 1 for category sensor-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_sensorConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2769748111L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXminus_handoffPositionSensorsXminus_handoffPositionSensorBXminus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf0_acAF0b_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_handoffPositionSensorsXminus_handoffPositionSensorBXminus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf0_acAF0b_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_handoffPositionSensorsXminus_handoffPositionSensorBXminus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf0_acAF0s_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_handoffPositionSensorsXminus_handoffPositionSensorXminus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf0_acAF0s_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_handoffPositionSensorsXminus_handoffPositionSensorXminus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf0_acAF0s_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_handoffPositionSensorsXminus_handoffPositionSensorXminus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf1_acAF1b_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_onlinePositionSensorsXminus_onlinePositionSensorBXminus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf1_acAF1b_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_onlinePositionSensorsXminus_onlinePositionSensorBXminus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf1_acAF1b_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_onlinePositionSensorsXminus_onlinePositionSensorBXminus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf1_acAF1s_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_onlinePositionSensorsXminus_onlinePositionSensorXminus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf1_acAF1s_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_onlinePositionSensorsXminus_onlinePositionSensorXminus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf1_acAF1s_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_onlinePositionSensorsXminus_onlinePositionSensorXminus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf3_acAF3b_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_standbyPositionSensorsXminus_standbyPositionSensorBXminus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf3_acAF3b_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_standbyPositionSensorsXminus_standbyPositionSensorBXminus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf3_acAF3b_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_standbyPositionSensorsXminus_standbyPositionSensorBXminus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf3_acAF3s_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_standbyPositionSensorsXminus_standbyPositionSensorXminus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf3_acAF3s_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_standbyPositionSensorsXminus_standbyPositionSensorXminus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acaf3_acAF3s_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXminus_standbyPositionSensorsXminus_standbyPositionSensorXminus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acap2_acAP2b_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXplus_handoffPositionSensorsXplus_handoffPositionSensorBXplus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acap2_acAP2b_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXplus_handoffPositionSensorsXplus_handoffPositionSensorBXplus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acap2_acAP2b_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXplus_handoffPositionSensorsXplus_handoffPositionSensorBXplus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acap2_acAP2s_byteNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXplus_handoffPositionSensorsXplus_handoffPositionSensorXplus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acap2_acAP2s_dioName</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXplus_handoffPositionSensorsXplus_handoffPositionSensorXplus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>acap2_acAP2s_inputNumero</EFDB_Name>
+      <EFDB_Name>autochangertrucks_acTruckXplus_handoffPositionSensorsXplus_handoffPositionSensorXplus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_onlinePositionSensorsXplus_onlinePositionSensorBXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_onlinePositionSensorsXplus_onlinePositionSensorBXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_onlinePositionSensorsXplus_onlinePositionSensorBXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_onlinePositionSensorsXplus_onlinePositionSensorXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_onlinePositionSensorsXplus_onlinePositionSensorXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_onlinePositionSensorsXplus_onlinePositionSensorXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_standbyPositionSensorsXplus_standbyPositionSensorBXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_standbyPositionSensorsXplus_standbyPositionSensorBXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_standbyPositionSensorsXplus_standbyPositionSensorBXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_standbyPositionSensorsXplus_standbyPositionSensorXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_standbyPositionSensorsXplus_standbyPositionSensorXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_acTruckXplus_standbyPositionSensorsXplus_standbyPositionSensorXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_closeSensorsLatchXminus_closeSensorBLatchXminus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_closeSensorsLatchXminus_closeSensorBLatchXminus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_closeSensorsLatchXminus_closeSensorBLatchXminus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_closeSensorsLatchXminus_closeSensorLatchXminus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_closeSensorsLatchXminus_closeSensorLatchXminus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_closeSensorsLatchXminus_closeSensorLatchXminus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_filterEngagedSensorsLatchXminus_filterEngagedSensorBLatchXminus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_filterEngagedSensorsLatchXminus_filterEngagedSensorBLatchXminus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_filterEngagedSensorsLatchXminus_filterEngagedSensorBLatchXminus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_filterEngagedSensorsLatchXminus_filterEngagedSensorLatchXminus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_filterEngagedSensorsLatchXminus_filterEngagedSensorLatchXminus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_filterEngagedSensorsLatchXminus_filterEngagedSensorLatchXminus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_openSensorsLatchXminus_openSensorBLatchXminus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_openSensorsLatchXminus_openSensorBLatchXminus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_openSensorsLatchXminus_openSensorBLatchXminus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_openSensorsLatchXminus_openSensorLatchXminus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_openSensorsLatchXminus_openSensorLatchXminus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_openSensorsLatchXminus_openSensorLatchXminus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_closeSensorsLatchXplus_closeSensorBLatchXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_closeSensorsLatchXplus_closeSensorBLatchXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_closeSensorsLatchXplus_closeSensorBLatchXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_closeSensorsLatchXplus_closeSensorLatchXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_closeSensorsLatchXplus_closeSensorLatchXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_closeSensorsLatchXplus_closeSensorLatchXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_filterEngagedSensorsLatchXplus_filterEngagedSensorBLatchXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_filterEngagedSensorsLatchXplus_filterEngagedSensorBLatchXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_filterEngagedSensorsLatchXplus_filterEngagedSensorBLatchXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_filterEngagedSensorsLatchXplus_filterEngagedSensorLatchXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_filterEngagedSensorsLatchXplus_filterEngagedSensorLatchXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_filterEngagedSensorsLatchXplus_filterEngagedSensorLatchXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_openSensorsLatchXplus_openSensorBLatchXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_openSensorsLatchXplus_openSensorBLatchXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_openSensorsLatchXplus_openSensorBLatchXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_openSensorsLatchXplus_openSensorLatchXplus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_openSensorsLatchXplus_openSensorLatchXplus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_openSensorsLatchXplus_openSensorLatchXplus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusCloseSensors_onlineClampXminusCloseSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusCloseSensors_onlineClampXminusCloseSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusCloseSensors_onlineClampXminusCloseSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusCloseSensors_onlineClampXminusCloseSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusCloseSensors_onlineClampXminusCloseSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusCloseSensors_onlineClampXminusCloseSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusOpenSensors_onlineClampXminusOpenSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusOpenSensors_onlineClampXminusOpenSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusOpenSensors_onlineClampXminusOpenSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusOpenSensors_onlineClampXminusOpenSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusOpenSensors_onlineClampXminusOpenSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_onlineClampXminusOpenSensors_onlineClampXminusOpenSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusCloseSensors_onlineClampXplusCloseSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusCloseSensors_onlineClampXplusCloseSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusCloseSensors_onlineClampXplusCloseSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusCloseSensors_onlineClampXplusCloseSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusCloseSensors_onlineClampXplusCloseSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusCloseSensors_onlineClampXplusCloseSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusOpenSensors_onlineClampXplusOpenSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusOpenSensors_onlineClampXplusOpenSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusOpenSensors_onlineClampXplusOpenSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusOpenSensors_onlineClampXplusOpenSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusOpenSensors_onlineClampXplusOpenSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_onlineClampXplusOpenSensors_onlineClampXplusOpenSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusCloseSensors_onlineClampYminusCloseSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusCloseSensors_onlineClampYminusCloseSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusCloseSensors_onlineClampYminusCloseSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusCloseSensors_onlineClampYminusCloseSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusCloseSensors_onlineClampYminusCloseSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusCloseSensors_onlineClampYminusCloseSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusOpenSensors_onlineClampYminusOpenSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusOpenSensors_onlineClampYminusOpenSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusOpenSensors_onlineClampYminusOpenSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusOpenSensors_onlineClampYminusOpenSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusOpenSensors_onlineClampYminusOpenSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_onlineClampYminusOpenSensors_onlineClampYminusOpenSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF0_Sensors_OUT_AF0_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF0_Sensors_OUT_AF0_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF0_Sensors_OUT_AF0_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF0_Sensors_OUT_AF0_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF0_Sensors_OUT_AF0_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF0_Sensors_OUT_AF0_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF1_Sensors_OUT_AF1_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF1_Sensors_OUT_AF1_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF1_Sensors_OUT_AF1_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF1_Sensors_OUT_AF1_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF1_Sensors_OUT_AF1_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF1_Sensors_OUT_AF1_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF3_Sensors_OUT_AF3_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF3_Sensors_OUT_AF3_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF3_Sensors_OUT_AF3_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF3_Sensors_OUT_AF3_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF3_Sensors_OUT_AF3_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AF3_Sensors_OUT_AF3_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AIN_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AIN_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AIN_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AOL_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AOL_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AOL_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP1_Sensors_OUT_AP1_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP1_Sensors_OUT_AP1_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP1_Sensors_OUT_AP1_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP1_Sensors_OUT_AP1_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP1_Sensors_OUT_AP1_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP1_Sensors_OUT_AP1_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP2_Sensors_OUT_AP2_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP2_Sensors_OUT_AP2_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP2_Sensors_OUT_AP2_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP2_Sensors_OUT_AP2_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP2_Sensors_OUT_AP2_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP2_Sensors_OUT_AP2_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP3_Sensors_OUT_AP3_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP3_Sensors_OUT_AP3_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP3_Sensors_OUT_AP3_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP3_Sensors_OUT_AP3_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP3_Sensors_OUT_AP3_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_OUT_AP3_Sensors_OUT_AP3_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselHoldingFilterSensors_carouselHoldingFilterSensor0_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselHoldingFilterSensors_carouselHoldingFilterSensor0_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselHoldingFilterSensors_carouselHoldingFilterSensor0_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselHoldingFilterSensors_carouselHoldingFilterSensor1_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselHoldingFilterSensors_carouselHoldingFilterSensor1_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselHoldingFilterSensors_carouselHoldingFilterSensor1_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselStoppedAtStandbySensors_carouselStoppedAtStandbyC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselStoppedAtStandbySensors_carouselStoppedAtStandbyC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselStoppedAtStandbySensors_carouselStoppedAtStandbyC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselStoppedAtStandbySensors_carouselStoppedAtStandby_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselStoppedAtStandbySensors_carouselStoppedAtStandby_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carouselStoppedAtStandbySensors_carouselStoppedAtStandby_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF0Sensors_carousel_CF0_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF0Sensors_carousel_CF0_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF0Sensors_carousel_CF0_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF0Sensors_carousel_CF0_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF0Sensors_carousel_CF0_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF0Sensors_carousel_CF0_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF1Sensors_carousel_CF1_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF1Sensors_carousel_CF1_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF1Sensors_carousel_CF1_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF1Sensors_carousel_CF1_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF1Sensors_carousel_CF1_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_carousel_CF1Sensors_carousel_CF1_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_inclinometerXminus_byteNumero</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_inclinometerXminus_deviceName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_inclinometerXplus_byteNumero</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_inclinometerXplus_deviceName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderConnectedSensors_loaderConnectedSensorC_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderConnectedSensors_loaderConnectedSensorC_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderConnectedSensors_loaderConnectedSensorC_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderConnectedSensors_loaderConnectedSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderConnectedSensors_loaderConnectedSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderConnectedSensors_loaderConnectedSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderHoldingFilterSensors_loaderHoldingFilterSensor0_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderHoldingFilterSensors_loaderHoldingFilterSensor0_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderHoldingFilterSensors_loaderHoldingFilterSensor0_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderHoldingFilterSensors_loaderHoldingFilterSensor1_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderHoldingFilterSensors_loaderHoldingFilterSensor1_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderHoldingFilterSensors_loaderHoldingFilterSensor1_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderPresenceSensors_presenceLoader_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderPresenceSensors_presenceLoader_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderPresenceSensors_presenceLoader_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderPresenceSensors_presenceLoader_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderPresenceSensors_presenceLoader_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderPresenceSensors_presenceLoader_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutSensors_lockOut_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutSensors_lockOut_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutSensors_lockOut_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutSensors_lockOut_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutSensors_lockOut_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutSensors_lockOut_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutShunt_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutShunt_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lockOutShunt_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmEngineeringKeySensors_engineeringKey_C_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmEngineeringKeySensors_engineeringKey_C_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmEngineeringKeySensors_engineeringKey_C_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmEngineeringKeySensors_engineeringKey_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmEngineeringKeySensors_engineeringKey_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmEngineeringKeySensors_engineeringKey_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLatchesStatus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLatchesStatus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLatchesStatus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLinearRail1Status_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLinearRail1Status_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLinearRail1Status_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLinearRail2Status_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLinearRail2Status_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmLinearRail2Status_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmOnlineClampsStatus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmOnlineClampsStatus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_lpmOnlineClampsStatus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_canbusConfiguration using level 1 for category canbus-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_canbusConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3209700913L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>baud</EFDB_Name>
+      <Description>CANbus rate.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>busName</EFDB_Name>
+      <Description>CANbus name. Can be 0 for changer or 1 for loader.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hardwareBootTimeout</EFDB_Name>
+      <Description>A timeout for the hardware booting process</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>masterNodeID</EFDB_Name>
+      <Description>CANbus master nodeID.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_controllerConfiguration using level 1 for category controller-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_controllerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3765972201L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxminuscontroller_encoderRibbonMinValue</EFDB_Name>
+      <Description>minimal position of the encoder ribbon.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxminuscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxminuscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxminuscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxpluscontroller_encoderRibbonMinValue</EFDB_Name>
+      <Description>minimal position of the encoder ribbon.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxpluscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxpluscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxpluscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselcontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselcontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselcontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminuscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminuscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminuscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxpluscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxpluscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxpluscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminuscontroller_latchName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminuscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminuscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminuscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxpluscontroller_latchName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxpluscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxpluscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxpluscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminuscontroller_onlineClampName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminuscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminuscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminuscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxpluscontroller_onlineClampName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxpluscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxpluscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxpluscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminuscontroller_onlineClampName</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminuscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminuscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminuscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_nodeIDConfiguration using level 1 for category nodeID-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_nodeIDConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3856037239L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acsensorsgateway_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxminuscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxpluscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>accelerobf_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ai814_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakesystemgateway_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselcontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminuscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxpluscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hyttc580_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminuscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxpluscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminuscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxpluscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminuscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinestraingauge_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>proximitysensorsdevice_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pt100_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempsensorsdevice1_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempsensorsdevice2_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_sensorConfiguration using level 1 for category sensor-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_sensorConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3142019645L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ai814_transmissionType</EFDB_Name>
+      <Description>Transmission types for CAN-CBX-AI814 see CAN-CBX-AI814_Manual.pdf § 8.6.2</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_serialNBConfiguration using level 1 for category serialNB-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_serialNBConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3304963596L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acsensorsgateway_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxminuscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxpluscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>accelerobf_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ai814_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakesystemgateway_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselcontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminuscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxpluscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hyttc580_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminuscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxpluscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminuscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxpluscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminuscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinestraingauge_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>proximitysensorsdevice_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pt100_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempsensorsdevice1_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempsensorsdevice2_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_canbusConfiguration using level 1 for category canbus-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_canbusConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 293655581L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>baud</EFDB_Name>
+      <Description>CANbus rate.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>busName</EFDB_Name>
+      <Description>CANbus name. Can be 0 for changer or 1 for loader.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hardwareBootTimeout</EFDB_Name>
+      <Description>A timeout for the hardware booting process</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>masterNodeID</EFDB_Name>
+      <Description>CANbus master nodeID.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_controllerConfiguration using level 1 for category controller-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_controllerConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3375764732L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carriercontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carriercontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carriercontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hookscontroller_paramsForCurrent</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hookscontroller_paramsForHoming</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hookscontroller_paramsForProfilePosition</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_nodeIDConfiguration using level 1 for category nodeID-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_nodeIDConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4179895460L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carriercontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hookscontroller_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderplutogateway_nodeID</EFDB_Name>
+      <Description>CANOpen node ID of this CANOpen device</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_serialNBConfiguration using level 1 for category serialNB-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_serialNBConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3860483647L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carriercontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hookscontroller_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderplutogateway_serialNB</EFDB_Name>
+      <Description>serial number of this CANOpen device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_carouselConfiguration using level 1 for category carousel-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Carousel_carouselConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2871082080L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brake1Limit</EFDB_Name>
+      <Description>upper brake1 (bay I) limit for state CLOSED</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brake2Limit</EFDB_Name>
+      <Description>upper brake2 (bay N) limit for state CLOSED</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brake3Limit</EFDB_Name>
+      <Description>upper brake3 (bay X) limit for state CLOSED</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>currentToPrepareUnlock</EFDB_Name>
+      <Description>for command unlock of carousel clamp : current to send to prepare unlock</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fastAcceleration</EFDB_Name>
+      <Description>acceleration in fast mode [rpm/s]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fastDeceleration</EFDB_Name>
+      <Description>deceleration in fast mode [rpm/s]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fastRotationTimeout</EFDB_Name>
+      <Description>in milliseconds; timeout for the rotation in fast mode</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fastVelocity</EFDB_Name>
+      <Description>velocity in fast mode [rpm]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockSensorMaxLimitXminus</EFDB_Name>
+      <Description>If lockSensor side X- returns a value above lockSensorMaxLimitXminus, the sensor is in error.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockSensorMaxLimitXplus</EFDB_Name>
+      <Description>If lockSensor side X+ returns a value above lockSensorMaxLimitXplus, the sensor is in error.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockSensorMinLimitXminus</EFDB_Name>
+      <Description>If lockSensor side X- returns a value &lt; lockSensorMinLimitXminus, sensor is in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockSensorMinLimitXplus</EFDB_Name>
+      <Description>If lockSensor side X+ returns a value &lt; lockSensorMinLimitXplus, sensor is in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxClampsOffsetDelta</EFDB_Name>
+      <Description>if difference between offset read on hyttc580 and persisted offset is over this limit an ALARM is launched</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxStandbyDeltaPosition</EFDB_Name>
+      <Description>over this value of deltaPosition, carousel position at STANDBY is NOT correct [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recoveryBackwardStep</EFDB_Name>
+      <Description>A number of steps to go back if after rotation carousel position has exceeded standbyPosition by more than maxStandbyDeltaPosition. [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recoveryForwardStep</EFDB_Name>
+      <Description>A number of steps to go back if after rotation carousel position has exceeded standbyPosition by more than maxStandbyDeltaPosition. [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recoveryLockingCurrent</EFDB_Name>
+      <Description>A current to be sent to clampXminus controller during locking recovery.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recoveryMaxVelocity</EFDB_Name>
+      <Description>If the velocity in clampXminus controller goes over this value during locking recovery, it means that the recovery process has failed. [rpm]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recoveryStandbyDeltaPosition</EFDB_Name>
+      <Description>over this value of deltaPosition, a rotation recovery is executed [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>slowAcceleration</EFDB_Name>
+      <Description>acceleration in slow mode [rpm/s]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>slowDeceleration</EFDB_Name>
+      <Description>deceleration in slow mode [rpm/s]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>slowRotationTimeout</EFDB_Name>
+      <Description>in milliseconds; timeout for the rotation in slow mode</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>slowVelocity</EFDB_Name>
+      <Description>velocity in slow mode [rpm]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_deltaAutochangerStandbyPosition</EFDB_Name>
+      <Description>autochanger delta STANDBY position to be used to store a filter on carousel on this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_standbyPosition</EFDB_Name>
+      <Description> carousel position when this socket is at standby [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_deltaAutochangerStandbyPosition</EFDB_Name>
+      <Description>autochanger delta STANDBY position to be used to store a filter on carousel on this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_standbyPosition</EFDB_Name>
+      <Description> carousel position when this socket is at standby [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_deltaAutochangerStandbyPosition</EFDB_Name>
+      <Description>autochanger delta STANDBY position to be used to store a filter on carousel on this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_standbyPosition</EFDB_Name>
+      <Description> carousel position when this socket is at standby [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_deltaAutochangerStandbyPosition</EFDB_Name>
+      <Description>autochanger delta STANDBY position to be used to store a filter on carousel on this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_standbyPosition</EFDB_Name>
+      <Description> carousel position when this socket is at standby [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_currentToUnlock</EFDB_Name>
+      <Description>value of current to send to controller to unlock carousel clamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_filterPresenceMaxValue</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_filterPresenceOffset3</EFDB_Name>
+      <Description>an offset for tests after carousel has been transported</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_timeoutForReleasing</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_timeoutForUnlocking</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_deltaAutochangerStandbyPosition</EFDB_Name>
+      <Description>autochanger delta STANDBY position to be used to store a filter on carousel on this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_standbyPosition</EFDB_Name>
+      <Description> carousel position when this socket is at standby [carousel encoder step]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeToPrepareUnlock</EFDB_Name>
+      <Description>for command unlock of carousel clamp : time between little current to prepare hardware and currentToLock </Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeToUpdateProtectionSystem</EFDB_Name>
+      <Description>This is the time to wait until protection system changes its status after motions.</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_readRateConfiguration using level 1 for category readRate-->
+  <!--==========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Carousel_readRateConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2670545188L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_sensorConfiguration using level 1 for category sensor-->
+  <!--======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Carousel_sensorConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 187822661L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAF3_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAF3_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAF3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAF3b_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAF3b_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAF3b_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1b_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1b_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1b_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2b_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2b_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2b_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3b_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3b_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3b_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caBrakesActivated_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caBrakesActivated_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caBrakesActivated_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0b_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0b_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0b_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1b_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1b_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1b_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFC_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFC_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFC_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFCb_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFCb_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFCb_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCS_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCS_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCS_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCSb_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCSb_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCSb_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableBrakes_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableBrakes_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableBrakes_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableRotation_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableRotation_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableRotation_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableShutter_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableShutter_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableShutter_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableUnclamp_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableUnclamp_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableUnclamp_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEng_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEng_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEng_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEngb_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEngb_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEngb_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockout_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockout_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockout_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockoutb_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockoutb_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockoutb_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caShutterInactive_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caShutterInactive_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caShutterInactive_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caSleep_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caSleep_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caSleep_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_enableShutterInterlock_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_enableShutterInterlock_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_enableShutterInterlock_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDI_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDI_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDI_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDIsafety_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDIsafety_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDIsafety_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_powerSave_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_powerSave_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_powerSave_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpCheckRotation_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpCheckRotation_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpCheckRotation_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopRotation_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopRotation_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopRotation_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopUnclamp_bitNumero</EFDB_Name>
+      <Description>Bit number on the byte where the value sensor is stored.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopUnclamp_byteNumero</EFDB_Name>
+      <Description>The byte number on the PDO where the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopUnclamp_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_filterPresenceXminus1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_lockSensorXminus1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_filterPresenceXplus1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_lockSensorXplus1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_ioModuleSensor1_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_filterPresenceXminus2_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_lockSensorXminus2_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_filterPresenceXplus2_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_lockSensorXplus2_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_ioModuleSensor2_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_filterPresenceXminus3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_lockSensorXminus3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_filterPresenceXplus3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_lockSensorXplus3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_ioModuleSensor3_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_filterPresenceXminus4_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_lockSensorXminus4_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_filterPresenceXplus4_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_lockSensorXplus4_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_ioModuleSensor4_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_filterPresenceXminus5_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_lockSensorXminus5_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_filterPresenceXplus5_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_lockSensorXplus5_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_ioModuleSensor5_deviceName</EFDB_Name>
+      <Description>name of the CAN OPEN device this sensor is plugged on</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_FilterIdentificator_sensorConfiguration using level 1 for category sensor-->
+  <!--=================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_FilterIdentificator_sensorConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1620903783L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor0_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor0_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor0_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor1_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor1_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor1_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor2_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor2_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor2_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor3_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor3_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor3_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor4_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor4_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor4_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor5_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor5_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filteridsensor5_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_FilterManager_filterConfiguration using level 1 for category filter-->
+  <!--===========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_FilterManager_filterConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 94796951L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>a_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>a_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>a_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>da1_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>da1_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>da1_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>da2_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>da2_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>da2_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dr1_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dr1_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dr1_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>du1_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>du1_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>du1_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>du2_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>du2_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>du2_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dz1_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dz1_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dz1_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ef_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ef_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ef_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f15_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f15_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f15_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f17_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f17_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f17_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f29_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f29_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f29_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f34_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f34_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f34_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f3_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f3_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f3_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f46_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f46_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f46_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f48_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f48_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f48_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f60_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f60_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>f60_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>g_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>g_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>g_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>i_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>i_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>i_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>oa_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>oa_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>oa_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ob_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ob_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ob_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>oc_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>oc_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>oc_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ph_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ph_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ph_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>r_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>r_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>r_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tu_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tu_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tu_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ty_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ty_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ty_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>u_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>u_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>u_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>y_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>y_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>y_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>z_family</EFDB_Name>
+      <Description>Filter family: S ; D ; F ; T ; O</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>z_filterID</EFDB_Name>
+      <Description>FilterID which is coded on filter frame with 6 hall effect sensors.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>z_weight</EFDB_Name>
+      <Description>weight of this filter</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kg</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_loaderConfiguration using level 1 for category loader-->
+  <!--====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Loader_loaderConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4070873433L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_deltaPosition</EFDB_Name>
+      <Description>delta position : used to know if carrier position is in a range of 2*deltaPosition around a given position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_engagedPosition</EFDB_Name>
+      <Description>Loader Engaged position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_handoffPosition</EFDB_Name>
+      <Description>Loader Handoff position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_highAcceleration</EFDB_Name>
+      <Description>high acceleration to move carrier empty from ENGAGED to STORAGE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_highDeceleration</EFDB_Name>
+      <Description>high deceleration to move carrier with a filter from ENGAGED to STORAGE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_highSpeed</EFDB_Name>
+      <Description>high speed to move carrier when it's empty or with a filter from ENGAGED to STORAGE position [rpm]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_lowAcceleration</EFDB_Name>
+      <Description>low acceleration to move carrier with a filter from ENGAGED to STORAGE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_lowDeceleration</EFDB_Name>
+      <Description>low deceleration to move carrier with a filter from ENGAGED to STORAGE position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_lowSpeed</EFDB_Name>
+      <Description>low speed to go with a filter from ENGAGED to HANDOFF position [rpm]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_maxCurrent</EFDB_Name>
+      <Description>For the Loader GUI : Maximum current to be sent to the Loader Carrier controller.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_maxSpeed</EFDB_Name>
+      <Description>For the Loader GUI : Loader Carrier Maximum speed. [rpm]</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_storagePosition</EFDB_Name>
+      <Description>Loader Storage position</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_timeoutForGoingToEngaged</EFDB_Name>
+      <Description>timeout in milliseconds to go from storage to engaged on loader</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_timeoutForGoingToHandOff</EFDB_Name>
+      <Description>timeout in milliseconds to go from storage to handoff on loader</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_timeoutForGoingToStorage</EFDB_Name>
+      <Description>timeout in milliseconds to go from handoff to storage on loader</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterDistanceMin</EFDB_Name>
+      <Description>maximum position of the filter</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_absolutePositionToClose</EFDB_Name>
+      <Description>target encoder absolute value in qc when hooks are CLOSED</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_currentThreshold</EFDB_Name>
+      <Description>current to open hooks in homing mode</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_currentToClamp</EFDB_Name>
+      <Description>current to clamp hooks</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_currentToOpen</EFDB_Name>
+      <Description>current to open hooks</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_minClampedVoltage</EFDB_Name>
+      <Description>Trigger to know when action clamp is completed. If force sensor voltage is over this limit then action clamp is completed.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>0.1 Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_relativePositionToUnclamp</EFDB_Name>
+      <Description>relative position in qc to unclamp when hooks are CLAMPED</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_timeoutForClampingHooks</EFDB_Name>
+      <Description>timeout : if closing strongly the clamp last more than this amount of time, then the subsystem goes in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_timeoutForClosingHooks</EFDB_Name>
+      <Description>timeout : if closing the clamp last more than this amount of time, then the subsystem goes in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_timeoutForOpeningHooks</EFDB_Name>
+      <Description>timeout : if opening the clamp last more than this amount of time, then the subsystem goes in ERROR.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_readRateConfiguration using level 1 for category readRate-->
+  <!--========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Loader_readRateConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 951994315L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_readSensorsRate</EFDB_Name>
+      <Description>define intervale time between 2 read of sensors</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
+  <!--====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_fcs_Loader_sensorConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 193746652L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -19131,1106 +27132,581 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyengsensors_keyEng_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LPS_LPS_0_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyengsensors_keyEng_dioName</EFDB_Name>
+      <EFDB_Name>plc_Loader_LPS_LPS_0_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyengsensors_keyEng_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LPS_LPS_0_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyengsensors_keyEngb_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LPS_LPS_1_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyengsensors_keyEngb_dioName</EFDB_Name>
+      <EFDB_Name>plc_Loader_LPS_LPS_1_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyengsensors_keyEngb_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LPS_LPS_1_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keylocksensors_keyLock_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LRH_LRH_0_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keylocksensors_keyLock_dioName</EFDB_Name>
+      <EFDB_Name>plc_Loader_LRH_LRH_0_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keylocksensors_keyLock_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LRH_LRH_0_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keylocksensors_keyLockb_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LRH_LRH_1_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keylocksensors_keyLockb_dioName</EFDB_Name>
+      <EFDB_Name>plc_Loader_LRH_LRH_1_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keylocksensors_keyLockb_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_Loader_LRH_LRH_1_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loadercarrierrelaystatus_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF0_acAF0b_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loadercarrierrelaystatus_dioName</EFDB_Name>
+      <EFDB_Name>plc_acAF0_acAF0b_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loadercarrierrelaystatus_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF0_acAF0b_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderchainpresencesensor_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF0_acAF0s_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderchainpresencesensor_dioName</EFDB_Name>
+      <EFDB_Name>plc_acAF0_acAF0s_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderchainpresencesensor_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF0_acAF0s_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderdefaultstatus_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF1_acAF1b_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderdefaultstatus_dioName</EFDB_Name>
+      <EFDB_Name>plc_acAF1_acAF1b_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderdefaultstatus_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF1_acAF1b_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterdistancesensor_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_acAF1_acAF1s_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF1_acAF1s_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF1_acAF1s_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF3_acAF3b_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF3_acAF3b_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF3_acAF3b_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF3_acAF3s_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF3_acAF3s_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAF3_acAF3s_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAP2_acAP2b_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAP2_acAP2b_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAP2_acAP2b_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAP2_acAP2s_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAP2_acAP2s_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_acAP2_acAP2s_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyEngSensors_keyEng_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyEngSensors_keyEng_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyEngSensors_keyEng_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyEngSensors_keyEngb_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyEngSensors_keyEngb_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyEngSensors_keyEngb_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyLockSensors_keyLock_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyLockSensors_keyLock_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyLockSensors_keyLock_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyLockSensors_keyLockb_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyLockSensors_keyLockb_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_keyLockSensors_keyLockb_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderCarrierRelayStatus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderCarrierRelayStatus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderCarrierRelayStatus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderChainPresenceSensor_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderChainPresenceSensor_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderChainPresenceSensor_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderDefaultStatus_byteNumero</EFDB_Name>
+      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderDefaultStatus_dioName</EFDB_Name>
+      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderDefaultStatus_inputNumero</EFDB_Name>
+      <Description>The input number on DIO device where this sensor is plugged on.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_loaderFilterDistanceSensor_byteNumero</EFDB_Name>
       <Description>byte number on the gateway</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterdistancesensor_deviceName</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterDistanceSensor_deviceName</EFDB_Name>
       <Description>name of the gateway this sensor is plugged on</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfiltergoodpositionstatus_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterGoodPositionStatus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfiltergoodpositionstatus_dioName</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterGoodPositionStatus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfiltergoodpositionstatus_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterGoodPositionStatus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterpresencesensors_loaderFilterPresenceSensor0_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterPresenceSensors_loaderFilterPresenceSensor0_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterpresencesensors_loaderFilterPresenceSensor0_dioName</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterPresenceSensors_loaderFilterPresenceSensor0_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterpresencesensors_loaderFilterPresenceSensor0_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterPresenceSensors_loaderFilterPresenceSensor0_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterpresencesensors_loaderFilterPresenceSensor1_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterPresenceSensors_loaderFilterPresenceSensor1_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterpresencesensors_loaderFilterPresenceSensor1_dioName</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterPresenceSensors_loaderFilterPresenceSensor1_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderfilterpresencesensors_loaderFilterPresenceSensor1_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderFilterPresenceSensors_loaderFilterPresenceSensor1_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderhooksrelaystatus_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderHooksRelayStatus_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderhooksrelaystatus_dioName</EFDB_Name>
+      <EFDB_Name>plc_loaderHooksRelayStatus_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderhooksrelaystatus_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderHooksRelayStatus_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderoncamerasensors_loaderOnCameraSensor0_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderOnCameraSensors_loaderOnCameraSensor0_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderoncamerasensors_loaderOnCameraSensor0_dioName</EFDB_Name>
+      <EFDB_Name>plc_loaderOnCameraSensors_loaderOnCameraSensor0_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderoncamerasensors_loaderOnCameraSensor0_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderOnCameraSensors_loaderOnCameraSensor0_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderoncamerasensors_loaderOnCameraSensor1_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderOnCameraSensors_loaderOnCameraSensor1_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderoncamerasensors_loaderOnCameraSensor1_dioName</EFDB_Name>
+      <EFDB_Name>plc_loaderOnCameraSensors_loaderOnCameraSensor1_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderoncamerasensors_loaderOnCameraSensor1_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loaderOnCameraSensors_loaderOnCameraSensor1_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loader_LFD_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loader_LFD_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loader_LFD_dioName</EFDB_Name>
+      <EFDB_Name>plc_loader_LFD_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loader_LFD_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loader_LFD_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loader_LFS_byteNumero</EFDB_Name>
+      <EFDB_Name>plc_loader_LFS_byteNumero</EFDB_Name>
       <Description>The byte numberwhere the value of this sensor is stored in.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loader_LFS_dioName</EFDB_Name>
+      <EFDB_Name>plc_loader_LFS_dioName</EFDB_Name>
       <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loader_LFS_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LPS_LPS_0_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LPS_LPS_0_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LPS_LPS_0_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LPS_LPS_1_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LPS_LPS_1_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LPS_LPS_1_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_LRH_0_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_LRH_0_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_LRH_0_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_LRH_1_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_LRH_1_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_LRH_1_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LockOutSensors_sensorConfiguration using level 1 for category sensor-->
-  <!--============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LockOutSensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3361240196L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LockOutShunt_sensorConfiguration using level 1 for category sensor-->
-  <!--==========================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LockOutShunt_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1505304461L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LpmEngineeringKeySensors_sensorConfiguration using level 1 for category sensor-->
-  <!--======================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LpmEngineeringKeySensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1582874129L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LpmLatchesStatus_sensorConfiguration using level 1 for category sensor-->
-  <!--==============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LpmLatchesStatus_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3243364010L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LpmLinearRail1Status_sensorConfiguration using level 1 for category sensor-->
-  <!--==================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LpmLinearRail1Status_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2332139193L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LpmLinearRail2Status_sensorConfiguration using level 1 for category sensor-->
-  <!--==================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LpmLinearRail2Status_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1934509714L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_LpmOnlineClampsStatus_sensorConfiguration using level 1 for category sensor-->
-  <!--===================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_LpmOnlineClampsStatus_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2290871704L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AF0_Sensors_sensorConfiguration using level 1 for category sensor-->
-  <!--=============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AF0_Sensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 120154583L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AF1_Sensors_sensorConfiguration using level 1 for category sensor-->
-  <!--=============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AF1_Sensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3669700816L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AF3_Sensors_sensorConfiguration using level 1 for category sensor-->
-  <!--=============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AF3_Sensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3136193695L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AIN_sensorConfiguration using level 1 for category sensor-->
-  <!--=====================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AIN_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1535536215L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AOL_sensorConfiguration using level 1 for category sensor-->
-  <!--=====================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AOL_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 120869528L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AP1_Sensors_sensorConfiguration using level 1 for category sensor-->
-  <!--=============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AP1_Sensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1980987618L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AP2_Sensors_sensorConfiguration using level 1 for category sensor-->
-  <!--=============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AP2_Sensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3419706794L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_OUT_AP3_Sensors_sensorConfiguration using level 1 for category sensor-->
-  <!--=============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_OUT_AP3_Sensors_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 373738669L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_C_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_C_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_C_inputNumero</EFDB_Name>
-      <Description>The input number on DIO device where this sensor is plugged on.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_byteNumero</EFDB_Name>
-      <Description>The byte numberwhere the value of this sensor is stored in.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_dioName</EFDB_Name>
-      <Description>The name of the Digital Input Output device where this sensor is plugged on.</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_inputNumero</EFDB_Name>
+      <EFDB_Name>plc_loader_LFS_inputNumero</EFDB_Name>
       <Description>The input number on DIO device where this sensor is plugged on.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
@@ -20252,28 +27728,28 @@
     </item>
     <item>
       <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20284,7 +27760,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 929231928L -->
+    <!--CCS: Dictionary_Checksum: 1092279050L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20294,51 +27770,58 @@
     </item>
     <item>
       <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task heartbeat</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_checkControllers_taskPeriodMillis</EFDB_Name>
+      <Description>period for task main-checkControllers</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>main_updateGui_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task main-updateGui</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-check</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-publish</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task monitor-update</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -20384,12 +27867,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TcpProxy_canbusConfiguration using level 1 for category canbus-->
-  <!--======================================================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_shutter_GeneralConfiguration using level 0 for category General-->
+  <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TcpProxy_canbusConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1263969679L -->
+    <EFDB_Topic>MTCamera_logevent_shutter_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3261627559L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20398,934 +27881,185 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>baud</EFDB_Name>
-      <Description>CANbus rate.</Description>
+      <EFDB_Name>controller_centeringSpeed</EFDB_Name>
+      <Description>Move blade sets at this speed when centering.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_localAMSaddr</EFDB_Name>
+      <Description>Local AMS address used by the subsystem.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>busName</EFDB_Name>
-      <Description>CANbus name. Can be 0 for changer or 1 for loader.</Description>
+      <EFDB_Name>controller_maxHallPositionError</EFDB_Name>
+      <Description>Max allowed difference of a Hall transition position from prediction.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_maxStrokeSpeed</EFDB_Name>
+      <Description>Max speed (to attain during a stroke.</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_minExposureTime</EFDB_Name>
+      <Description>The minimum exposure time.</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>hardwareBootTimeout</EFDB_Name>
-      <Description>A timeout for the hardware booting process</Description>
+      <EFDB_Name>controller_noticeReaderRestartDelay</EFDB_Name>
+      <Description>Restart delay for the notification reader.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_noticeReaderStartupDelay</EFDB_Name>
+      <Description>Startup delay for the notification reader.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_plcAMSaddr</EFDB_Name>
+      <Description>AMS address of the shutter controller.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_plcAckTimeout</EFDB_Name>
+      <Description>Ack timeout for commands sent to the shutter controller.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_plcIPaddr</EFDB_Name>
+      <Description>IP address of the shutter controller.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_referenceMinusXpositions</EFDB_Name>
+      <Description>Reference positions for the -X blade set.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_referencePlusXpositions</EFDB_Name>
+      <Description>Reference positions for the +X blade set.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_safeCtrlTempRange</EFDB_Name>
+      <Description>Safe internal temperature range for motor controller modules.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>controller_safeRtdTempRange</EFDB_Name>
+      <Description>Safe temperature ranges for RTD sites.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_default_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_default_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>publisher_configurationName</EFDB_Name>
+      <Description>The name of the subsystem configuration in effect.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>publisher_publicationInterval</EFDB_Name>
+      <Description>The interval between regular status publications.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>statemachine_resetSyncTimeout</EFDB_Name>
+      <Description>Wait this long for the shutter to enter Still or Disabled after a reset.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>statemachine_taskRestartDelay</EFDB_Name>
+      <Description>How long to delay restarting a crashed long-running task.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>watchdog_checkInterval</EFDB_Name>
+      <Description>The interval between checks of the PLC  message counter.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_shutter_timersConfiguration using level 0 for category timers-->
+  <!--=================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_shutter_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2733398984L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_agentMonitorService_taskPeriodMillis</EFDB_Name>
+      <Description>period for task agentMonitorService</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>masterNodeID</EFDB_Name>
-      <Description>CANbus master nodeID.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <EFDB_Name>periodictasks_heartbeat_taskPeriodMillis</EFDB_Name>
+      <Description>period for task heartbeat</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TcpProxy_controllerConfiguration using level 1 for category controller-->
-  <!--==============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TcpProxy_controllerConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2306965584L -->
     <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminuscontroller_encoderRibbonMinValue</EFDB_Name>
-      <Description>minimal position of the encoder ribbon.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxpluscontroller_encoderRibbonMinValue</EFDB_Name>
-      <Description>minimal position of the encoder ribbon.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselcontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselcontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselcontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampyminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampyminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampyminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TcpProxy_nodeIDConfiguration using level 1 for category nodeID-->
-  <!--======================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TcpProxy_nodeIDConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3278349158L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acsensorsgateway_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminuscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxpluscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>accelerobf_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ai814_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakesystemgateway_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselcontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxminuscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxpluscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>hyttc580_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxminuscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxpluscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxminuscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxpluscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampyminuscontroller_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinestraingauge_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>proximitysensorsdevice_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>pt100_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tempsensorsdevice1_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tempsensorsdevice2_nodeID</EFDB_Name>
-      <Description>CANOpen node ID of this CANOpen device</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TcpProxy_sensorConfiguration using level 1 for category sensor-->
-  <!--======================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TcpProxy_sensorConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2663940816L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ai814_transmissionType</EFDB_Name>
-      <Description>Transmission types for CAN-CBX-AI814 see CAN-CBX-AI814_Manual.pdf § 8.6.2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TcpProxy_serialNBConfiguration using level 1 for category serialNB-->
-  <!--==========================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TcpProxy_serialNBConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4022556748L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acsensorsgateway_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminuscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxpluscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>accelerobf_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ai814_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakesystemgateway_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselcontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxminuscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampxpluscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>hyttc580_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxminuscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>latchxpluscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxminuscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampxpluscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineclampyminuscontroller_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinestraingauge_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>proximitysensorsdevice_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>pt100_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tempsensorsdevice1_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tempsensorsdevice2_serialNB</EFDB_Name>
-      <Description>serial number of this CANOpen device</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempCellXminus_LimitsConfiguration using level 1 for category Limits-->
-  <!--============================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempCellXminus_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4078310962L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempClampMotorXminus_LimitsConfiguration using level 1 for category Limits-->
-  <!--==================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempClampMotorXminus_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 783286486L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempClampMotorXplus_LimitsConfiguration using level 1 for category Limits-->
-  <!--=================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempClampMotorXplus_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2647354981L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempClampMotorYminus_LimitsConfiguration using level 1 for category Limits-->
-  <!--==================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempClampMotorYminus_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4008274764L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempFrontBox_LimitsConfiguration using level 1 for category Limits-->
-  <!--==========================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempFrontBox_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 486346268L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempLinearRailMotorXminus_LimitsConfiguration using level 1 for category Limits-->
-  <!--=======================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempLinearRailMotorXminus_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3818829232L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempLinearRailMotorXplus_LimitsConfiguration using level 1 for category Limits-->
-  <!--======================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempLinearRailMotorXplus_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 524272589L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_TempRearBox_LimitsConfiguration using level 1 for category Limits-->
-  <!--=========================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_fcs_TempRearBox_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4140819218L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
+      <EFDB_Name>periodictasks_runtimeInfo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task runtimeInfo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -21404,7 +28138,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_GeneralConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3538467910L -->
+    <!--CCS: Dictionary_Checksum: 1762377615L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -21441,8 +28175,36 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>glycolCooling</EFDB_Name>
+      <Description>cooling by glycol (true)/water (false)</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>listenTo</EFDB_Name>
       <Description>Which refrig subsystem to listen to (RefrigAgentProperties)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maq20_GlycHeatXfer_flowChanPath</EFDB_Name>
+      <Description>path to flow-rate Channel</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maq20_GlycHeatXfer_inletTChanPath</EFDB_Name>
+      <Description>Path to inlet temperature Channel</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maq20_GlycHeatXfer_outletTChanPath</EFDB_Name>
+      <Description>Path to outlet temperature Channel</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -21493,13 +28255,6 @@
       <EFDB_Name>periodictasks_schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
       <Description>Number of threads assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>requireListening</EFDB_Name>
-      <Description>Require listening to thermal subsystem or equivalent for Normal mode</Description>
-      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -21572,7 +28327,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_timersConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1169918676L -->
+    <!--CCS: Dictionary_Checksum: 1910215140L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -21658,6 +28413,13 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>periodictasks_publishParams_taskPeriodMillis</EFDB_Name>
+      <Description>period for task publishParams</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>periodictasks_runtimeInfo_taskPeriodMillis</EFDB_Name>
       <Description>period for task runtimeInfo</Description>
       <IDL_Type>long long</IDL_Type>
@@ -21674,6 +28436,1283 @@
     <item>
       <EFDB_Name>periodictasks_updateCtrlState_taskPeriodMillis</EFDB_Name>
       <Description>period for task updateCtrlState</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_DeviceConfiguration using level 0 for category Device-->
+  <!--=================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2671311423L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>protrtds_node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rtds_node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rtds_serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_DevicesConfiguration using level 0 for category Devices-->
+  <!--===================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1231670791L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>protrtds_disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rtds_disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_GeneralConfiguration using level 0 for category General-->
+  <!--===================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1114176838L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_chanNames</EFDB_Name>
+      <Description>Path regular expression to select the Channels to be averaged</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_chanWeights</EFDB_Name>
+      <Description>Weights of Channels to be averaged</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_ignoreNaN</EFDB_Name>
+      <Description>if true ignore (omit) NaN channels</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_chanNames</EFDB_Name>
+      <Description>Path regular expression to select the Channels to be averaged</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_chanWeights</EFDB_Name>
+      <Description>Weights of Channels to be averaged</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_ignoreNaN</EFDB_Name>
+      <Description>if true ignore (omit) NaN channels</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_default_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_default_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_monitor_check_scheduler_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_monitor_check_scheduler_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_LimitsConfiguration using level 0 for category Limits-->
+  <!--=================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 36497739L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_warnHi</EFDB_Name>
+      <Description>Average Cold Plate RTD Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_warnLo</EFDB_Name>
+      <Description>Average Cold Plate RTD Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_limitHi</EFDB_Name>
+      <Description>Average Cold Plate RTD Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_Temp_AvgColdTemp_limitLo</EFDB_Name>
+      <Description>Average Cold Plate RTD Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_warnHi</EFDB_Name>
+      <Description>Average Cryo Plate RTD Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_warnLo</EFDB_Name>
+      <Description>Average Cryo Plate RTD Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_limitHi</EFDB_Name>
+      <Description>Average Cryo Plate RTD Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Temp_AvgCryoTemp_limitLo</EFDB_Name>
+      <Description>Average Cryo Plate RTD Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rtdLocation</EFDB_Name>
+      <Description>rtd location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cold_Temp_warnHi indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cold_Temp_warnHi</EFDB_Name>
+      <Description>Cold Plate RTD 00 high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cold_Temp_warnLo indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cold_Temp_warnLo</EFDB_Name>
+      <Description>Cold Plate RTD 00 low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cold_Temp_limitHi indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cold_Temp_limitHi</EFDB_Name>
+      <Description>Cold Plate RTD 00 high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cold_Temp_limitLo indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cold_Temp_limitLo</EFDB_Name>
+      <Description>Cold Plate RTD 00 low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cryo_Temp_warnHi indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cryo_Temp_warnHi</EFDB_Name>
+      <Description>Cryo Plate RTD 02 high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cryo_Temp_warnLo indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cryo_Temp_warnLo</EFDB_Name>
+      <Description>Cryo Plate RTD 02 low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cryo_Temp_limitHi indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cryo_Temp_limitHi</EFDB_Name>
+      <Description>Cryo Plate RTD 02 high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Cryo_Temp_limitLo indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Cryo_Temp_limitLo</EFDB_Name>
+      <Description>Cryo Plate RTD 02 low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Grid_Temp_warnHi indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Grid_Temp_warnHi</EFDB_Name>
+      <Description>Cryo Flexure RTD 01 high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Grid_Temp_warnLo indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Grid_Temp_warnLo</EFDB_Name>
+      <Description>Cryo Flexure RTD 01 low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Grid_Temp_limitHi indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Grid_Temp_limitHi</EFDB_Name>
+      <Description>Cryo Flexure RTD 01 high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array rtd_Grid_Temp_limitLo indexed by rtdLocation-->
+    <item>
+      <EFDB_Name>rtd_Grid_Temp_limitLo</EFDB_Name>
+      <Description>Cryo Flexure RTD 01 low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimLocation</EFDB_Name>
+      <Description>trim location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_ColdTotal_P_warnHi</EFDB_Name>
+      <Description>Cold Total Power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_ColdTotal_P_warnLo</EFDB_Name>
+      <Description>Cold Total Power low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_ColdTotal_P_limitHi</EFDB_Name>
+      <Description>Cold Total Power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_ColdTotal_P_limitLo</EFDB_Name>
+      <Description>Cold Total Power low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_CryoTotal_P_warnHi</EFDB_Name>
+      <Description>Cryo Total Power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_CryoTotal_P_warnLo</EFDB_Name>
+      <Description>Cryo Total Power low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_CryoTotal_P_limitHi</EFDB_Name>
+      <Description>Cryo Total Power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_CryoTotal_P_limitLo</EFDB_Name>
+      <Description>Cryo Total Power low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulkTmp_warnHi</EFDB_Name>
+      <Description>Heater Bulk PS Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulkTmp_warnLo</EFDB_Name>
+      <Description>Heater Bulk PS Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulkTmp_limitHi</EFDB_Name>
+      <Description>Heater Bulk PS Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulkTmp_limitLo</EFDB_Name>
+      <Description>Heater Bulk PS Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_I_warnHi</EFDB_Name>
+      <Description>Heater Bulk PS Current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_I_warnLo</EFDB_Name>
+      <Description>Heater Bulk PS Current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_I_limitHi</EFDB_Name>
+      <Description>Heater Bulk PS Current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_I_limitLo</EFDB_Name>
+      <Description>Heater Bulk PS Current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_P_warnHi</EFDB_Name>
+      <Description>Heater Bulk PS Power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_P_warnLo</EFDB_Name>
+      <Description>Heater Bulk PS Power low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_P_limitHi</EFDB_Name>
+      <Description>Heater Bulk PS Power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_P_limitLo</EFDB_Name>
+      <Description>Heater Bulk PS Power low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_V_warnHi</EFDB_Name>
+      <Description>Heater Bulk PS Voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_V_warnLo</EFDB_Name>
+      <Description>Heater Bulk PS Voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_V_limitHi</EFDB_Name>
+      <Description>Heater Bulk PS Voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrBulk_V_limitLo</EFDB_Name>
+      <Description>Heater Bulk PS Voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrPsTmp_warnHi</EFDB_Name>
+      <Description>Heater PS Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrPsTmp_warnLo</EFDB_Name>
+      <Description>Heater PS Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrPsTmp_limitHi</EFDB_Name>
+      <Description>Heater PS Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trim_Htrs_HtrPsTmp_limitLo</EFDB_Name>
+      <Description>Heater PS Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_I_warnHi indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_I_warnHi</EFDB_Name>
+      <Description>Cold Heater 0 Current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_I_warnLo indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_I_warnLo</EFDB_Name>
+      <Description>Cold Heater 0 Current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_I_limitHi indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_I_limitHi</EFDB_Name>
+      <Description>Cold Heater 0 Current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_I_limitLo indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_I_limitLo</EFDB_Name>
+      <Description>Cold Heater 0 Current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_P_warnHi indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_P_warnHi</EFDB_Name>
+      <Description>Cold Heater 0 Power high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_P_warnLo indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_P_warnLo</EFDB_Name>
+      <Description>Cold Heater 0 Power low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_P_limitHi indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_P_limitHi</EFDB_Name>
+      <Description>Cold Heater 0 Power high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_P_limitLo indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_P_limitLo</EFDB_Name>
+      <Description>Cold Heater 0 Power low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_V_warnHi indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_V_warnHi</EFDB_Name>
+      <Description>Cold Heater 0 Voltage high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_V_warnLo indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_V_warnLo</EFDB_Name>
+      <Description>Cold Heater 0 Voltage low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_V_limitHi indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_V_limitHi</EFDB_Name>
+      <Description>Cold Heater 0 Voltage high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Trim_Htrs_V_limitLo indexed by trimLocation-->
+    <item>
+      <EFDB_Name>trim_Trim_Htrs_V_limitLo</EFDB_Name>
+      <Description>Cold Heater 0 Voltage low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>12</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_PicConfiguration using level 0 for category Pic-->
+  <!--===========================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_PicConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 910380493L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_basePower</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_maxOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_minOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_basePower</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_maxOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_minOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_basePower</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_maxOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_minOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_basePower</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_maxOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_minOutput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_ColdTempCtrlC_iterate_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_ColdTempCtrlMYE_iterate_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_ColdTempCtrlPYE_iterate_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_CryoTempCtrl_iterate_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_RefrigConfiguration using level 0 for category Refrig-->
+  <!--=================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_RefrigConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1746649997L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_tempDeadband</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_tempLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlc_tempWeights</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_tempDeadband</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_tempLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlmye_tempWeights</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_tempDeadband</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_tempLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldtempctrlpye_tempWeights</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_tempDeadband</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_tempLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryotempctrl_tempWeights</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_coldPowerWeights</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_connType</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_cryoPowerWeights</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_devcId</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_devcParm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>trimpower_node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_ThermalLimitsConfiguration using level 0 for category ThermalLimits-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_ThermalLimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2027611568L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldTempLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coldTempLowLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryoTempLowLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_timersConfiguration using level 0 for category timers-->
+  <!--=================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_thermal_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2606706814L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_ColdTempCtrlC_tempCheck_taskPeriodMillis</EFDB_Name>
+      <Description>period for task ColdTempCtrlC-tempCheck</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_ColdTempCtrlMYE_tempCheck_taskPeriodMillis</EFDB_Name>
+      <Description>period for task ColdTempCtrlMYE-tempCheck</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_ColdTempCtrlPYE_tempCheck_taskPeriodMillis</EFDB_Name>
+      <Description>period for task ColdTempCtrlPYE-tempCheck</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_CryoTempCtrl_tempCheck_taskPeriodMillis</EFDB_Name>
+      <Description>period for task CryoTempCtrl-tempCheck</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_agentMonitorService_taskPeriodMillis</EFDB_Name>
+      <Description>period for task agentMonitorService</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_heartbeat_taskPeriodMillis</EFDB_Name>
+      <Description>period for task heartbeat</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_maintain_power_TrimPower_taskPeriodMillis</EFDB_Name>
+      <Description>period for task maintain-power-TrimPower</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_check_ProtRtds_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/ProtRtds</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_check_Rtds_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/Rtds</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_check_TrimPower_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check/TrimPower</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_publish_avgTemp_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/avgTemp</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_publish_coldTemp_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish/coldTemp</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_publish_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_update_avgTemp_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/avgTemp</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_update_coldTemp_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update/coldTemp</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_monitor_update_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_runtimeInfo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task runtimeInfo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>periodictasks_thermal_state_taskPeriodMillis</EFDB_Name>
+      <Description>period for task thermal-state</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>ms</Units>
       <Count>1</Count>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -5,7 +5,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_BFR</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2878214622L -->
+    <!--CCS: Dictionary_Checksum: 3156915507L -->
     <item>
       <EFDB_Name>clean_5_24V_I</EFDB_Name>
       <Description>Clean 5 and 24V current</Description>
@@ -30,13 +30,6 @@
     <item>
       <EFDB_Name>dirty_48V_I</EFDB_Name>
       <Description>Dirty 48V current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>heater_I</EFDB_Name>
-      <Description>Heater current</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
@@ -89,82 +82,89 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_24VC</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1459569460L -->
+    <!--CCS: Dictionary_Checksum: 3981611484L -->
     <item>
-      <EFDB_Name>n_24vc_Board_T</EFDB_Name>
+      <EFDB_Name>board_T</EFDB_Name>
       <Description>24V Clean PDU board temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_24vc_FPGA_T</EFDB_Name>
+      <EFDB_Name>body_Maq20_I</EFDB_Name>
+      <Description>Body MAQ20 current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>body_Maq20_V</EFDB_Name>
+      <Description>Body MAQ20 voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_I</EFDB_Name>
+      <Description>Cryostat MAQ20 current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryo_Maq20_V</EFDB_Name>
+      <Description>Cryostat MAQ20 voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_I</EFDB_Name>
+      <Description>FES carouselC current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselC_V</EFDB_Name>
+      <Description>FES carouselC voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_I</EFDB_Name>
+      <Description>FES changerC current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerC_V</EFDB_Name>
+      <Description>FES changerC voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_I</EFDB_Name>
+      <Description>FES loaderC current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderC_V</EFDB_Name>
+      <Description>FES loaderC voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T</EFDB_Name>
       <Description>24V Clean PDU FPGA temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_I</EFDB_Name>
-      <Description>24V Clean PDU main current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_T</EFDB_Name>
-      <Description>24V Clean PDU main temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vc_Main_V</EFDB_Name>
-      <Description>24V Clean PDU main voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_I</EFDB_Name>
-      <Description>Body purge current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>body_Purge_V</EFDB_Name>
-      <Description>Body purge voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_I</EFDB_Name>
-      <Description>Body purge MAQ20 current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>bpu_Maq20_V</EFDB_Name>
-      <Description>Body purge MAQ20 voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_I</EFDB_Name>
-      <Description>FES/shutter HCU current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fes_Shu_HCU_V</EFDB_Name>
-      <Description>FES/shutter HCU voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -177,6 +177,20 @@
     <item>
       <EFDB_Name>gauges_V</EFDB_Name>
       <Description>Gauges voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_I</EFDB_Name>
+      <Description>Interstitial valves current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>int_Valves_V</EFDB_Name>
+      <Description>Interstitial valves voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -196,15 +210,50 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_I</EFDB_Name>
-      <Description>Power/cryo HCU current</Description>
+      <EFDB_Name>main_I</EFDB_Name>
+      <Description>24V Clean PDU main current</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pwr_Cry_HCU_V</EFDB_Name>
-      <Description>Power/cryo HCU voltage</Description>
+      <EFDB_Name>main_T</EFDB_Name>
+      <Description>24V Clean PDU main temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V</EFDB_Name>
+      <Description>24V Clean PDU main voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_I</EFDB_Name>
+      <Description>Shutter PLC 1 current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC1_V</EFDB_Name>
+      <Description>Shutter PLC 1 voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_I</EFDB_Name>
+      <Description>Shutter PLC 2 current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_PLC2_V</EFDB_Name>
+      <Description>Shutter PLC 2 voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -215,40 +264,12 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_24VD</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 185595877L -->
+    <!--CCS: Dictionary_Checksum: 1245527488L -->
     <item>
-      <EFDB_Name>n_24vd_Board_T</EFDB_Name>
+      <EFDB_Name>board_T</EFDB_Name>
       <Description>24V Dirty PDU board temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_FPGA_T</EFDB_Name>
-      <Description>24V Dirty PDU FPGA temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_I</EFDB_Name>
-      <Description>24V Dirty PDU main current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_T</EFDB_Name>
-      <Description>24V Dirty PDU main temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>n_24vd_Main_V</EFDB_Name>
-      <Description>24V Dirty PDU main voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -266,6 +287,69 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>fes_Brakes_I</EFDB_Name>
+      <Description>FES brakes current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Brakes_V</EFDB_Name>
+      <Description>FES brakes voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_I</EFDB_Name>
+      <Description>FES changerD current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_ChangerD_V</EFDB_Name>
+      <Description>FES changerD voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_I</EFDB_Name>
+      <Description>FES clamps current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Clamps_V</EFDB_Name>
+      <Description>FES clamps voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_I</EFDB_Name>
+      <Description>FES loaderD current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_LoaderD_V</EFDB_Name>
+      <Description>FES loaderD voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T</EFDB_Name>
+      <Description>24V Dirty PDU FPGA temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>hex_Turbo_I</EFDB_Name>
       <Description>Hex turbo pump current</Description>
       <IDL_Type>double</IDL_Type>
@@ -279,43 +363,106 @@
       <Units>Volt</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>main_I</EFDB_Name>
+      <Description>24V Dirty PDU main current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_T</EFDB_Name>
+      <Description>24V Dirty PDU main temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>main_V</EFDB_Name>
+      <Description>24V Dirty PDU main voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_I</EFDB_Name>
+      <Description>Shutter brakes current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Brakes_V</EFDB_Name>
+      <Description>Shutter brakes voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
   </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_quadbox_PDU_48V using level 1-->
   <!--========================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_48V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 844609743L -->
+    <!--CCS: Dictionary_Checksum: 202661958L -->
     <item>
-      <EFDB_Name>n_48v_Board_T</EFDB_Name>
+      <EFDB_Name>board_T</EFDB_Name>
       <Description>48V PDU board temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_FPGA_T</EFDB_Name>
+      <EFDB_Name>fes_CarouselD_I</EFDB_Name>
+      <Description>FES carouselD current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_CarouselD_V</EFDB_Name>
+      <Description>FES carouselD voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_I</EFDB_Name>
+      <Description>FES heater current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fes_Heater_V</EFDB_Name>
+      <Description>FES heater voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fpga_T</EFDB_Name>
       <Description>48V PDU FPGA temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_I</EFDB_Name>
+      <EFDB_Name>main_I</EFDB_Name>
       <Description>48V PDU main current</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_T</EFDB_Name>
+      <EFDB_Name>main_T</EFDB_Name>
       <Description>48V PDU main temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>n_48v_Main_V</EFDB_Name>
+      <EFDB_Name>main_V</EFDB_Name>
       <Description>48V PDU main voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
@@ -331,6 +478,34 @@
     <item>
       <EFDB_Name>purge_Fan_V</EFDB_Name>
       <Description>Purge fan voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_I</EFDB_Name>
+      <Description>Shutter motor 1 current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor1_V</EFDB_Name>
+      <Description>Shutter motor 1 voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_I</EFDB_Name>
+      <Description>Shutter motor 2 current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtr_Motor2_V</EFDB_Name>
+      <Description>Shutter motor 2 voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
       <Count>1</Count>
@@ -614,7 +789,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Reb</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 72957452L -->
+    <!--CCS: Dictionary_Checksum: 3712155700L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO</EFDB_Name>
@@ -943,12 +1118,26 @@
       <Count>71</Count>
     </item>
   </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_rebpower_RebTotalPower using level 1-->
+  <!--===============================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_rebpower_RebTotalPower</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4179052400L -->
+    <item>
+      <EFDB_Name>rebTotalPower</EFDB_Name>
+      <Description>Reb Total Power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_rebpower_Rebps using level 1-->
   <!--=======================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Rebps</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 283005396L -->
+    <!--CCS: Dictionary_Checksum: 2375833259L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
       <EFDB_Name>boardTemp0</EFDB_Name>
@@ -1001,6 +1190,14 @@
     <item>
       <EFDB_Name>boardTemp6</EFDB_Name>
       <Description>Board temperature 6</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>13</Count>
+    </item>
+    <!--CCSMETA: Array fPGATemp indexed by location-->
+    <item>
+      <EFDB_Name>fPGATemp</EFDB_Name>
+      <Description>FPGA temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>13</Count>
@@ -2259,180 +2456,97 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP1_I using level 1-->
-  <!--======================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_Cip using level 1-->
+  <!--===================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP1_I</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3377731400L -->
+    <EFDB_Topic>MTCamera_vacuum_Cip</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 628322291L -->
+    <!--CCSMETA: Array cryo_I indexed by location-->
     <item>
-      <EFDB_Name>cip1_I</EFDB_Name>
+      <EFDB_Name>cryo_I</EFDB_Name>
       <Description>Cryo ion pump 1 current</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>1</Count>
+      <Count>6</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP1_V using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP1_V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3445606188L -->
+    <!--CCSMETA: Array cryo_Life indexed by location-->
     <item>
-      <EFDB_Name>cip1_V</EFDB_Name>
+      <EFDB_Name>cryo_Life</EFDB_Name>
+      <Description>Cryo ion pump 1 lifetime</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Usage indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Usage</EFDB_Name>
+      <Description>Cryo ion pump 1 usage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array cryo_V indexed by location-->
+    <item>
+      <EFDB_Name>cryo_V</EFDB_Name>
       <Description>Cryo ion pump 1 voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>1</Count>
+      <Count>6</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP2_I using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP2_I</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1700513562L -->
+    <!--CCSMETA: Array hx_I indexed by location-->
     <item>
-      <EFDB_Name>cip2_I</EFDB_Name>
-      <Description>Cryo ion pump 2 current</Description>
+      <EFDB_Name>hx_I</EFDB_Name>
+      <Description>HX ion pump 1 current</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
-      <Count>1</Count>
+      <Count>6</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP2_V using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP2_V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1632638846L -->
+    <!--CCSMETA: Array hx_Life indexed by location-->
     <item>
-      <EFDB_Name>cip2_V</EFDB_Name>
-      <Description>Cryo ion pump 2 voltage</Description>
+      <EFDB_Name>hx_Life</EFDB_Name>
+      <Description>HX ion pump 1 lifetime</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_Usage indexed by location-->
+    <item>
+      <EFDB_Name>hx_Usage</EFDB_Name>
+      <Description>HX ion pump 1 usage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>6</Count>
+    </item>
+    <!--CCSMETA: Array hx_V indexed by location-->
+    <item>
+      <EFDB_Name>hx_V</EFDB_Name>
+      <Description>HX ion pump 1 voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
-      <Count>1</Count>
+      <Count>6</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP3_I using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP3_I</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 22972628L -->
     <item>
-      <EFDB_Name>cip3_I</EFDB_Name>
-      <Description>Cryo ion pump 3 current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>cip location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP3_V using level 1-->
-  <!--======================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_Cryo using level 1-->
+  <!--====================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP3_V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 89479344L -->
+    <EFDB_Topic>MTCamera_vacuum_Cryo</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 107569487L -->
     <item>
-      <EFDB_Name>cip3_V</EFDB_Name>
-      <Description>Cryo ion pump 3 voltage</Description>
+      <EFDB_Name>airPressure</EFDB_Name>
+      <Description>UT compressed air pressure</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
+      <Units>psig</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP4_I using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP4_I</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3862258175L -->
-    <item>
-      <EFDB_Name>cip4_I</EFDB_Name>
-      <Description>Cryo ion pump 4 current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP4_V using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP4_V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3795759515L -->
-    <item>
-      <EFDB_Name>cip4_V</EFDB_Name>
-      <Description>Cryo ion pump 4 voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP5_I using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP5_I</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2184195633L -->
-    <item>
-      <EFDB_Name>cip5_I</EFDB_Name>
-      <Description>Cryo ion pump 5 current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP5_V using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP5_V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2252078677L -->
-    <item>
-      <EFDB_Name>cip5_V</EFDB_Name>
-      <Description>Cryo ion pump 5 voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP6_I using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP6_I</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 775945827L -->
-    <item>
-      <EFDB_Name>cip6_I</EFDB_Name>
-      <Description>Cryo ion pump 6 current</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CIP6_V using level 1-->
-  <!--======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CIP6_V</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 708062727L -->
-    <item>
-      <EFDB_Name>cip6_V</EFDB_Name>
-      <Description>Cryo ion pump 6 voltage</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Volt</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_CryoVac using level 1-->
-  <!--=======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_CryoVac</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3986274856L -->
     <item>
       <EFDB_Name>cryoVac</EFDB_Name>
       <Description>Cryostat vacuum</Description>
@@ -2440,13 +2554,27 @@
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_ForelineVac using level 1-->
-  <!--===========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_ForelineVac</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3015630784L -->
+    <item>
+      <EFDB_Name>flineCurrent</EFDB_Name>
+      <Description>Cryo foreline pump current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinePower</EFDB_Name>
+      <Description>Cryo foreline pump power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flineVoltage</EFDB_Name>
+      <Description>Cryo foreline pump voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>forelineVac</EFDB_Name>
       <Description>Foreline pump vacuum</Description>
@@ -2454,97 +2582,69 @@
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_Hex1Vac using level 1-->
-  <!--=======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_Hex1Vac</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3004044124L -->
     <item>
-      <EFDB_Name>hex1Vac</EFDB_Name>
-      <Description>Heat exchanger 1 vacuum</Description>
+      <EFDB_Name>gaugeDose</EFDB_Name>
+      <Description>Cryostat vacuum gauge pressure dose</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpCartPressure</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_Hex2Vac using level 1-->
-  <!--=======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_Hex2Vac</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1996811375L -->
-    <item>
-      <EFDB_Name>hex2Vac</EFDB_Name>
-      <Description>Heat exchanger 2 vacuum</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Torr</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_TurboCurrent using level 1-->
-  <!--============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_TurboCurrent</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 712557024L -->
     <item>
       <EFDB_Name>turboCurrent</EFDB_Name>
-      <Description>TurboPump current</Description>
+      <Description>Cryo turbo pump current</Description>
       <IDL_Type>double</IDL_Type>
       <Units>mA</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_TurboPower using level 1-->
-  <!--==========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_TurboPower</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 276285080L -->
+    <item>
+      <EFDB_Name>turboGaugeDose</EFDB_Name>
+      <Description>Cryostat turbo vacuum gauge pressure dose</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboHours</EFDB_Name>
+      <Description>Cryo turbo pump hours</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>turboPower</EFDB_Name>
-      <Description>TurboPump power</Description>
+      <Description>Cryo turbo pump power</Description>
       <IDL_Type>double</IDL_Type>
       <Units>W</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_TurboPumpTemp using level 1-->
-  <!--=============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_TurboPumpTemp</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3365989911L -->
     <item>
-      <EFDB_Name>turboPumpTemp</EFDB_Name>
-      <Description>TurboPump pump temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>deg C</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_TurboSpeed using level 1-->
-  <!--==========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_TurboSpeed</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3054233021L -->
-    <item>
-      <EFDB_Name>turboSpeed</EFDB_Name>
-      <Description>Turbo pump speed (RPM)</Description>
+      <EFDB_Name>turboPumpStatus</EFDB_Name>
+      <Description>Cryo turbo pump status</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_TurboVac using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_TurboVac</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1282131722L -->
+    <item>
+      <EFDB_Name>turboPumpTemp</EFDB_Name>
+      <Description>Cryo turbo pump temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboSpeed</EFDB_Name>
+      <Description>Cryo turbo pump speed (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>turboVac</EFDB_Name>
       <Description>Turbo pump vacuum</Description>
@@ -2552,18 +2652,214 @@
       <Units>Torr</Units>
       <Count>1</Count>
     </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_TurboVoltage using level 1-->
-  <!--============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_vacuum_TurboVoltage</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3029650990L -->
     <item>
       <EFDB_Name>turboVoltage</EFDB_Name>
-      <Description>TurboPump voltage</Description>
+      <Description>Cryo turbo pump voltage</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_HX using level 1-->
+  <!--==================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_vacuum_HX</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4189470899L -->
+    <item>
+      <EFDB_Name>airPressure</EFDB_Name>
+      <Description>UT compressed air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flineCurrent</EFDB_Name>
+      <Description>HX foreline pump current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinePower</EFDB_Name>
+      <Description>HX foreline pump power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flineVoltage</EFDB_Name>
+      <Description>HX foreline pump voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forelineVac</EFDB_Name>
+      <Description>HX foreline pump vacuum</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gaugeDose</EFDB_Name>
+      <Description>HX vacuum gauge pressure dose</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hexVac</EFDB_Name>
+      <Description>Heat exchanger vacuum</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpCartPressure</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboCurrent</EFDB_Name>
+      <Description>HX turbo pump current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboGaugeDose</EFDB_Name>
+      <Description>HX turbo vacuum gauge pressure dose</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr.hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboHours</EFDB_Name>
+      <Description>HX turbo pump hours</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboPower</EFDB_Name>
+      <Description>HX turbo pump power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>W</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboPumpStatus</EFDB_Name>
+      <Description>HX turbo pump status</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboPumpTemp</EFDB_Name>
+      <Description>HX turbo pump temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboSpeed</EFDB_Name>
+      <Description>HX turbo pump speed (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboVac</EFDB_Name>
+      <Description>HX turbo pump vacuum</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>turboVoltage</EFDB_Name>
+      <Description>HX turbo pump voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_vacuum_Inst using level 1-->
+  <!--====================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_vacuum_Inst</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2581776088L -->
+    <item>
+      <EFDB_Name>cryoFlineValveState</EFDB_Name>
+      <Description>Cryo Foreline Valve Limit Switches State</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flineCurrent</EFDB_Name>
+      <Description>Inst foreline pump current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flinePower</EFDB_Name>
+      <Description>Inst foreline pump power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flineVoltage</EFDB_Name>
+      <Description>Inst foreline pump voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hxFlineValveState</EFDB_Name>
+      <Description>HX Foreline Valve Limit Switches State</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>instVac</EFDB_Name>
+      <Description>Interstitial vacuum</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpCartCycling</EFDB_Name>
+      <Description>Pump Cart Cycling Status</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpCartPressure</EFDB_Name>
+      <Description>Pump Cart Inlet Pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Torr</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpCartTemperature</EFDB_Name>
+      <Description>Pump Cart Temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>deg C</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pumpCartVenting</EFDB_Name>
+      <Description>Pump Cart Venting Status</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -3712,2745 +4008,6511 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_AcSensorsGateway using level 1-->
-  <!--=============================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_AutochangerTrucks_Trending using level 2 for category Trending-->
+  <!--=========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_AcSensorsGateway</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 434637041L -->
+    <EFDB_Topic>MTCamera_fcs_Autochanger_AutochangerTrucks_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1312796863L -->
     <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxminus_handoffInError</EFDB_Name>
+      <Description>are autochanger truck position sensors at handoff in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxminus_handoffSensorValue</EFDB_Name>
+      <Description>is the autochanger truck at handoff position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>intValues</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_AcTruckXminus using level 1-->
-  <!--==========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_AcTruckXminus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4132836703L -->
-    <item>
-      <EFDB_Name>averageCurrent</EFDB_Name>
-      <Description>average current read on AC truck controller : index 0x2027</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>followingError</EFDB_Name>
-      <Description>following error read on AC truck controller : index 0x20F4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffInError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxminus_onlineInError</EFDB_Name>
+      <Description>are autochanger truck position sensors at online in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>handoffSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxminus_onlineSensorValue</EFDB_Name>
+      <Description>is the autochanger truck at online position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>onlineInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position of this AC truck along Linear Rails</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbySensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_AcTruckXminusController using level 1-->
-  <!--====================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_AcTruckXminusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 969114237L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <EFDB_Name>actruckxminus_position</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxminus_standbyInError</EFDB_Name>
+      <Description>are autochanger truck position sensors at standby in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxminus_standbySensorValue</EFDB_Name>
+      <Description>is the autochanger truck at standby position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <EFDB_Name>actruckxplus_handoffInError</EFDB_Name>
+      <Description>are autochanger truck position sensors at handoff in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxplus_handoffSensorValue</EFDB_Name>
+      <Description>is the autochanger truck at handoff position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxplus_onlineInError</EFDB_Name>
+      <Description>are autochanger truck position sensors at online in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxplus_onlineSensorValue</EFDB_Name>
+      <Description>is the autochanger truck at online position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>actruckxplus_position</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_AcTruckXplus using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_AcTruckXplus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 83399290L -->
-    <item>
-      <EFDB_Name>averageCurrent</EFDB_Name>
-      <Description>average current read on AC truck controller : index 0x2027</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>followingError</EFDB_Name>
-      <Description>following error read on AC truck controller : index 0x20F4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffInError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxplus_standbyInError</EFDB_Name>
+      <Description>are autochanger truck position sensors at standby in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>handoffSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>actruckxplus_standbySensorValue</EFDB_Name>
+      <Description>is the autochanger truck at standby position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
-    <item>
-      <EFDB_Name>onlineInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position of this AC truck along Linear Rails</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbySensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_AcTruckXplusController using level 1-->
-  <!--===================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_AcTruckXplusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1309349700L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Accelerobf using level 1-->
-  <!--=======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Accelerobf</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2384180315L -->
-    <item>
-      <EFDB_Name>accelerationX</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>accelerationY</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>accelerationZ</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>angularVelocityX</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>angularVelocityY</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>angularVelocityZ</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Ai814 using level 1-->
-  <!--==================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Ai814</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3850736691L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Autochanger</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2876594363L -->
-    <item>
-      <EFDB_Name>carouselHoldingFilter</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselHoldingFilterInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF0</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF0_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF1_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CS</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CS_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableClamps</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableLatches</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableRailLin1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableRailLin2</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringKey</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inclinaisonXminus</EFDB_Name>
-      <Description>inclinaison returned by inclinometerXminus</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>degree</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inclinaisonXplus</EFDB_Name>
-      <Description>inclinaison returned by inclinometerXplus</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>degree</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderConnectedSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderConnectedSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderPresence</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderPresenceInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LRH_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockOut</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockOutInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockOutShunt</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AIN</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AOL</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_AutochangerTrucks using level 1-->
-  <!--==============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_AutochangerTrucks</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1120843597L -->
     <item>
       <EFDB_Name>atHandoff</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>both autochanger trucks are at handoff position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>atOnline</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>both autochanger trucks are at online position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>both autochanger trucks are at standby position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>driverPosition</EFDB_Name>
+      <Description>position of autochanger driver truck along linear rails</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followerPosition</EFDB_Name>
+      <Description>position of autochanger follower truck along linear rails</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>homing on both autochanger truck controllers is done</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>autochanger trucks position sensors are in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>masterPosition</EFDB_Name>
-      <Description>position of AC master truck along Linear Rails</Description>
+      <EFDB_Name>proximityDistance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>proximityVoltage</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Latches_Trending using level 2 for category Trending-->
+  <!--===============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Autochanger_Latches_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3276996158L -->
+    <item>
+      <EFDB_Name>filterId</EFDB_Name>
+      <Description>ID of filter on autochanger trucks</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterName</EFDB_Name>
+      <Description>name of filter on autochanger trucks</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterPresenceStatus</EFDB_Name>
+      <Description>autochanger latches filter presence status {ENGAGED; NO_FILTER; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_filterEngagedSensorsInError</EFDB_Name>
+      <Description>are autochanger filter engaged sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_filterPresenceSensorValue</EFDB_Name>
+      <Description>is a filter detected by the autochanger latch sensors</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_inError</EFDB_Name>
+      <Description>are autochanger latch sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_lockSensorValue</EFDB_Name>
+      <Description>is the autochanger latch locked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_lockSensorsInError</EFDB_Name>
+      <Description>are autochanger lock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_lockStatus</EFDB_Name>
+      <Description>autochanger latch lockStatus {OPENED; CLOSED; IN_TRAVEL; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_unlockSensorValue</EFDB_Name>
+      <Description>is the autochanger latch unlocked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxminus_unlockSensorsInError</EFDB_Name>
+      <Description>are autochanger unlock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_filterEngagedSensorsInError</EFDB_Name>
+      <Description>are autochanger filter engaged sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_filterPresenceSensorValue</EFDB_Name>
+      <Description>is a filter detected by the autochanger latch sensors</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_inError</EFDB_Name>
+      <Description>are autochanger latch sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_lockSensorValue</EFDB_Name>
+      <Description>is the autochanger latch locked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_lockSensorsInError</EFDB_Name>
+      <Description>are autochanger lock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_lockStatus</EFDB_Name>
+      <Description>autochanger latch lockStatus {OPENED; CLOSED; IN_TRAVEL; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_unlockSensorValue</EFDB_Name>
+      <Description>is the autochanger latch unlocked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latchxplus_unlockSensorsInError</EFDB_Name>
+      <Description>are autochanger unlock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockStatus</EFDB_Name>
+      <Description>autochanger latches lockStatus {OPENED; CLOSED; IN_TRAVEL; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_OnlineClamps_Trending using level 2 for category Trending-->
+  <!--====================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Autochanger_OnlineClamps_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2370309370L -->
+    <item>
+      <EFDB_Name>lockStatus</EFDB_Name>
+      <Description>autochanger three online clamps lockStatus {OPENED; CLOSED; LOCKED; IN_TRAVEL; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampRawStrain</EFDB_Name>
+      <Description>raw strain gauge value read on onlineClampXplus. It measures the clamps deformation and is used for the computation of the onlineClampStrain value.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mV</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampStrain</EFDB_Name>
+      <Description>normalized strain value computed from onlineClampRawStrain and Xplus motor temperature. It gives the force on the clamp to know if a clamp is clamped or closed. Gauge factor : 2.07 Wheatstone bridge</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>m/m</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_inError</EFDB_Name>
+      <Description>are autochanger online clamp sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_lockSensorInError</EFDB_Name>
+      <Description>are autochanger online clamp lock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_lockSensorValue</EFDB_Name>
+      <Description>is autochanger online clamp locked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_lockStatus</EFDB_Name>
+      <Description>autochanger online clamp lockStatus</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_sentCurrent</EFDB_Name>
+      <Description>last current sent to the controller of this online clamp </Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_unlockSensorInError</EFDB_Name>
+      <Description>are autochanger online clamp unlock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxminus_unlockSensorValue</EFDB_Name>
+      <Description>is autochanger online clamp unlocked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_inError</EFDB_Name>
+      <Description>are autochanger online clamp sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_lockSensorInError</EFDB_Name>
+      <Description>are autochanger online clamp lock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_lockSensorValue</EFDB_Name>
+      <Description>is autochanger online clamp locked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_lockStatus</EFDB_Name>
+      <Description>autochanger online clamp lockStatus</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_sentCurrent</EFDB_Name>
+      <Description>last current sent to the controller of this online clamp </Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_unlockSensorInError</EFDB_Name>
+      <Description>are autochanger online clamp unlock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampxplus_unlockSensorValue</EFDB_Name>
+      <Description>is autochanger online clamp unlocked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_inError</EFDB_Name>
+      <Description>are autochanger online clamp sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_lockSensorInError</EFDB_Name>
+      <Description>are autochanger online clamp lock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_lockSensorValue</EFDB_Name>
+      <Description>is autochanger online clamp locked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_lockStatus</EFDB_Name>
+      <Description>autochanger online clamp lockStatus</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_sentCurrent</EFDB_Name>
+      <Description>last current sent to the controller of this online clamp </Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_unlockSensorInError</EFDB_Name>
+      <Description>are autochanger online clamp unlock sensors in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclampyminus_unlockSensorValue</EFDB_Name>
+      <Description>is autochanger online clamp unlocked</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Temperatures using level 2-->
+  <!--=====================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Autochanger_Temperatures</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1800035090L -->
+    <item>
+      <EFDB_Name>tempCellXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempClampMotorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempClampMotorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempClampMotorYminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempFrontBox</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempLinearRailMotorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempLinearRailMotorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tempRearBox</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcSensorsGateway_Trending using level 2 for category Trending-->
+  <!--====================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_AcSensorsGateway_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 454556600L -->
+    <item>
+      <EFDB_Name>acAF0b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF0s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF1b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF1s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF3b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF3s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAP2b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAP2s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselHoldingFilterSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselHoldingFilterSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselStoppedAtStandby</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselStoppedAtStandbyC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF0_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>engineeringKey</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>engineeringkey_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor5</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forceSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forceSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inclinometerXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inclinometerXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyEng</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyEngb</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyLock</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyLockb</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lps_0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lps_1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lrh_0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lrh_1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCarrierRelayStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderChainPresenceSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderConnectedSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderConnectedSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderDefaultStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderEngagedPositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderEngagedPositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterDistanceSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterGoodPositionStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterPresenceSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterPresenceSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHandoffPositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHandoffPositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHoldingFilterSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHoldingFilterSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHooksRelayStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOnCameraSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOnCameraSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderStoragePositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderStoragePositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loader_LFD</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loader_LFS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockOut</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockOutShunt</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockout_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLatchesStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLinearRail1Status</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLinearRail2Status</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmOnlineClampsStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF0_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF3_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AIN</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AOL</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP2_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP3_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>overClampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>presenceLoader</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>presenceloader_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>unclampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>underClampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXminusController_Trending using level 2 for category Trending-->
+  <!--===========================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_AcTruckXminusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1622663564L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
       <IDL_Type>long</IDL_Type>
       <Units>micron</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>slavePosition</EFDB_Name>
-      <Description>position of AC slave truck along Linear Rails</Description>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
       <IDL_Type>long</IDL_Type>
       <Units>micron</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_BrakeSystemGateway using level 1-->
-  <!--===============================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXplusController_Trending using level 2 for category Trending-->
+  <!--==========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_BrakeSystemGateway</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4159987192L -->
+    <EFDB_Topic>MTCamera_fcs_Canbus0_AcTruckXplusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 313474385L -->
     <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>intValues</EFDB_Name>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Accelerobf_Trending using level 2 for category Trending-->
+  <!--==============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_Accelerobf_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2319033051L -->
+    <item>
+      <EFDB_Name>accelerationX</EFDB_Name>
+      <Description>angular acceleration along the X axis (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>accelerationY</EFDB_Name>
+      <Description>angular acceleration along the Y axis (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>accelerationZ</EFDB_Name>
+      <Description>angular acceleration along the Z axis (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>airmass</EFDB_Name>
+      <Description>camera body airmass indication</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>angularVelocityX</EFDB_Name>
+      <Description>angular velocity along the X axis (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>angularVelocityY</EFDB_Name>
+      <Description>angular velocity along the Y axis (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>angularVelocityZ</EFDB_Name>
+      <Description>angular velocity along the Z axis (RPM)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>azimut</EFDB_Name>
+      <Description>camera body azimut from the Z axis</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>elevation</EFDB_Name>
+      <Description>camera body elevation from the Z axis</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>degree</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gravity</EFDB_Name>
+      <Description>camera body gravity indication</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Ai814_Trending using level 2 for category Trending-->
+  <!--=========================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_Ai814_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3931002535L -->
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending using level 2 for category Trending-->
+  <!--======================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 153145976L -->
+    <item>
+      <EFDB_Name>acAF0b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF0s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF1b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF1s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF3b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF3s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAP2b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAP2s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselHoldingFilterSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselHoldingFilterSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselStoppedAtStandby</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselStoppedAtStandbyC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF0_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>engineeringKey</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>engineeringkey_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor5</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forceSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forceSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inclinometerXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inclinometerXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyEng</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyEngb</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyLock</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyLockb</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lps_0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lps_1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lrh_0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lrh_1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCarrierRelayStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderChainPresenceSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderConnectedSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderConnectedSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderDefaultStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderEngagedPositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderEngagedPositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterDistanceSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterGoodPositionStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterPresenceSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterPresenceSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHandoffPositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHandoffPositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHoldingFilterSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHoldingFilterSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHooksRelayStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOnCameraSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOnCameraSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderStoragePositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderStoragePositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loader_LFD</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loader_LFS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockOut</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockOutShunt</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockout_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLatchesStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLinearRail1Status</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLinearRail2Status</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmOnlineClampsStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF0_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF3_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AIN</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AOL</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP2_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP3_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>overClampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>presenceLoader</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>presenceloader_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>unclampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>underClampedStatusSensor</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel using level 1-->
-  <!--=====================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_CarouselController_Trending using level 2 for category Trending-->
+  <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Carousel</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3128307458L -->
+    <EFDB_Topic>MTCamera_fcs_Canbus0_CarouselController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1196028887L -->
     <item>
-      <EFDB_Name>af3</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>af3_InError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>ap1</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXminusController_Trending using level 2 for category Trending-->
+  <!--=========================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_ClampXminusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3247584423L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>ap1_InError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>ap2</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXplusController_Trending using level 2 for category Trending-->
+  <!--========================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_ClampXplusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3610149437L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>ap2_InError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>ap3</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Hyttc580_Trending using level 2 for category Trending-->
+  <!--============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_Hyttc580_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4130876379L -->
+    <item>
+      <EFDB_Name>pdo1</EFDB_Name>
+      <Description>value of the PDO1 read on the HYTTC580</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pdo2</EFDB_Name>
+      <Description>value of the PDO2 read on the HYTTC580</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pdo4</EFDB_Name>
+      <Description>value of the PDO4 read on the HYTTC580</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXminusController_Trending using level 2 for category Trending-->
+  <!--=========================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_LatchXminusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1151376015L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>ap3_InError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXplusController_Trending using level 2 for category Trending-->
+  <!--========================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_LatchXplusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2159047279L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXminusController_Trending using level 2 for category Trending-->
+  <!--===============================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineClampXminusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2363028241L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXplusController_Trending using level 2 for category Trending-->
+  <!--==============================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineClampXplusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3589486380L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampYminusController_Trending using level 2 for category Trending-->
+  <!--===============================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineClampYminusController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1120629728L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineStrainGauge_Trending using level 2 for category Trending-->
+  <!--=====================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineStrainGauge_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2171501237L -->
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ProximitySensorsDevice_Trending using level 2 for category Trending-->
+  <!--==========================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_ProximitySensorsDevice_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 217235361L -->
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Pt100_Trending using level 2 for category Trending-->
+  <!--=========================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_Pt100_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 510586873L -->
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice1_Trending using level 2 for category Trending-->
+  <!--======================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_TempSensorsDevice1_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1148841563L -->
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice2_Trending using level 2 for category Trending-->
+  <!--======================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus0_TempSensorsDevice2_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1971328537L -->
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_CarrierController_Trending using level 2 for category Trending-->
+  <!--=====================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus1_CarrierController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3913831446L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_HooksController_Trending using level 2 for category Trending-->
+  <!--===================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus1_HooksController_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 474905309L -->
+    <item>
+      <EFDB_Name>averageCurrent</EFDB_Name>
+      <Description>average current read on AC truck controller : index 0x2027</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeActivated</EFDB_Name>
+      <Description>are brakes activated by the controller if controllerWithBrake</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>current</EFDB_Name>
+      <Description>actual current read on controller : index 0x6078</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <Description>number of errors read on the controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>errorRegister</EFDB_Name>
+      <Description>error register read on controller</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>followingError</EFDB_Name>
+      <Description>following error read on AC truck controller : index 0x20F4</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inError</EFDB_Name>
+      <Description>device is in error</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <Description>code from the last error read on controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lastErrorName</EFDB_Name>
+      <Description>name of the last error corresponding to lastErrorCode</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>mode</EFDB_Name>
+      <Description>mode of the EPOS controller {HOMING; PROFILE_POSITION; PROFILE_VELOCITY; POSITION; MASTER_ENCODER; VELOCITY; CURRENT}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>position</EFDB_Name>
+      <Description>position read on controller : index:0x6064 subindex:0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileAcceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileDeceleration</EFDB_Name>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>rpm/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>profileVelocity</EFDB_Name>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>state of the EPOS controller {SWITCH_ON_DISABLED; READY_TO_SWITCH_ON; SWITCHED_ON; OPERATION_ENABLE; FAULT; QUICKSTOP; UNKNOWN_STATE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>velocity</EFDB_Name>
+      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending using level 2 for category Trending-->
+  <!--======================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3747844937L -->
+    <item>
+      <EFDB_Name>acAF0b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF0s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF1b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF1s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF3b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAF3s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAP2b</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>acAP2s</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselHoldingFilterSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselHoldingFilterSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselStoppedAtStandby</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carouselStoppedAtStandbyC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF0_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carousel_CF1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>closeSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>engineeringKey</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>engineeringkey_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterEngagedSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterIDSensor5</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forceSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>forceSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>handoffPositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inclinometerXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inclinometerXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyEng</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyEngb</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyLock</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>keyLockb</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lps_0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lps_1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lrh_0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lrh_1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCarrierRelayStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderChainPresenceSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderCloseSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderConnectedSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderConnectedSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderDefaultStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderEngagedPositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderEngagedPositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterDistanceSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterGoodPositionStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterPresenceSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderFilterPresenceSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHandoffPositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHandoffPositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHoldingFilterSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHoldingFilterSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderHooksRelayStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOnCameraSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOnCameraSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderOpenSensor4</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderStoragePositionSensor0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loaderStoragePositionSensor1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loader_LFD</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>loader_LFS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockOut</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockOutShunt</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lockout_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLatchesStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLinearRail1Status</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmLinearRail2Status</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lpmOnlineClampsStatus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF0</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF0_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AF3_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AIN</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AOL</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP1</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP1_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP2</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP2_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP3</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>out_AP3_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXminusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampXplusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusCloseSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusCloseSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusOpenSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineClampYminusOpenSensorC</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlinePositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorBLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorBLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorLatchXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>openSensorLatchXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>overClampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>presenceLoader</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>presenceloader_C</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorBXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorBXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorXminus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>standbyPositionSensorXplus</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>unclampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>underClampedStatusSensor</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket1_Trending using level 2 for category Trending-->
+  <!--============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Socket1_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3899725955L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>is carousel socket at STANDBY position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>brakeState1</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>clampxminus1_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>brakeState2</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>clampxminus1_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus1_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus1_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>brakeState3</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>clampxminus1_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus1_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus1_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>brakesActivated</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>clampxplus1_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus1_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus1_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus1_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus1_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus1_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus1_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampsState</EFDB_Name>
+      <Description>clamps state on this socket {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>empty</EFDB_Name>
+      <Description>is the carousel socket empty</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>caEng</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>filterID</EFDB_Name>
+      <Description>id of filter in this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ioStatus</EFDB_Name>
+      <Description>IO module status for this socket {UNKNOWN_STATUS; IS_SOCKET_AT_STANDBY; IS_READY_NOT_IN_POSITION; ERROR_READING_POSITION; SAFE_STATE; BOOTING; NOT_POWERED_ON; NOT_WORKING_FOR_OTHER_REASON}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket2_Trending using level 2 for category Trending-->
+  <!--============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Socket2_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2984804193L -->
+    <item>
+      <EFDB_Name>atStandby</EFDB_Name>
+      <Description>is carousel socket at STANDBY position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>caeng_InError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>clampxminus2_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus2_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus2_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus2_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus2_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus2_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus2_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus2_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampsState</EFDB_Name>
+      <Description>clamps state on this socket {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>empty</EFDB_Name>
+      <Description>is the carousel socket empty</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>caLockout</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>filterID</EFDB_Name>
+      <Description>id of filter in this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ioStatus</EFDB_Name>
+      <Description>IO module status for this socket {UNKNOWN_STATUS; IS_SOCKET_AT_STANDBY; IS_READY_NOT_IN_POSITION; ERROR_READING_POSITION; SAFE_STATE; BOOTING; NOT_POWERED_ON; NOT_WORKING_FOR_OTHER_REASON}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket3_Trending using level 2 for category Trending-->
+  <!--============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Socket3_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 810524672L -->
+    <item>
+      <EFDB_Name>atStandby</EFDB_Name>
+      <Description>is carousel socket at STANDBY position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>calockout_InError</EFDB_Name>
-      <Description>MISSING</Description>
+      <EFDB_Name>clampxminus3_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus3_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus3_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus3_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus3_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus3_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus3_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus3_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampsState</EFDB_Name>
+      <Description>clamps state on this socket {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>empty</EFDB_Name>
+      <Description>is the carousel socket empty</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterID</EFDB_Name>
+      <Description>id of filter in this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ioStatus</EFDB_Name>
+      <Description>IO module status for this socket {UNKNOWN_STATUS; IS_SOCKET_AT_STANDBY; IS_READY_NOT_IN_POSITION; ERROR_READING_POSITION; SAFE_STATE; BOOTING; NOT_POWERED_ON; NOT_WORKING_FOR_OTHER_REASON}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket4_Trending using level 2 for category Trending-->
+  <!--============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Socket4_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 47886501L -->
+    <item>
+      <EFDB_Name>atStandby</EFDB_Name>
+      <Description>is carousel socket at STANDBY position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus4_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus4_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampsState</EFDB_Name>
+      <Description>clamps state on this socket {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>empty</EFDB_Name>
+      <Description>is the carousel socket empty</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterID</EFDB_Name>
+      <Description>id of filter in this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ioStatus</EFDB_Name>
+      <Description>IO module status for this socket {UNKNOWN_STATUS; IS_SOCKET_AT_STANDBY; IS_READY_NOT_IN_POSITION; ERROR_READING_POSITION; SAFE_STATE; BOOTING; NOT_POWERED_ON; NOT_WORKING_FOR_OTHER_REASON}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket5_Trending using level 2 for category Trending-->
+  <!--============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Socket5_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2206035908L -->
+    <item>
+      <EFDB_Name>atStandby</EFDB_Name>
+      <Description>is carousel socket at STANDBY position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxminus5_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_clampState</EFDB_Name>
+      <Description>carousel clamp state {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_filterPositionSensorValue</EFDB_Name>
+      <Description>value returned by filter position sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_filterPresenceOffset2</EFDB_Name>
+      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_filterPresenceStatus</EFDB_Name>
+      <Description>carousel clamp filter presence status {NOFILTER; ENGAGED; LOCKABLE; NOT_LOCKABLE; ERROR; UNKNOWN}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_lockSensorOffset1</EFDB_Name>
+      <Description>offset1 for carousel lock sensor read on hyttc580</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_lockSensorValue</EFDB_Name>
+      <Description>value returned by carousel lock sensor</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampxplus5_lockStatus</EFDB_Name>
+      <Description>carousel clamp lock status {UNLOCKED; LOCKED; RELAXED; OPENED; CLOSED; UNKNOWN; ERROR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clampsState</EFDB_Name>
+      <Description>clamps state on this socket {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>empty</EFDB_Name>
+      <Description>is the carousel socket empty</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filterID</EFDB_Name>
+      <Description>id of filter in this socket</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ioStatus</EFDB_Name>
+      <Description>IO module status for this socket {UNKNOWN_STATUS; IS_SOCKET_AT_STANDBY; IS_READY_NOT_IN_POSITION; ERROR_READING_POSITION; SAFE_STATE; BOOTING; NOT_POWERED_ON; NOT_WORKING_FOR_OTHER_REASON}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Trending using level 2 for category Trending-->
+  <!--====================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2209172173L -->
+    <item>
+      <EFDB_Name>atStandby</EFDB_Name>
+      <Description>is a carousel socket at standby position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampsStateAtStandby</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>state of the clamps for the socket at standby position {READYTOCLAMP; UNCLAMPEDONFILTER; UNCLAMPEDEMPTY; CLAMPEDONFILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on carousel controller : index 0x6078</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>deltaPositionAtStandby</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>carousel delta position at standby value </Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>carousel steps</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>emptyAtStandby</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableBrakes</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableRotation</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableShutter</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>enableUnclamp</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>is an empty carousel socket at standby position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>estimatedPosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>carousel estimated position</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>carousel steps</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>filterAtStandbyName</EFDB_Name>
-      <Description>name of filter at STANDBY position</Description>
-      <IDL_Type>string</IDL_Type>
+      <EFDB_Name>filterAtStandbyId</EFDB_Name>
+      <Description>id of filter at STANDBY position</Description>
+      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>filterOnAutochangerName</EFDB_Name>
-      <Description>name of filter on AC trucks</Description>
+      <Description>name of filter on autochanger trucks</Description>
       <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>locked</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>minLocked</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>threshold value corresponding to the carousel clamps locked status as read on TTC580</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>moving</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CF0</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CF0_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CF1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CF1_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CFC</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CFC_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CS</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_CS_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>carousel position; read on controller</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>positionSensorType</EFDB_Name>
-      <Description>position sensor type on carousel controller</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. In slow mode this field is set to slowAcceleration.In fast mode it is set to fast acceleration. (RPM)</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. In slow mode this field is set to slowDeceleration.In fast mode to fastDeceleration. (RPM)</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. In slow mode this field is set to slowVelocity.In fast mode to fastVelocity. (RPM)</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>rotationTimeout</EFDB_Name>
-      <Description>max time needed for a rotation of 2 sockets. In slow mode this field is set to slowRotationTimeout. In fast mode to fastRotationTimeout</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sensor1</EFDB_Name>
-      <Description>carousel sensor1</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sensor2</EFDB_Name>
-      <Description>carousel sensor2</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sensor3</EFDB_Name>
-      <Description>carousel sensor3</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>shutterInactive</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>slaveStatusAtStandby</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sleep</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
+      <Units>mV</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socketAtStandbyID</EFDB_Name>
-      <Description>id of socket at STANDBY position</Description>
+      <Description>id of carousel socket at STANDBY position</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socketAtStandbyName</EFDB_Name>
-      <Description>name of socket at STANDBY position</Description>
+      <Description>name of carousel socket at STANDBY position</Description>
       <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature1</EFDB_Name>
-      <Description>carousel temperature1</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature2</EFDB_Name>
-      <Description>carousel temperature2</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature3</EFDB_Name>
-      <Description>carousel temperature3</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature4</EFDB_Name>
-      <Description>carousel temperature4</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tpCheckRotation</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tpStopRotation</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tpStopUnclamp</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>tp_InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>carousel velocity read on carousel controller (RPM)</Description>
-      <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_CarouselController using level 1-->
-  <!--===============================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending using level 2 for category Trending-->
+  <!--================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_CarouselController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2407717082L -->
+    <EFDB_Topic>MTCamera_fcs_Duration_Autochanger_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 79989557L -->
     <item>
-      <EFDB_Name>booted</EFDB_Name>
+      <EFDB_Name>autochangertrucks_ALIGN_FOLLOWER</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
+      <EFDB_Name>autochangertrucks_MOVE_FOLLOWER_TRUCK_ALONE</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
+      <EFDB_Name>autochangertrucks_MOVE_TO_ABSOLUTE_POSITION</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <EFDB_Name>latches_latchXminus_CLOSE</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
+      <EFDB_Name>latches_latchXminus_OPEN</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>inError</EFDB_Name>
+      <EFDB_Name>latches_latchXplus_CLOSE</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>initialized</EFDB_Name>
+      <EFDB_Name>latches_latchXplus_OPEN</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <EFDB_Name>onlineclamps_onlineClampXminus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
+      <EFDB_Name>onlineclamps_onlineClampXminus_CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>mode</EFDB_Name>
+      <EFDB_Name>onlineclamps_onlineClampXminus_LOCK_ONLINECLAMP</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_REOPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_UNLOCK_ONLINECLAMP</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_LOCK_ONLINECLAMP</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_REOPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_UNLOCK_ONLINECLAMP</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_LOCK_ONLINECLAMP</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_REOPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_UNLOCK_ONLINECLAMP</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carrier using level 1-->
-  <!--====================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Carousel_Trending using level 2 for category Trending-->
+  <!--=============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Carrier</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3579491723L -->
+    <EFDB_Topic>MTCamera_fcs_Duration_Carousel_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 208709108L -->
+    <item>
+      <EFDB_Name>rotate_CAROUSEL_TO_ABSOLUTE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rotate_CAROUSEL_TO_RELATIVE_POSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_RELEASECLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_UNLOCKCLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_RELEASECLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_UNLOCKCLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_RELEASECLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_UNLOCKCLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_RELEASECLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_UNLOCKCLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_RELEASECLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_UNLOCKCLAMPS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_RELEASE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_UNLOCK</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Loader_Trending using level 2 for category Trending-->
+  <!--===========================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Duration_Loader_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2126547202L -->
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_ABSOLUTEPOSITION</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_ENGAGED</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_HANDOFF</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_STORAGE</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_CLAMPLOADERHOOKS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_CLOSELOADERHOOKS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_OPENHOMINGLOADERHOOKS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_UNCLAMPLOADERHOOKS</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Trending using level 2 for category Trending-->
+  <!--====================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Duration_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3648583864L -->
+    <item>
+      <EFDB_Name>sETFILTER</EFDB_Name>
+      <Description>duration of command setFilter</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Fcs_Mcm_Trending using level 2 for category Trending-->
+  <!--===================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Fcs_Mcm_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 299899778L -->
+    <item>
+      <EFDB_Name>autochanger_trucks_location</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochanger_trucks_position</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filter_on_autochanger_id</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>filter_on_autochanger_name</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Carrier_Trending using level 2 for category Trending-->
+  <!--==========================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Loader_Carrier_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3643041460L -->
     <item>
       <EFDB_Name>atEngaged</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader carrier at engaged position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>atHandoff</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader carrier at handoff position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>atStorage</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader carrier at storage position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>controllerInError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader carrier controller in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on loader carrier controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>engagedSensorOn</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader carrier engaged position sensor on</Description>
       <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitSwitchDownInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitSwitchUpInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>loader carrier position</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6083 subindex 0. In slow mode this field is set to slowSpeed. (RPM)</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6084 subindex 0. In slow mode this field is set to slowSpeed. (RPM)</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. In slow mode this field is set to slowSpeed. (RPM)</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>Hz</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>speed</EFDB_Name>
-      <Description>loader carrier actual velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_CarrierController using level 1-->
-  <!--==============================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Hooks_Trending using level 2 for category Trending-->
+  <!--========================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_CarrierController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2614455093L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_CcsVersions using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_CcsVersions</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3806026202L -->
-    <item>
-      <EFDB_Name>agent_version</EFDB_Name>
-      <Description>The Version</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>distribution_version</EFDB_Name>
-      <Description>The Version</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>toolkit_version</EFDB_Name>
-      <Description>The Version</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXminus1 using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXminus1</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2891968472L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXminus2 using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXminus2</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1908444430L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXminus3 using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXminus3</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 984984764L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXminus4 using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXminus4</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 294604515L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXminus5 using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXminus5</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1526361937L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXminusController using level 1-->
-  <!--==================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXminusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3595915933L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXplus1 using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXplus1</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 861795234L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXplus2 using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXplus2</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4005728628L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXplus3 using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXplus3</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2780278982L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXplus4 using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXplus4</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2391626393L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXplus5 using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXplus5</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3321393963L -->
-    <item>
-      <EFDB_Name>clampState</EFDB_Name>
-      <Description>global clamp state like CLAMPEDONFILTER or READYTOCLAMP</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionSensorValue</EFDB_Name>
-      <Description>value returned by filter position sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceMinNoFilter</EFDB_Name>
-      <Description>offset1 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between 0 and filterPresenceOffset1 then sensor is in error.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceOffset2</EFDB_Name>
-      <Description>offset2 for filter presence sensor read on hyttc580 : if filter presence sensor returns a value between filterPresenceOffset1 and filterPresenceOffset2 then the filter is engaged and lockable.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>filter presence status like LOCKABLE or ENGAGED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorOffset1</EFDB_Name>
-      <Description>offset1 for lock sensor read on hyttc580</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>value returned by lock sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of this clamp like LOCKED or UNLOCKED</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>temperature</EFDB_Name>
-      <Description>temperature in clamp read on AI814</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ClampXplusController using level 1-->
-  <!--=================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ClampXplusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2751450458L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Config using level 1-->
-  <!--===================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Config</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 666057613L -->
-    <item>
-      <EFDB_Name>data_Devices_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category Devices</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_General_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category General</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_Limits_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category Limits</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_autochanger_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category autochanger</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_canbus_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category canbus</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_carousel_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category carousel</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_controller_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category controller</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_filter_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category filter</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_loader_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category loader</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_nodeID_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category nodeID</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_readRate_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category readRate</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_sensor_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category sensor</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_serialNB_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category serialNB</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>data_timers_checksum</EFDB_Name>
-      <Description>Configuration data checksum for category timers</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Hooks using level 1-->
-  <!--==================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Hooks</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2585131525L -->
+    <EFDB_Topic>MTCamera_fcs_Loader_Hooks_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3365172436L -->
     <item>
       <EFDB_Name>allHooksInStateCLOSED</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>are all the loader hooks in the CLOSED state</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampState</EFDB_Name>
-      <Description>loader clamp lock status</Description>
+      <Description>loader clamp lock status {CLAMPED; UNCLAMPED; CLOSED; OPENED; UNKNOWN; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>controllerInError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>is the loader clamp controller in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on loader clamp controller (index 0x6078)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>forceClampedStatus</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>clamp force sensors – enough force to hold filter</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>forceOverClampedStatus</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>clamp force sensors – too much force on the hooks – risk of damaging both the hooks and the filter interfaces</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6471,2248 +10533,386 @@
     </item>
     <item>
       <EFDB_Name>forceStatus</EFDB_Name>
-      <Description>loader clamp lock status</Description>
+      <Description>loader clamp force lock status {UNCLAMPED; CLAMPED; UNDER_CLAMPED; OVER_CLAMPED; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>forceUnclampedStatus</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>clamp force sensors – not enough force to hold filter</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>forceUnderClampedStatus</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>clamp force sensors – filter between engaged and storage position but insufficient force to properly hold filter</Description>
       <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>loader clamp position</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>statusPublishedByHook1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook1_inError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook sensors in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook1_lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook locked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook1_lockStatus</EFDB_Name>
-      <Description>loader hook lock status</Description>
+      <Description>loader hook lock status {OPENED; CLOSED; IN_TRAVEL; UNKNOWN; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook1_unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook unlocked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>statusPublishedByHook2</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>statuspublishedbyhook2_inError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook sensors in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook2_lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook locked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook2_lockStatus</EFDB_Name>
-      <Description>loader hook lock status</Description>
+      <Description>loader hook lock status {OPENED; CLOSED; IN_TRAVEL; UNKNOWN; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook2_unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook unlocked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>statusPublishedByHook3</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>statuspublishedbyhook3_inError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook sensors in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook3_lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook locked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook3_lockStatus</EFDB_Name>
-      <Description>loader hook lock status</Description>
+      <Description>loader hook lock status {OPENED; CLOSED; IN_TRAVEL; UNKNOWN; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook3_unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook unlocked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>statusPublishedByHook4</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>statuspublishedbyhook4_inError</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook sensors in error</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook4_lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook locked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook4_lockStatus</EFDB_Name>
-      <Description>loader hook lock status</Description>
+      <Description>loader hook lock status {OPENED; CLOSED; IN_TRAVEL; UNKNOWN; ERROR}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>statuspublishedbyhook4_unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>loader hook unlocked</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_HooksController using level 1-->
-  <!--============================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Trending using level 2 for category Trending-->
+  <!--===========================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_HooksController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 517619601L -->
+    <EFDB_Topic>MTCamera_fcs_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2294723773L -->
     <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <EFDB_Name>canbus0</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Hyttc580 using level 1-->
-  <!--=====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Hyttc580</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 641540025L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>pdo1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>pdo2</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>pdo4</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_LatchXminus using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_LatchXminus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3935073494L -->
-    <item>
-      <EFDB_Name>controllerInFault</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>AC latch lock status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_LatchXminusController using level 1-->
-  <!--==================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_LatchXminusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2383033675L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_LatchXplus using level 1-->
-  <!--=======================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_LatchXplus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3500546618L -->
-    <item>
-      <EFDB_Name>controllerInFault</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>AC latch lock status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_LatchXplusController using level 1-->
-  <!--=================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_LatchXplusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2496924263L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Latches using level 1-->
-  <!--====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Latches</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 750045242L -->
-    <item>
-      <EFDB_Name>filterId</EFDB_Name>
-      <Description>id of filter on AC trucks</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterName</EFDB_Name>
-      <Description>name of filter on AC trucks</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceStatus</EFDB_Name>
-      <Description>AC latch filter presence status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>AC latch lock status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader using level 1-->
-  <!--===================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Loader</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 412224770L -->
-    <item>
-      <EFDB_Name>af0</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>af0InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>af1</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>af1InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>af3</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>af3InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ap2</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ap2InError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carrierRelayStatus</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterDistance</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPositionStatus</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterPresenceSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>hooksRelayStatus</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyEng</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyEngInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyLock</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyLockInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lfd</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lfs</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderDefaultStatus</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOnCameraSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOnCameraSensorsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lps</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpsInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lrh</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lrhInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>safetyBeltPresence</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_LoaderPlutoGateway using level 1-->
-  <!--===============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_LoaderPlutoGateway</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1125821844L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>intValues</EFDB_Name>
+      <EFDB_Name>canbus1</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClampXminus using level 1-->
-  <!--==============================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_shutter_Trending using level 0 for category Trending-->
+  <!--===============================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClampXminus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3154113760L -->
+    <EFDB_Topic>MTCamera_shutter_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2612329863L -->
     <item>
-      <EFDB_Name>controllerBooted</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_actPos</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerInFault</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on AC online clamp controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>AC online clamp lock status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>online clamp position read on controller</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sentCurrent</EFDB_Name>
-      <Description>last current sent to the controller of this online clamp </Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClampXminusController using level 1-->
-  <!--========================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClampXminusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2478101297L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClampXplus using level 1-->
-  <!--=============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClampXplus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 526494509L -->
-    <item>
-      <EFDB_Name>controllerBooted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerInFault</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on AC online clamp controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>AC online clamp lock status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>online clamp position read on controller</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sentCurrent</EFDB_Name>
-      <Description>last current sent to the controller of this online clamp </Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClampXplusController using level 1-->
-  <!--=======================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClampXplusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1789892399L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClampYminus using level 1-->
-  <!--==============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClampYminus</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4097753227L -->
-    <item>
-      <EFDB_Name>controllerBooted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerInFault</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on AC online clamp controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>AC online clamp lock status</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>online clamp position read on controller</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>sentCurrent</EFDB_Name>
-      <Description>last current sent to the controller of this online clamp </Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorInError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unlockSensorValue</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClampYminusController using level 1-->
-  <!--========================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClampYminusController</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1044396851L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>brakeActivated</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>controllerWithBrake</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>current</EFDB_Name>
-      <Description>actual current read on controller : index 0x6078</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>mode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>position</EFDB_Name>
-      <Description>position read on controller : index:0x6064 subindex:0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mA</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>state</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineClamps using level 1-->
-  <!--=========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineClamps</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 650453691L -->
-    <item>
-      <EFDB_Name>homingDone</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockStatus</EFDB_Name>
-      <Description>lock status of the 3 online clamps</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampRawStrain</EFDB_Name>
-      <Description>strain read on onlineClampGauge used for the computation of onlineClampStrain. It measures the deformation. The gauge returns a voltage. Gauge factor : 2.07 Wheatstone bridge</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mV</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampStrain</EFDB_Name>
-      <Description>normalized strain is computed from onlineClampRawStrain and temperature and give the force of the clamp to know if a clamp is clamped or closed. Gauge factor : 2.07 Wheatstone bridge</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>mV</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_OnlineStrainGauge using level 1-->
-  <!--==============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_OnlineStrainGauge</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1643775090L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_ProximitySensorsDevice using level 1-->
-  <!--===================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_ProximitySensorsDevice</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 157978563L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Pt100 using level 1-->
-  <!--==================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Pt100</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2829141648L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_RuntimeInfo using level 1-->
-  <!--========================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_RuntimeInfo</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3506789196L -->
-    <item>
-      <EFDB_Name>freeMemory</EFDB_Name>
-      <Description>Free Memory available that could be used by the JVM</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>byte</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>maxMemory</EFDB_Name>
-      <Description>Maximum Memory available to the JVM</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>byte</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>nThreads</EFDB_Name>
-      <Description>Number of Threads allocated by the CCS process</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>processCpuLoad</EFDB_Name>
-      <Description>Recent cpu usage for the whole system. This value is a double in the [0.0,1.0] interval.</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>systemCpuLoad</EFDB_Name>
-      <Description>Recent cpu usage for the JVM process. This value is a double in the [0.0,1.0] interval.</Description>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_actVel</EFDB_Name>
+      <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>totalMemory</EFDB_Name>
-      <Description>Total Memory allocated by JVM</Description>
-      <IDL_Type>long long</IDL_Type>
-      <Units>byte</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>uptime</EFDB_Name>
-      <Description>Number of seconds since the CCS process was started</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>s</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Socket1 using level 1-->
-  <!--====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Socket1</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1943797825L -->
-    <item>
-      <EFDB_Name>atStandby</EFDB_Name>
-      <Description>true if this socket is at STANDBY</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselMoving</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampsState</EFDB_Name>
-      <Description>clamps state on this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>deltaPosition</EFDB_Name>
-      <Description>difference between actual carousel position and carousel position when this socket is at STANDBY.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>empty</EFDB_Name>
-      <Description>true if this socket is empty : no filter</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterID</EFDB_Name>
-      <Description>id of filter in this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterName</EFDB_Name>
-      <Description>name of filter in this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>slaveStatus</EFDB_Name>
-      <Description>status of the slave module status for this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>socketID</EFDB_Name>
-      <Description>id of this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Socket2 using level 1-->
-  <!--====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Socket2</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3982644628L -->
-    <item>
-      <EFDB_Name>atStandby</EFDB_Name>
-      <Description>true if this socket is at STANDBY</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselMoving</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampsState</EFDB_Name>
-      <Description>clamps state on this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>deltaPosition</EFDB_Name>
-      <Description>difference between actual carousel position and carousel position when this socket is at STANDBY.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>empty</EFDB_Name>
-      <Description>true if this socket is empty : no filter</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterID</EFDB_Name>
-      <Description>id of filter in this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterName</EFDB_Name>
-      <Description>name of filter in this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>slaveStatus</EFDB_Name>
-      <Description>status of the slave module status for this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>socketID</EFDB_Name>
-      <Description>id of this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Socket3 using level 1-->
-  <!--====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Socket3</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2566363431L -->
-    <item>
-      <EFDB_Name>atStandby</EFDB_Name>
-      <Description>true if this socket is at STANDBY</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselMoving</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampsState</EFDB_Name>
-      <Description>clamps state on this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>deltaPosition</EFDB_Name>
-      <Description>difference between actual carousel position and carousel position when this socket is at STANDBY.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>empty</EFDB_Name>
-      <Description>true if this socket is empty : no filter</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterID</EFDB_Name>
-      <Description>id of filter in this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterName</EFDB_Name>
-      <Description>name of filter in this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>slaveStatus</EFDB_Name>
-      <Description>status of the slave module status for this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>socketID</EFDB_Name>
-      <Description>id of this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Socket4 using level 1-->
-  <!--====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Socket4</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 191887487L -->
-    <item>
-      <EFDB_Name>atStandby</EFDB_Name>
-      <Description>true if this socket is at STANDBY</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselMoving</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampsState</EFDB_Name>
-      <Description>clamps state on this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>deltaPosition</EFDB_Name>
-      <Description>difference between actual carousel position and carousel position when this socket is at STANDBY.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>empty</EFDB_Name>
-      <Description>true if this socket is empty : no filter</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterID</EFDB_Name>
-      <Description>id of filter in this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterName</EFDB_Name>
-      <Description>name of filter in this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>slaveStatus</EFDB_Name>
-      <Description>status of the slave module status for this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>socketID</EFDB_Name>
-      <Description>id of this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Socket5 using level 1-->
-  <!--====================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Socket5</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2130326732L -->
-    <item>
-      <EFDB_Name>atStandby</EFDB_Name>
-      <Description>true if this socket is at STANDBY</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselMoving</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampsState</EFDB_Name>
-      <Description>clamps state on this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>deltaPosition</EFDB_Name>
-      <Description>difference between actual carousel position and carousel position when this socket is at STANDBY.</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>empty</EFDB_Name>
-      <Description>true if this socket is empty : no filter</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterID</EFDB_Name>
-      <Description>id of filter in this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>micron</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterName</EFDB_Name>
-      <Description>name of filter in this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>slaveStatus</EFDB_Name>
-      <Description>status of the slave module status for this socket</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>socketID</EFDB_Name>
-      <Description>id of this socket</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_TempSensorsDevice1 using level 1-->
-  <!--===============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_TempSensorsDevice1</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1591129055L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_brakeEngaged</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_ctrlTemp</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_enabled</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_TempSensorsDevice2 using level 1-->
-  <!--===============================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_TempSensorsDevice2</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1808403270L -->
-    <item>
-      <EFDB_Name>booted</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>errorHistoryNB</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_errorID</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>errorRegister</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inError</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>initialized</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lastErrorCode</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_hasSafeTemp</EFDB_Name>
       <Description>MISSING</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lastErrorName</EFDB_Name>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_highLimit</EFDB_Name>
       <Description>MISSING</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_isHomed</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_lowLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_MINUSX_setAcc</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_actPos</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_actVel</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_brakeEngaged</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_ctrlTemp</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_enabled</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_errorID</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_hasSafeTemp</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_highLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_isHomed</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_lowLimit</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_axstatus_PLUSX_setAcc</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_isCalibrated</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_isSafetyOn</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_motionProfile</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_smState</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_tempIsSafe_CONTROL_BOX</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_tempIsSafe_MINUSX_MOTOR</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_tempIsSafe_PLUSX_MOTOR</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_temperature_CONTROL_BOX</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_temperature_MINUSX_MOTOR</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shutterstatus_temperature_PLUSX_MOTOR</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -8769,14 +10969,14 @@
       <EFDB_Name>flowRate</EFDB_Name>
       <Description>chiller flow rate</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>gallon/min</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>flowSetPoint</EFDB_Name>
       <Description>chiller flow setpoint</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>gallon/min</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -8871,12 +11071,187 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_chiller_FParam_Trending using level 1 for category Trending-->
+  <!--======================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_chiller_FParam_Trending</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 224699981L -->
+    <item>
+      <EFDB_Name>bubblev_TIME</EFDB_Name>
+      <Description>Bubble valve open duration</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>clr_KI_SETPT</EFDB_Name>
+      <Description>If 1, clear Ki at setpoint</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cold_PERIOD</EFDB_Name>
+      <Description>Cold valve period (s)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cool_CAPACITY</EFDB_Name>
+      <Description>Cool capacity, % of max</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dut_DT_HI</EFDB_Name>
+      <Description>DUT upper DeltaT limit</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dut_DT_LO</EFDB_Name>
+      <Description>DUT lower DeltaT limit</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dut_KI</EFDB_Name>
+      <Description>DUT integral coeff</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dut_KP</EFDB_Name>
+      <Description>DUT proportional coeff</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dut_TMAX</EFDB_Name>
+      <Description>DUT upper temp limit</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dut_TMIN</EFDB_Name>
+      <Description>DUT lower temp limit</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flowmeter_LO</EFDB_Name>
+      <Description>Low-flow-meter alarm thresh</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gal/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>flow_ERR_MASK</EFDB_Name>
+      <Description>Flow-switch error mask time (s)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>heat_CAPACITY</EFDB_Name>
+      <Description>Heat capacity, % of max</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pid_GAINFAC</EFDB_Name>
+      <Description>PID cool (&lt;0)/heat (&gt;0) factor</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pid_KD</EFDB_Name>
+      <Description>PID differential coeff</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pid_KI</EFDB_Name>
+      <Description>PID integral coeff</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>pid_KP</EFDB_Name>
+      <Description>PID proportional coeff</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ramp_DEFAULT</EFDB_Name>
+      <Description>Default ramp rate (deg/min)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>°C/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>refrig_OFF</EFDB_Name>
+      <Description>Refrig-off timer (min)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>setpt_SETTLE</EFDB_Name>
+      <Description>Min SetPoint stable time (s)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>setpt_TOL</EFDB_Name>
+      <Description>SetPoint tolerance (deg-C)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tank_SETPOINT</EFDB_Name>
+      <Description>Tank pressure setpoint</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psig</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>thermsl_MASS</EFDB_Name>
+      <Description>Thermal mass (DUT damping)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>t_CTRL_MODE</EFDB_Name>
+      <Description>T-control Normal (0)/DUT (1)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_chiller_Maq20 using level 1-->
   <!--======================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_chiller_Maq20</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 265805253L -->
+    <!--CCS: Dictionary_Checksum: 460290037L -->
     <item>
       <EFDB_Name>ambientTemp</EFDB_Name>
       <Description>TC19: Ambient</Description>
@@ -8962,10 +11337,17 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>glycHeatXfer</EFDB_Name>
+      <Description>Heat transfer rate to cooling glycol</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>kW</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>glycInputFlow</EFDB_Name>
       <Description>Glycol flow rate into Chiller</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>gallon/min</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -9048,6 +11430,166 @@
     <item>
       <EFDB_Name>stg2Return</EFDB_Name>
       <Description>TC13: Stage2 Return</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_thermal_Cold_Temp using level 1-->
+  <!--==========================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_thermal_Cold_Temp</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2724887452L -->
+    <item>
+      <EFDB_Name>avgColdTemp</EFDB_Name>
+      <Description>Average Cold Plate RTD Temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_thermal_Cryo_Temp using level 1-->
+  <!--==========================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_thermal_Cryo_Temp</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2041243352L -->
+    <item>
+      <EFDB_Name>avgCryoTemp</EFDB_Name>
+      <Description>Average Cryo Plate RTD Temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_thermal_Rtd using level 1-->
+  <!--====================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_thermal_Rtd</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2669752829L -->
+    <!--CCSMETA: Array cold_Temp indexed by location-->
+    <item>
+      <EFDB_Name>cold_Temp</EFDB_Name>
+      <Description>Cold Plate RTD 00</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array cryo_Temp indexed by location-->
+    <item>
+      <EFDB_Name>cryo_Temp</EFDB_Name>
+      <Description>Cryo Plate RTD 02</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <!--CCSMETA: Array grid_Temp indexed by location-->
+    <item>
+      <EFDB_Name>grid_Temp</EFDB_Name>
+      <Description>Grid RTD 01</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>20</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>rtd location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_thermal_Trim using level 1-->
+  <!--=====================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_thermal_Trim</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2480012650L -->
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>trim location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array trim_Htrs_I indexed by location-->
+    <item>
+      <EFDB_Name>trim_Htrs_I</EFDB_Name>
+      <Description>Cold Heater 0 Current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Htrs_P indexed by location-->
+    <item>
+      <EFDB_Name>trim_Htrs_P</EFDB_Name>
+      <Description>Cold Heater 0 Power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>12</Count>
+    </item>
+    <!--CCSMETA: Array trim_Htrs_V indexed by location-->
+    <item>
+      <EFDB_Name>trim_Htrs_V</EFDB_Name>
+      <Description>Cold Heater 0 Voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>12</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_thermal_Trim_Htrs using level 1-->
+  <!--==========================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_thermal_Trim_Htrs</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1982894119L -->
+    <item>
+      <EFDB_Name>coldtotal_P</EFDB_Name>
+      <Description>Cold Total Power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cryototal_P</EFDB_Name>
+      <Description>Cryo Total Power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrBulkTmp</EFDB_Name>
+      <Description>Heater Bulk PS Temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrbulk_I</EFDB_Name>
+      <Description>Heater Bulk PS Current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>A</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrbulk_P</EFDB_Name>
+      <Description>Heater Bulk PS Power</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Watt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrbulk_V</EFDB_Name>
+      <Description>Heater Bulk PS Voltage</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Volt</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrPsTmp</EFDB_Name>
+      <Description>Heater PS Temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>

--- a/tests/test_Units.py
+++ b/tests/test_Units.py
@@ -9,8 +9,7 @@ import pytest
 
 # These nonstandard units are explicitly allowed.
 # Remove entries if and when astropy adds support for them.
-NONSTANDARD_UNITS = {"unitless", "psia", "psig", "VA"}
-
+NONSTANDARD_UNITS = {"unitless", "psia", "psig", "VA", "rpm", "rpm/s", "carousel steps", "gallon/min"}
 
 def check_for_issues(csc: str, topic: str) -> str:
     jira = ""


### PR DESCRIPTION
  * ATCamera/CCCamera/MTCamera
    * Full refresh of camera Events/Telemetry XML based on currently installed CCS subsystems
    * XML now based derived from https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml
    * Current release: https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml/releases/tag/org-lsst-ccs-camera-sal-xml-parent-1.0.0
    * Reviewing changes for individual CCS subsystem is possible by comparing to previous XML release., e.g. https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml/compare/refactor_XML_20...org-lsst-ccs-camera-sal-xml-parent-1.0.0#diff
