### PR TITLE
Tickets/dm-41678

### DIFF
--- a/doc/news/interface_changes/DM-41678.tunablelaser.rst
+++ b/doc/news/interface_changes/DM-41678.tunablelaser.rst
@@ -1,0 +1,3 @@
+Added new command ``setOpticalConfiguration`` to change the optical alignment configuration.
+
+Added new log event ``opticalConfiguration`` which reflects the set optical alignment configuration.

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Commands.xml
@@ -26,6 +26,18 @@
   </SALCommand>
   <SALCommand>
     <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_command_setOpticalConfiguration</EFDB_Topic>
+    <item>
+      <EFDB_Name>configuration</EFDB_Name>
+      <Description>Optical alignment configuration to be set.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALCommand>
+  <SALCommand>
+    <Subsystem>TunableLaser</Subsystem>
     <EFDB_Topic>TunableLaser_command_setBurstMode</EFDB_Topic>
     <item>
       <EFDB_Name>count</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
@@ -36,6 +36,18 @@ LaserErrorCode_HW_CPU_ERROR = 7304
   </SALEvent>
   <SALEvent>
     <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_logevent_opticalConfiguration</EFDB_Topic>
+    <item>
+      <EFDB_Name>configuration</EFDB_Name>
+      <Description>The new optical alignment configuration.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <SALEvent>
+    <Subsystem>TunableLaser</Subsystem>
     <EFDB_Topic>TunableLaser_logevent_burstModeSet</EFDB_Topic>
   </SALEvent>
   <SALEvent>


### PR DESCRIPTION
Adds support for tunablelaser changing its alignment.

This branch adds 1 event (`alignmentChanged`) for when the optical alignment of the laser is changed and adds 1 function definition (`changeAlignment`) for when changing the optical alignment of the laser. 

This blocks tickets DM-40029 and DM-41426 which implement the function  and use the event in the tunablelaser CSC.