### PR TITLE
Adding three commands to tunable laser for the thermal sensor

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -20,8 +20,7 @@ v21.0.0
 
   * MTM2
 
-    * Improve the description of ``MTM2_forceErrorTangent`` topic.
-
+    * Improve the description of ``MTM2_forceErrorTangent`` topic.     
 
   * Added command for mask rotation for ts_CBP
 
@@ -41,6 +40,10 @@ v21.0.0
 
     * Improve support for publishing block id.
 
+  * TunableLaser
+
+    * Adding 3 commands to TunableLaser: ``changeTempCtrlSetpoint``, ``turnOnTempCtrl``, and ``turnOffTempCtrl``.
+    * Adding 3 events to TunableLaser: ``setPointChanged``, ``tempCtrlOn``, and ``tempCtrlOff``.
 
 v20.1.0
 -------

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Commands.xml
@@ -44,4 +44,25 @@
     <EFDB_Topic>TunableLaser_command_triggerBurst</EFDB_Topic>
     <Description>Trigger an increased burst of energy.</Description>
   </SALCommand>
+  <SALCommand>
+    <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_command_changeTempCtrlSetpoint</EFDB_Topic>
+    <item>
+      <EFDB_Name>setpoint</EFDB_Name>
+      <Description>Set point for the thermal sensor.</Description>
+      <IDL_Type>float</IDL_Type>
+      <Units>deg_C</Units>
+      <Count>1</Count>
+    </item>
+  </SALCommand>
+  <SALCommand>
+    <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_command_turnOnTempCtrl</EFDB_Topic>
+    <Description>Send command to turn on thermal sensor.</Description>
+  </SALCommand>
+  <SALCommand>
+    <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_command_turnOffTempCtrl</EFDB_Topic>
+    <Description>Send command to turn off thermal sensor.</Description>
+  </SALCommand>
 </SALCommandSet>

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
@@ -53,4 +53,23 @@ LaserErrorCode_HW_CPU_ERROR = 7304
       <Count>1</Count>
     </item>
   </SALEvent>
+  <SALEvent>
+    <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_logevent_setPointChanged</EFDB_Topic>
+    <item>
+      <EFDB_Name>setPoint</EFDB_Name>
+      <Description>Value of the temp control set point that was changed</Description>
+      <IDL_Type>float</IDL_Type>
+      <Units>deg_C</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <SALEvent>
+    <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_logevent_tempCtrlOn</EFDB_Topic>
+  </SALEvent>
+  <SALEvent>
+    <Subsystem>TunableLaser</Subsystem>
+    <EFDB_Topic>TunableLaser_logevent_tempCtrlOff</EFDB_Topic>
+  </SALEvent>
 </SALEventSet>


### PR DESCRIPTION
Adding three commands for the temperature control thermal sensor on the laser.

1. Changing the temperature set point
2. Turning it on
3. Turning it off