### PR TITLE
ATCamera/CCCamera/MTCamera org-lsst-ccs-camera-sal-xml version 1.0.3

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -41,6 +41,10 @@ v21.0.0
 
     * Improve support for publishing block id.
 
+  * ATCamera/CCCamera/MTCamera
+    * Update to https://github.com/lsst-camera-ccs/org-lsst-ccs-camera-sal-xml version 1.0.3
+    * Release notes: https://jira.slac.stanford.edu/issues/?jql=project%20%3D%20LCOBM%20AND%20fixVersion%20%3D%20XML-1.0.3
+
 
 v20.1.0
 -------

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -1160,27 +1160,6 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=======================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>ATCamera</Subsystem>
-    <EFDB_Topic>ATCamera_logevent_focal_plane_Ccd_RaftsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2538589901L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>ccd location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
   <!--============================================================================================================================================================-->
   <SALEvent>
@@ -2947,7 +2926,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3622275020L -->
+    <!--CCS: Dictionary_Checksum: 1695348347L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4189,7 +4168,7 @@
     </item>
     <item>
       <EFDB_Name>metaDataRegisters</EFDB_Name>
-      <Description>Names of meta-data related registers which must be in the sequencer</Description>
+      <Description>Names of meta-data related registers which must be in the sequencer (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -4294,14 +4273,14 @@
     </item>
     <item>
       <EFDB_Name>sequencer</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sequencerChecksums</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -4357,7 +4336,7 @@
     </item>
     <item>
       <EFDB_Name>webHooks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -4504,56 +4483,56 @@
     </item>
     <item>
       <EFDB_Name>sumDriverChecks</EFDB_Name>
-      <Description>Driver Stats for warnings on sums</Description>
+      <Description>Driver Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumDriverStats</EFDB_Name>
-      <Description>Driver Stats for sums over location</Description>
+      <Description>Driver Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumFirmwareChecks</EFDB_Name>
-      <Description>Firmware Stats for warnings on sums</Description>
+      <Description>Firmware Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumFirmwareStats</EFDB_Name>
-      <Description>Firmware Stats for sums over location</Description>
+      <Description>Firmware Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRdsChecks</EFDB_Name>
-      <Description>Rds Stats for warnings on sums</Description>
+      <Description>Rds Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRdsStats</EFDB_Name>
-      <Description>Rds Stats for sums over location</Description>
+      <Description>Rds Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRmsChecks</EFDB_Name>
-      <Description>Rms Stats for warnings on sums</Description>
+      <Description>Rms Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRmsStats</EFDB_Name>
-      <Description>Rms Stats for sums over location</Description>
+      <Description>Rms Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6786,14 +6765,14 @@
     </item>
     <item>
       <EFDB_Name>guider_headerFilesList</EFDB_Name>
-      <Description>List of spec files to be read by this FITS service</Description>
+      <Description>List of spec files to be read by this FITS service (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>science_headerFilesList</EFDB_Name>
-      <Description>List of spec files to be read by this FITS service</Description>
+      <Description>List of spec files to be read by this FITS service (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6814,7 +6793,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_additionalFileCommands</EFDB_Name>
-      <Description>Commands to issue on additional (non FITS) files</Description>
+      <Description>Commands to issue on additional (non FITS) files (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6828,7 +6807,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_commands</EFDB_Name>
-      <Description>Commands to be issued after FITS files written</Description>
+      <Description>Commands to be issued after FITS files written (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6842,7 +6821,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_environment</EFDB_Name>
-      <Description>Environment variables to set when issuing FITS file commands</Description>
+      <Description>Environment variables to set when issuing FITS file commands (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -6989,7 +6968,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_subsystemsToClearOnNewRun</EFDB_Name>
-      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only)</Description>
+      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only) (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -1077,14 +1077,14 @@
     </item>
     <item>
       <EFDB_Name>filterNames</EFDB_Name>
-      <Description>Map of available filter names to types</Description>
+      <Description>Map of available filter names to types (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>filterTypes</EFDB_Name>
-      <Description>List of available filter types</Description>
+      <Description>List of available filter types (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -1861,56 +1861,56 @@
     </item>
     <item>
       <EFDB_Name>sumDriverChecks</EFDB_Name>
-      <Description>Driver Stats for warnings on sums</Description>
+      <Description>Driver Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumDriverStats</EFDB_Name>
-      <Description>Driver Stats for sums over location</Description>
+      <Description>Driver Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumFirmwareChecks</EFDB_Name>
-      <Description>Firmware Stats for warnings on sums</Description>
+      <Description>Firmware Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumFirmwareStats</EFDB_Name>
-      <Description>Firmware Stats for sums over location</Description>
+      <Description>Firmware Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRdsChecks</EFDB_Name>
-      <Description>Rds Stats for warnings on sums</Description>
+      <Description>Rds Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRdsStats</EFDB_Name>
-      <Description>Rds Stats for sums over location</Description>
+      <Description>Rds Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRmsChecks</EFDB_Name>
-      <Description>Rms Stats for warnings on sums</Description>
+      <Description>Rms Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRmsStats</EFDB_Name>
-      <Description>Rms Stats for sums over location</Description>
+      <Description>Rms Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -2300,7 +2300,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1541745519L -->
+    <!--CCS: Dictionary_Checksum: 4066292126L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -3469,7 +3469,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1342477388L -->
+    <!--CCS: Dictionary_Checksum: 1122639152L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5026,7 +5026,7 @@
     </item>
     <item>
       <EFDB_Name>serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5414,7 +5414,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration using level 1 for category Devices-->
@@ -7833,27 +7833,6 @@
       <Count>9</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=======================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>CCCamera</Subsystem>
-    <EFDB_Topic>CCCamera_logevent_focal_plane_Ccd_RaftsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 432390802L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>ccd location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
   <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
   <!--============================================================================================================================================================-->
   <SALEvent>
@@ -9806,7 +9785,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2936887366L -->
+    <!--CCS: Dictionary_Checksum: 3352229690L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -11524,7 +11503,7 @@
     </item>
     <item>
       <EFDB_Name>metaDataRegisters</EFDB_Name>
-      <Description>Names of meta-data related registers which must be in the sequencer</Description>
+      <Description>Names of meta-data related registers which must be in the sequencer (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11629,14 +11608,14 @@
     </item>
     <item>
       <EFDB_Name>sequencer</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sequencerChecksums</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11692,7 +11671,7 @@
     </item>
     <item>
       <EFDB_Name>webHooks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11713,14 +11692,14 @@
     </item>
     <item>
       <EFDB_Name>guider_headerFilesList</EFDB_Name>
-      <Description>List of spec files to be read by this FITS service</Description>
+      <Description>List of spec files to be read by this FITS service (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>science_headerFilesList</EFDB_Name>
-      <Description>List of spec files to be read by this FITS service</Description>
+      <Description>List of spec files to be read by this FITS service (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11741,7 +11720,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_additionalFileCommands</EFDB_Name>
-      <Description>Commands to issue on additional (non FITS) files</Description>
+      <Description>Commands to issue on additional (non FITS) files (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11755,7 +11734,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_commands</EFDB_Name>
-      <Description>Commands to be issued after FITS files written</Description>
+      <Description>Commands to be issued after FITS files written (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11769,7 +11748,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_environment</EFDB_Name>
-      <Description>Environment variables to set when issuing FITS file commands</Description>
+      <Description>Environment variables to set when issuing FITS file commands (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11916,7 +11895,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_subsystemsToClearOnNewRun</EFDB_Name>
-      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only)</Description>
+      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only) (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -665,7 +665,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_Reb</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 4145174168L -->
+    <!--CCS: Dictionary_Checksum: 2252133633L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO</EFDB_Name>
@@ -973,7 +973,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_Rebps</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 258615373L -->
+    <!--CCS: Dictionary_Checksum: 2343408552L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
       <EFDB_Name>boardTemp0</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -1429,7 +1429,7 @@
     </item>
     <item>
       <EFDB_Name>serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5180,7 +5180,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2456616912L -->
+    <!--CCS: Dictionary_Checksum: 1569289345L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -6507,7 +6507,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2677932763L -->
+    <!--CCS: Dictionary_Checksum: 3203409092L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -8631,7 +8631,7 @@
     </item>
     <item>
       <EFDB_Name>serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8813,7 +8813,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9065,30 +9065,30 @@
     </item>
     <item>
       <EFDB_Name>fanspeed_warnHi</EFDB_Name>
-      <Description>Fan Speed high warning level (RPM)</Description>
+      <Description>Fan Speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_warnLo</EFDB_Name>
-      <Description>Fan Speed low warning level (RPM)</Description>
+      <Description>Fan Speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitHi</EFDB_Name>
-      <Description>Fan Speed high alarm level (RPM)</Description>
+      <Description>Fan Speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitLo</EFDB_Name>
-      <Description>Fan Speed low alarm level (RPM)</Description>
+      <Description>Fan Speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -9366,7 +9366,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9618,30 +9618,30 @@
     </item>
     <item>
       <EFDB_Name>fanspeed_warnHi</EFDB_Name>
-      <Description>Fan Speed high warning level (RPM)</Description>
+      <Description>Fan Speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_warnLo</EFDB_Name>
-      <Description>Fan Speed low warning level (RPM)</Description>
+      <Description>Fan Speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitHi</EFDB_Name>
-      <Description>Fan Speed high alarm level (RPM)</Description>
+      <Description>Fan Speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitLo</EFDB_Name>
-      <Description>Fan Speed low alarm level (RPM)</Description>
+      <Description>Fan Speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -9919,7 +9919,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -10227,30 +10227,30 @@
     </item>
     <item>
       <EFDB_Name>fanspeed_warnHi</EFDB_Name>
-      <Description>Fan Speed high warning level (RPM)</Description>
+      <Description>Fan Speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_warnLo</EFDB_Name>
-      <Description>Fan Speed low warning level (RPM)</Description>
+      <Description>Fan Speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitHi</EFDB_Name>
-      <Description>Fan Speed high alarm level (RPM)</Description>
+      <Description>Fan Speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitLo</EFDB_Name>
-      <Description>Fan Speed low alarm level (RPM)</Description>
+      <Description>Fan Speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -10626,7 +10626,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -10878,30 +10878,30 @@
     </item>
     <item>
       <EFDB_Name>fanspeed_warnHi</EFDB_Name>
-      <Description>Fan Speed high warning level (RPM)</Description>
+      <Description>Fan Speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_warnLo</EFDB_Name>
-      <Description>Fan Speed low warning level (RPM)</Description>
+      <Description>Fan Speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitHi</EFDB_Name>
-      <Description>Fan Speed high alarm level (RPM)</Description>
+      <Description>Fan Speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitLo</EFDB_Name>
-      <Description>Fan Speed low alarm level (RPM)</Description>
+      <Description>Fan Speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -11179,7 +11179,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11487,30 +11487,30 @@
     </item>
     <item>
       <EFDB_Name>fanspeed_warnHi</EFDB_Name>
-      <Description>Fan Speed high warning level (RPM)</Description>
+      <Description>Fan Speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_warnLo</EFDB_Name>
-      <Description>Fan Speed low warning level (RPM)</Description>
+      <Description>Fan Speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitHi</EFDB_Name>
-      <Description>Fan Speed high alarm level (RPM)</Description>
+      <Description>Fan Speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitLo</EFDB_Name>
-      <Description>Fan Speed low alarm level (RPM)</Description>
+      <Description>Fan Speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -11886,7 +11886,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -12138,30 +12138,30 @@
     </item>
     <item>
       <EFDB_Name>fanspeed_warnHi</EFDB_Name>
-      <Description>Fan Speed high warning level (RPM)</Description>
+      <Description>Fan Speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_warnLo</EFDB_Name>
-      <Description>Fan Speed low warning level (RPM)</Description>
+      <Description>Fan Speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitHi</EFDB_Name>
-      <Description>Fan Speed high alarm level (RPM)</Description>
+      <Description>Fan Speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>fanspeed_limitLo</EFDB_Name>
-      <Description>Fan Speed low alarm level (RPM)</Description>
+      <Description>Fan Speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -13244,7 +13244,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -13300,7 +13300,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -13447,7 +13447,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -13752,30 +13752,30 @@
     </item>
     <item>
       <EFDB_Name>turbospeed_warnHi</EFDB_Name>
-      <Description>Cryo turbo pump speed high warning level (RPM)</Description>
+      <Description>Cryo turbo pump speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>turbospeed_warnLo</EFDB_Name>
-      <Description>Cryo turbo pump speed low warning level (RPM)</Description>
+      <Description>Cryo turbo pump speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>turbospeed_limitHi</EFDB_Name>
-      <Description>Cryo turbo pump speed high alarm level (RPM)</Description>
+      <Description>Cryo turbo pump speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>turbospeed_limitLo</EFDB_Name>
-      <Description>Cryo turbo pump speed low alarm level (RPM)</Description>
+      <Description>Cryo turbo pump speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -14088,30 +14088,30 @@
     </item>
     <item>
       <EFDB_Name>turbospeed_warnHi</EFDB_Name>
-      <Description>HX turbo pump speed high warning level (RPM)</Description>
+      <Description>HX turbo pump speed high warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>turbospeed_warnLo</EFDB_Name>
-      <Description>HX turbo pump speed low warning level (RPM)</Description>
+      <Description>HX turbo pump speed low warning level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>turbospeed_limitHi</EFDB_Name>
-      <Description>HX turbo pump speed high alarm level (RPM)</Description>
+      <Description>HX turbo pump speed high alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>turbospeed_limitLo</EFDB_Name>
-      <Description>HX turbo pump speed low alarm level (RPM)</Description>
+      <Description>HX turbo pump speed low alarm level</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -14175,7 +14175,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -14231,7 +14231,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -14378,7 +14378,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -14434,7 +14434,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>3</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration using level 1 for category Devices-->
@@ -14914,7 +14914,7 @@
     </item>
     <item>
       <EFDB_Name>serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -14963,7 +14963,7 @@
     </item>
     <item>
       <EFDB_Name>serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -15789,56 +15789,56 @@
     </item>
     <item>
       <EFDB_Name>sumDriverChecks</EFDB_Name>
-      <Description>Driver Stats for warnings on sums</Description>
+      <Description>Driver Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumDriverStats</EFDB_Name>
-      <Description>Driver Stats for sums over location</Description>
+      <Description>Driver Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumFirmwareChecks</EFDB_Name>
-      <Description>Firmware Stats for warnings on sums</Description>
+      <Description>Firmware Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumFirmwareStats</EFDB_Name>
-      <Description>Firmware Stats for sums over location</Description>
+      <Description>Firmware Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRdsChecks</EFDB_Name>
-      <Description>Rds Stats for warnings on sums</Description>
+      <Description>Rds Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRdsStats</EFDB_Name>
-      <Description>Rds Stats for sums over location</Description>
+      <Description>Rds Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRmsChecks</EFDB_Name>
-      <Description>Rms Stats for warnings on sums</Description>
+      <Description>Rms Stats for warnings on sums (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sumRmsStats</EFDB_Name>
-      <Description>Rms Stats for sums over location</Description>
+      <Description>Rms Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -16211,27 +16211,6 @@
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>201</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_RaftsConfiguration using level 1 for category Rafts-->
-  <!--=======================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_focal_plane_Ccd_RaftsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2502921873L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>location</EFDB_Name>
-      <Description>ccd location</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
@@ -18595,7 +18574,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2018670384L -->
+    <!--CCS: Dictionary_Checksum: 3517909367L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -20329,7 +20308,7 @@
     </item>
     <item>
       <EFDB_Name>metaDataRegisters</EFDB_Name>
-      <Description>Names of meta-data related registers which must be in the sequencer</Description>
+      <Description>Names of meta-data related registers which must be in the sequencer (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20434,14 +20413,14 @@
     </item>
     <item>
       <EFDB_Name>sequencer</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>sequencerChecksums</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20497,7 +20476,7 @@
     </item>
     <item>
       <EFDB_Name>webHooks</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20518,14 +20497,14 @@
     </item>
     <item>
       <EFDB_Name>guider_headerFilesList</EFDB_Name>
-      <Description>List of spec files to be read by this FITS service</Description>
+      <Description>List of spec files to be read by this FITS service (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>science_headerFilesList</EFDB_Name>
-      <Description>List of spec files to be read by this FITS service</Description>
+      <Description>List of spec files to be read by this FITS service (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20546,7 +20525,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_additionalFileCommands</EFDB_Name>
-      <Description>Commands to issue on additional (non FITS) files</Description>
+      <Description>Commands to issue on additional (non FITS) files (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20560,7 +20539,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_commands</EFDB_Name>
-      <Description>Commands to be issued after FITS files written</Description>
+      <Description>Commands to be issued after FITS files written (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20574,7 +20553,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_environment</EFDB_Name>
-      <Description>Environment variables to set when issuing FITS file commands</Description>
+      <Description>Environment variables to set when issuing FITS file commands (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20721,7 +20700,7 @@
     </item>
     <item>
       <EFDB_Name>imagehandlingconfig_subsystemsToClearOnNewRun</EFDB_Name>
-      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only)</Description>
+      <Description>Subsystems whose data should be cleared when a new run starts (SLAC only) (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -21394,14 +21373,14 @@
     <item>
       <EFDB_Name>onlineclamps_maxClosedStrain</EFDB_Name>
       <Description>if strain &gt;= maxClosedStrain, clamps are OPENED</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>short</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclamps_maxLockedStrain</EFDB_Name>
       <Description>if strain &lt; maxLockedStrain, clamps are LOCKED</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>short</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -21436,7 +21415,7 @@
     <item>
       <EFDB_Name>onlineclamps_minLockedStrain</EFDB_Name>
       <Description>if strain &lt; minLockedStrain, clamps may be in ERROR</Description>
-      <IDL_Type>string</IDL_Type>
+      <IDL_Type>short</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -23395,21 +23374,21 @@
     </item>
     <item>
       <EFDB_Name>actruckxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>actruckxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>actruckxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -23423,84 +23402,84 @@
     </item>
     <item>
       <EFDB_Name>actruckxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>actruckxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>actruckxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>carouselcontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>carouselcontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>carouselcontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>clampxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -23514,21 +23493,21 @@
     </item>
     <item>
       <EFDB_Name>latchxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>latchxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>latchxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -23542,21 +23521,21 @@
     </item>
     <item>
       <EFDB_Name>latchxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>latchxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>latchxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -23570,21 +23549,21 @@
     </item>
     <item>
       <EFDB_Name>onlineclampxminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclampxminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclampxminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -23598,21 +23577,21 @@
     </item>
     <item>
       <EFDB_Name>onlineclampxpluscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclampxpluscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclampxpluscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -23626,21 +23605,21 @@
     </item>
     <item>
       <EFDB_Name>onlineclampyminuscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclampyminuscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>onlineclampyminuscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -24032,42 +24011,42 @@
     </item>
     <item>
       <EFDB_Name>carriercontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>carriercontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>carriercontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hookscontroller_paramsForCurrent</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hookscontroller_paramsForHoming</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>hookscontroller_paramsForProfilePosition</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -27952,28 +27931,28 @@
     </item>
     <item>
       <EFDB_Name>controller_referenceMinusXpositions</EFDB_Name>
-      <Description>Reference positions for the -X blade set.</Description>
+      <Description>Reference positions for the -X blade set. (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>controller_referencePlusXpositions</EFDB_Name>
-      <Description>Reference positions for the +X blade set.</Description>
+      <Description>Reference positions for the +X blade set. (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>controller_safeCtrlTempRange</EFDB_Name>
-      <Description>Safe internal temperature range for motor controller modules.</Description>
+      <Description>Safe internal temperature range for motor controller modules. (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>controller_safeRtdTempRange</EFDB_Name>
-      <Description>Safe temperature ranges for RTD sites.</Description>
+      <Description>Safe temperature ranges for RTD sites. (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -28085,7 +28064,7 @@
     </item>
     <item>
       <EFDB_Name>maq20_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -28470,7 +28449,7 @@
     </item>
     <item>
       <EFDB_Name>rtds_serials</EFDB_Name>
-      <Description>serial numbers of MAQ20 modules</Description>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -29432,7 +29411,7 @@
     </item>
     <item>
       <EFDB_Name>coldtempctrlc_tempWeights</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -29453,7 +29432,7 @@
     </item>
     <item>
       <EFDB_Name>coldtempctrlmye_tempWeights</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -29474,7 +29453,7 @@
     </item>
     <item>
       <EFDB_Name>coldtempctrlpye_tempWeights</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -29495,7 +29474,7 @@
     </item>
     <item>
       <EFDB_Name>cryotempctrl_tempWeights</EFDB_Name>
-      <Description>MISSING</Description>
+      <Description>MISSING (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -29505,7 +29484,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>6</Count>
     </item>
     <item>
       <EFDB_Name>trimpower_connType</EFDB_Name>
@@ -29519,7 +29498,7 @@
       <Description>MISSING</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
-      <Count>1</Count>
+      <Count>6</Count>
     </item>
     <item>
       <EFDB_Name>trimpower_devcId</EFDB_Name>
@@ -29715,6 +29694,3058 @@
       <Description>period for task thermal-state</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_DevicesConfiguration using level 1 for category Devices-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_BFR_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2446993154L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_UtilConfiguration using level 1 for category Util-->
+  <!--===================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_BFR_UtilConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 4110331987L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DeviceConfiguration using level 1 for category Device-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_BodyMaq20_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3603424438L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_BodyMaq20_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 891925327L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_LimitsConfiguration using level 1 for category Limits-->
+  <!--========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 634225295L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambairtemp_warnHi</EFDB_Name>
+      <Description>Ambient air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambairtemp_warnLo</EFDB_Name>
+      <Description>Ambient air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambairtemp_limitHi</EFDB_Name>
+      <Description>Ambient air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambairtemp_limitLo</EFDB_Name>
+      <Description>Ambient air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_warnHi</EFDB_Name>
+      <Description>Camera average temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_warnLo</EFDB_Name>
+      <Description>Camera average temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_limitHi</EFDB_Name>
+      <Description>Camera average temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_limitLo</EFDB_Name>
+      <Description>Camera average temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxminustemp_warnHi</EFDB_Name>
+      <Description>Back flange X- in temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxminustemp_warnLo</EFDB_Name>
+      <Description>Back flange X- in temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxminustemp_limitHi</EFDB_Name>
+      <Description>Back flange X- in temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxminustemp_limitLo</EFDB_Name>
+      <Description>Back flange X- in temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxplustemp_warnHi</EFDB_Name>
+      <Description>Back flange X+ in temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxplustemp_warnLo</EFDB_Name>
+      <Description>Back flange X+ in temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxplustemp_limitHi</EFDB_Name>
+      <Description>Back flange X+ in temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngxplustemp_limitLo</EFDB_Name>
+      <Description>Back flange X+ in temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngyminustemp_warnHi</EFDB_Name>
+      <Description>Back flange Y- in temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngyminustemp_warnLo</EFDB_Name>
+      <Description>Back flange Y- in temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngyminustemp_limitHi</EFDB_Name>
+      <Description>Back flange Y- in temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backflngyminustemp_limitLo</EFDB_Name>
+      <Description>Back flange Y- in temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyxplustemp_warnHi</EFDB_Name>
+      <Description>Camera body X+ air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyxplustemp_warnLo</EFDB_Name>
+      <Description>Camera body X+ air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyxplustemp_limitHi</EFDB_Name>
+      <Description>Camera body X+ air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyxplustemp_limitLo</EFDB_Name>
+      <Description>Camera body X+ air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyminustemp_warnHi</EFDB_Name>
+      <Description>Camera body Y- air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyminustemp_warnLo</EFDB_Name>
+      <Description>Camera body Y- air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyminustemp_limitHi</EFDB_Name>
+      <Description>Camera body Y- air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyminustemp_limitLo</EFDB_Name>
+      <Description>Camera body Y- air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyplustemp_warnHi</EFDB_Name>
+      <Description>Camera body Y+ air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyplustemp_warnLo</EFDB_Name>
+      <Description>Camera body Y+ air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyplustemp_limitHi</EFDB_Name>
+      <Description>Camera body Y+ air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cambodyyplustemp_limitLo</EFDB_Name>
+      <Description>Camera body Y+ air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxminustemp_warnHi</EFDB_Name>
+      <Description>Camera housing X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxminustemp_warnLo</EFDB_Name>
+      <Description>Camera housing X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxminustemp_limitHi</EFDB_Name>
+      <Description>Camera housing X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxminustemp_limitLo</EFDB_Name>
+      <Description>Camera housing X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxplustemp_warnHi</EFDB_Name>
+      <Description>Camera housing X+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxplustemp_warnLo</EFDB_Name>
+      <Description>Camera housing X+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxplustemp_limitHi</EFDB_Name>
+      <Description>Camera housing X+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousxplustemp_limitLo</EFDB_Name>
+      <Description>Camera housing X+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyminustemp_warnHi</EFDB_Name>
+      <Description>Camera housing Y- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyminustemp_warnLo</EFDB_Name>
+      <Description>Camera housing Y- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyminustemp_limitHi</EFDB_Name>
+      <Description>Camera housing Y- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyminustemp_limitLo</EFDB_Name>
+      <Description>Camera housing Y- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyplustemp_warnHi</EFDB_Name>
+      <Description>Camera housing Y+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyplustemp_warnLo</EFDB_Name>
+      <Description>Camera housing Y+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyplustemp_limitHi</EFDB_Name>
+      <Description>Camera housing Y+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camhousyplustemp_limitLo</EFDB_Name>
+      <Description>Camera housing Y+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairtemp_warnHi</EFDB_Name>
+      <Description>Autochanger Y- return air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairtemp_warnLo</EFDB_Name>
+      <Description>Autochanger Y- return air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairtemp_limitHi</EFDB_Name>
+      <Description>Autochanger Y- return air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairtemp_limitLo</EFDB_Name>
+      <Description>Autochanger Y- return air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairvel_warnHi</EFDB_Name>
+      <Description>Autochanger Y- return air velocity high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairvel_warnLo</EFDB_Name>
+      <Description>Autochanger Y- return air velocity low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairvel_limitHi</EFDB_Name>
+      <Description>Autochanger Y- return air velocity high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgryminusrtnairvel_limitLo</EFDB_Name>
+      <Description>Autochanger Y- return air velocity low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_warnHi</EFDB_Name>
+      <Description>Dome X- air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_warnLo</EFDB_Name>
+      <Description>Dome X- air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_limitHi</EFDB_Name>
+      <Description>Dome X- air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_limitLo</EFDB_Name>
+      <Description>Dome X- air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_warnHi</EFDB_Name>
+      <Description>Dome Y- air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_warnLo</EFDB_Name>
+      <Description>Dome Y- air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_limitHi</EFDB_Name>
+      <Description>Dome Y- air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_limitLo</EFDB_Name>
+      <Description>Dome Y- air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1xminustemp_warnHi</EFDB_Name>
+      <Description>L1 X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1xminustemp_warnLo</EFDB_Name>
+      <Description>L1 X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1xminustemp_limitHi</EFDB_Name>
+      <Description>L1 X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1xminustemp_limitLo</EFDB_Name>
+      <Description>L1 X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1yminustemp_warnHi</EFDB_Name>
+      <Description>L1 Y- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1yminustemp_warnLo</EFDB_Name>
+      <Description>L1 Y- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1yminustemp_limitHi</EFDB_Name>
+      <Description>L1 Y- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1yminustemp_limitLo</EFDB_Name>
+      <Description>L1 Y- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xminustemp_warnHi</EFDB_Name>
+      <Description>L2 X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xminustemp_warnLo</EFDB_Name>
+      <Description>L2 X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xminustemp_limitHi</EFDB_Name>
+      <Description>L2 X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xminustemp_limitLo</EFDB_Name>
+      <Description>L2 X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xplustemp_warnHi</EFDB_Name>
+      <Description>L2 X+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xplustemp_warnLo</EFDB_Name>
+      <Description>L2 X+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xplustemp_limitHi</EFDB_Name>
+      <Description>L2 X+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2xplustemp_limitLo</EFDB_Name>
+      <Description>L2 X+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yminustemp_warnHi</EFDB_Name>
+      <Description>L2 Y- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yminustemp_warnLo</EFDB_Name>
+      <Description>L2 Y- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yminustemp_limitHi</EFDB_Name>
+      <Description>L2 Y- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yminustemp_limitLo</EFDB_Name>
+      <Description>L2 Y- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yplustemp_warnHi</EFDB_Name>
+      <Description>L2 Y+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yplustemp_warnLo</EFDB_Name>
+      <Description>L2 Y+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yplustemp_limitHi</EFDB_Name>
+      <Description>L2 Y+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2yplustemp_limitLo</EFDB_Name>
+      <Description>L2 Y+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxminustemp_warnHi</EFDB_Name>
+      <Description>Shroud ring X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxminustemp_warnLo</EFDB_Name>
+      <Description>Shroud ring X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxminustemp_limitHi</EFDB_Name>
+      <Description>Shroud ring X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxminustemp_limitLo</EFDB_Name>
+      <Description>Shroud ring X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxplustemp_warnHi</EFDB_Name>
+      <Description>Shroud ring X+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxplustemp_warnLo</EFDB_Name>
+      <Description>Shroud ring X+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxplustemp_limitHi</EFDB_Name>
+      <Description>Shroud ring X+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngxplustemp_limitLo</EFDB_Name>
+      <Description>Shroud ring X+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyminustemp_warnHi</EFDB_Name>
+      <Description>Shroud ring Y- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyminustemp_warnLo</EFDB_Name>
+      <Description>Shroud ring Y- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyminustemp_limitHi</EFDB_Name>
+      <Description>Shroud ring Y- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyminustemp_limitLo</EFDB_Name>
+      <Description>Shroud ring Y- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyplustemp_warnHi</EFDB_Name>
+      <Description>Shroud ring Y+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyplustemp_warnLo</EFDB_Name>
+      <Description>Shroud ring Y+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyplustemp_limitHi</EFDB_Name>
+      <Description>Shroud ring Y+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdrngyplustemp_limitLo</EFDB_Name>
+      <Description>Shroud ring Y+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairtemp_warnHi</EFDB_Name>
+      <Description>Shutter electronics return air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairtemp_warnLo</EFDB_Name>
+      <Description>Shutter electronics return air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairtemp_limitHi</EFDB_Name>
+      <Description>Shutter electronics return air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairtemp_limitLo</EFDB_Name>
+      <Description>Shutter electronics return air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairvel_warnHi</EFDB_Name>
+      <Description>Shutter electronics return air velocity high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairvel_warnLo</EFDB_Name>
+      <Description>Shutter electronics return air velocity low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairvel_limitHi</EFDB_Name>
+      <Description>Shutter electronics return air velocity high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtreboxrtnairvel_limitLo</EFDB_Name>
+      <Description>Shutter electronics return air velocity low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairtemp_warnHi</EFDB_Name>
+      <Description>Shutter motors return air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairtemp_warnLo</EFDB_Name>
+      <Description>Shutter motors return air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairtemp_limitHi</EFDB_Name>
+      <Description>Shutter motors return air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairtemp_limitLo</EFDB_Name>
+      <Description>Shutter motors return air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairvel_warnHi</EFDB_Name>
+      <Description>Shutter motors return air velocity high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairvel_warnLo</EFDB_Name>
+      <Description>Shutter motors return air velocity low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairvel_limitHi</EFDB_Name>
+      <Description>Shutter motors return air velocity high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrmtrrtnairvel_limitLo</EFDB_Name>
+      <Description>Shutter motors return air velocity low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vpplenumintemp_warnHi</EFDB_Name>
+      <Description>VP plenum in temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vpplenumintemp_warnLo</EFDB_Name>
+      <Description>VP plenum in temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vpplenumintemp_limitHi</EFDB_Name>
+      <Description>VP plenum in temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vpplenumintemp_limitLo</EFDB_Name>
+      <Description>VP plenum in temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DeviceConfiguration using level 1 for category Device-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_CryoMaq20_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2090781872L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_CryoMaq20_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2877244163L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPCFan_PicConfiguration using level 1 for category Pic-->
+  <!--====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_MPCFan_PicConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1133520787L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>baseDuty</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxRpm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minRpm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>offDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_LimitsConfiguration using level 1 for category Limits-->
+  <!--=======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2434245818L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>avgairtempout_warnHi</EFDB_Name>
+      <Description>MPC average air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>avgairtempout_warnLo</EFDB_Name>
+      <Description>MPC average air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>avgairtempout_limitHi</EFDB_Name>
+      <Description>MPC average air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>avgairtempout_limitLo</EFDB_Name>
+      <Description>MPC average air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_warnHi</EFDB_Name>
+      <Description>MPC filter delta pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_warnLo</EFDB_Name>
+      <Description>MPC filter delta pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_limitHi</EFDB_Name>
+      <Description>MPC filter delta pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_limitLo</EFDB_Name>
+      <Description>MPC filter delta pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_warnHi</EFDB_Name>
+      <Description>MPC total delta pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_warnLo</EFDB_Name>
+      <Description>MPC total delta pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_limitHi</EFDB_Name>
+      <Description>MPC total delta pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_limitLo</EFDB_Name>
+      <Description>MPC total delta pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_warnHi</EFDB_Name>
+      <Description>MPC actual delta temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_warnLo</EFDB_Name>
+      <Description>MPC actual delta temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_limitHi</EFDB_Name>
+      <Description>MPC actual delta temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_limitLo</EFDB_Name>
+      <Description>MPC actual delta temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_warnHi</EFDB_Name>
+      <Description>MPC fan accumulated run time high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_warnLo</EFDB_Name>
+      <Description>MPC fan accumulated run time low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_limitHi</EFDB_Name>
+      <Description>MPC fan accumulated run time high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_limitLo</EFDB_Name>
+      <Description>MPC fan accumulated run time low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_warnHi</EFDB_Name>
+      <Description>MPC fan speed high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_warnLo</EFDB_Name>
+      <Description>MPC fan speed low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_limitHi</EFDB_Name>
+      <Description>MPC fan speed high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_limitLo</EFDB_Name>
+      <Description>MPC fan speed low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_warnHi</EFDB_Name>
+      <Description>MPC relative humidity high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_warnLo</EFDB_Name>
+      <Description>MPC relative humidity low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_limitHi</EFDB_Name>
+      <Description>MPC relative humidity high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_limitLo</EFDB_Name>
+      <Description>MPC relative humidity low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_warnHi</EFDB_Name>
+      <Description>MPC pre-filter air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_warnLo</EFDB_Name>
+      <Description>MPC pre-filter air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_limitHi</EFDB_Name>
+      <Description>MPC pre-filter air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_limitLo</EFDB_Name>
+      <Description>MPC pre-filter air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_warnHi</EFDB_Name>
+      <Description>MPC return air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_warnLo</EFDB_Name>
+      <Description>MPC return air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_limitHi</EFDB_Name>
+      <Description>MPC return air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_limitLo</EFDB_Name>
+      <Description>MPC return air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_warnHi</EFDB_Name>
+      <Description>MPC return air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_warnLo</EFDB_Name>
+      <Description>MPC return air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_limitHi</EFDB_Name>
+      <Description>MPC return air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_limitLo</EFDB_Name>
+      <Description>MPC return air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_warnHi</EFDB_Name>
+      <Description>MPC supply air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_warnLo</EFDB_Name>
+      <Description>MPC supply air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_limitHi</EFDB_Name>
+      <Description>MPC supply air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_limitLo</EFDB_Name>
+      <Description>MPC supply air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_warnHi</EFDB_Name>
+      <Description>MPC supply air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_warnLo</EFDB_Name>
+      <Description>MPC supply air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_limitHi</EFDB_Name>
+      <Description>MPC supply air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_limitLo</EFDB_Name>
+      <Description>MPC supply air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_warnHi</EFDB_Name>
+      <Description>MPC coolant valve position high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_warnLo</EFDB_Name>
+      <Description>MPC coolant valve position low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_limitHi</EFDB_Name>
+      <Description>MPC coolant valve position high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_limitLo</EFDB_Name>
+      <Description>MPC coolant valve position low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_DevicesConfiguration using level 1 for category Devices-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_PDU_48V_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3204833872L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_UtilConfiguration using level 1 for category Util-->
+  <!--=======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_PDU_48V_UtilConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3137032959L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--===================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2021200639L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_default_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_default_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_update_publish_scheduler_nTasks</EFDB_Name>
+      <Description>Number of tasks assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>schedulers_monitor_update_publish_scheduler_nThreads</EFDB_Name>
+      <Description>Number of threads assigned to the Scheduler.</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_PicConfiguration using level 1 for category Pic-->
+  <!--===========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_PicConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2197991207L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fan_loop_MPCFan_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fan_loop_UTFan_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fan_loop_VPCFan_updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--=================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3326406085L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>agentmonitorservice_taskPeriodMillis</EFDB_Name>
+      <Description>period for task agentMonitorService</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>heartbeat_taskPeriodMillis</EFDB_Name>
+      <Description>period for task heartbeat</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_check_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-check</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_publish_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-publish</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>monitor_update_taskPeriodMillis</EFDB_Name>
+      <Description>period for task monitor-update</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>runtimeinfo_taskPeriodMillis</EFDB_Name>
+      <Description>period for task runtimeInfo</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ut_alarms_taskPeriodMillis</EFDB_Name>
+      <Description>period for task UT-alarms</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ut_state_taskPeriodMillis</EFDB_Name>
+      <Description>period for task UT-state</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vpc_loop_VPCHtrs_taskPeriodMillis</EFDB_Name>
+      <Description>period for task vpc-loop-VPCHtrs</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DeviceConfiguration using level 1 for category Device-->
+  <!--=========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_Pluto_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1138719255L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DevicesConfiguration using level 1 for category Devices-->
+  <!--===========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_Pluto_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1185941047L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Telescope_DevicesConfiguration using level 1 for category Devices-->
+  <!--===============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_Telescope_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2147095324L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UTFan_PicConfiguration using level 1 for category Pic-->
+  <!--===================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UTFan_PicConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3954954148L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>baseDuty</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxRpm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minRpm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>offDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_LimitsConfiguration using level 1 for category Limits-->
+  <!--======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1576580427L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_warnHi</EFDB_Name>
+      <Description>UT weighted average temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_warnLo</EFDB_Name>
+      <Description>UT weighted average temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_limitHi</EFDB_Name>
+      <Description>UT weighted average temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averagetemp_limitLo</EFDB_Name>
+      <Description>UT weighted average temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolflowrate_warnHi</EFDB_Name>
+      <Description>UT coolant flow rate high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolflowrate_warnLo</EFDB_Name>
+      <Description>UT coolant flow rate low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolflowrate_limitHi</EFDB_Name>
+      <Description>UT coolant flow rate high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolflowrate_limitLo</EFDB_Name>
+      <Description>UT coolant flow rate low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpiperetntemp_warnHi</EFDB_Name>
+      <Description>UT coolant pipe return temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpiperetntemp_warnLo</EFDB_Name>
+      <Description>UT coolant pipe return temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpiperetntemp_limitHi</EFDB_Name>
+      <Description>UT coolant pipe return temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpiperetntemp_limitLo</EFDB_Name>
+      <Description>UT coolant pipe return temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpipesplytemp_warnHi</EFDB_Name>
+      <Description>UT coolant pipe supply temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpipesplytemp_warnLo</EFDB_Name>
+      <Description>UT coolant pipe supply temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpipesplytemp_limitHi</EFDB_Name>
+      <Description>UT coolant pipe supply temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolpipesplytemp_limitLo</EFDB_Name>
+      <Description>UT coolant pipe supply temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolreturnprs_warnHi</EFDB_Name>
+      <Description>UT coolant return pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolreturnprs_warnLo</EFDB_Name>
+      <Description>UT coolant return pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolreturnprs_limitHi</EFDB_Name>
+      <Description>UT coolant return pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolreturnprs_limitLo</EFDB_Name>
+      <Description>UT coolant return pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolsupplyprs_warnHi</EFDB_Name>
+      <Description>UT coolant supply pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolsupplyprs_warnLo</EFDB_Name>
+      <Description>UT coolant supply pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolsupplyprs_limitHi</EFDB_Name>
+      <Description>UT coolant supply pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolsupplyprs_limitLo</EFDB_Name>
+      <Description>UT coolant supply pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_warnHi</EFDB_Name>
+      <Description>Telescope dome X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_warnLo</EFDB_Name>
+      <Description>Telescope dome X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_limitHi</EFDB_Name>
+      <Description>Telescope dome X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domexminustemp_limitLo</EFDB_Name>
+      <Description>Telescope dome X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_warnHi</EFDB_Name>
+      <Description>Telescope dome Y- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_warnLo</EFDB_Name>
+      <Description>Telescope dome Y- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_limitHi</EFDB_Name>
+      <Description>Telescope dome Y- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeyminustemp_limitLo</EFDB_Name>
+      <Description>Telescope dome Y- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>faninlettemp_warnHi</EFDB_Name>
+      <Description>UT fan inlet temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>faninlettemp_warnLo</EFDB_Name>
+      <Description>UT fan inlet temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>faninlettemp_limitHi</EFDB_Name>
+      <Description>UT fan inlet temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>faninlettemp_limitLo</EFDB_Name>
+      <Description>UT fan inlet temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_warnHi</EFDB_Name>
+      <Description>UT fan accumulated run time high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_warnLo</EFDB_Name>
+      <Description>UT fan accumulated run time low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_limitHi</EFDB_Name>
+      <Description>UT fan accumulated run time high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_limitLo</EFDB_Name>
+      <Description>UT fan accumulated run time low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_warnHi</EFDB_Name>
+      <Description>UT fan speed high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_warnLo</EFDB_Name>
+      <Description>UT fan speed low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_limitHi</EFDB_Name>
+      <Description>UT fan speed high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_limitLo</EFDB_Name>
+      <Description>UT fan speed low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxminustemp_warnHi</EFDB_Name>
+      <Description>UT Mid-plate X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxminustemp_warnLo</EFDB_Name>
+      <Description>UT Mid-plate X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxminustemp_limitHi</EFDB_Name>
+      <Description>UT Mid-plate X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxminustemp_limitLo</EFDB_Name>
+      <Description>UT Mid-plate X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxplustemp_warnHi</EFDB_Name>
+      <Description>UT Mid-plate X+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxplustemp_warnLo</EFDB_Name>
+      <Description>UT Mid-plate X+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxplustemp_limitHi</EFDB_Name>
+      <Description>UT Mid-plate X+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midxplustemp_limitLo</EFDB_Name>
+      <Description>UT Mid-plate X+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxminustemp_warnHi</EFDB_Name>
+      <Description>UT Support ring X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxminustemp_warnLo</EFDB_Name>
+      <Description>UT Support ring X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxminustemp_limitHi</EFDB_Name>
+      <Description>UT Support ring X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxminustemp_limitLo</EFDB_Name>
+      <Description>UT Support ring X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxplustemp_warnHi</EFDB_Name>
+      <Description>UT Support ring X+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxplustemp_warnLo</EFDB_Name>
+      <Description>UT Support ring X+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxplustemp_limitHi</EFDB_Name>
+      <Description>UT Support ring X+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppxplustemp_limitLo</EFDB_Name>
+      <Description>UT Support ring X+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxminustemp_warnHi</EFDB_Name>
+      <Description>UT Top end X- temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxminustemp_warnLo</EFDB_Name>
+      <Description>UT Top end X- temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxminustemp_limitHi</EFDB_Name>
+      <Description>UT Top end X- temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxminustemp_limitLo</EFDB_Name>
+      <Description>UT Top end X- temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxplustemp_warnHi</EFDB_Name>
+      <Description>UT Top end X+ temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxplustemp_warnLo</EFDB_Name>
+      <Description>UT Top end X+ temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxplustemp_limitHi</EFDB_Name>
+      <Description>UT Top end X+ temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topxplustemp_limitLo</EFDB_Name>
+      <Description>UT Top end X+ temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_warnHi</EFDB_Name>
+      <Description>UT coolant valve position high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_warnLo</EFDB_Name>
+      <Description>UT coolant valve position low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_limitHi</EFDB_Name>
+      <Description>UT coolant valve position high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_limitLo</EFDB_Name>
+      <Description>UT coolant valve position low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w2q1temp_warnHi</EFDB_Name>
+      <Description>UT W2 Q1 temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w2q1temp_warnLo</EFDB_Name>
+      <Description>UT W2 Q1 temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w2q1temp_limitHi</EFDB_Name>
+      <Description>UT W2 Q1 temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w2q1temp_limitLo</EFDB_Name>
+      <Description>UT W2 Q1 temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w4q3temp_warnHi</EFDB_Name>
+      <Description>UT W4 Q3 temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w4q3temp_warnLo</EFDB_Name>
+      <Description>UT W4 Q3 temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w4q3temp_limitHi</EFDB_Name>
+      <Description>UT W4 Q3 temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w4q3temp_limitLo</EFDB_Name>
+      <Description>UT W4 Q3 temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DeviceConfiguration using level 1 for category Device-->
+  <!--===========================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UtMaq20_DeviceConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 379862014L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>node</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>serials</EFDB_Name>
+      <Description>serial numbers of MAQ20 modules (colon delimited array)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--=============================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UtMaq20_DevicesConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3559070750L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disabled</EFDB_Name>
+      <Description>If true, Device is diabled</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtilConfiguration using level 1 for category Util-->
+  <!--===============================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UtilConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 999754620L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxTemperature</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCFan_PicConfiguration using level 1 for category Pic-->
+  <!--====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_VPCFan_PicConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2195939940L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>awGain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>baseDuty</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>gain</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxRpm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minInput</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minRpm</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>offDutyCycle</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>smoothTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timeConst</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>tolerance</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCHtrs_VpcConfiguration using level 1 for category Vpc-->
+  <!--=====================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_VPCHtrs_VpcConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3841190064L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaTemps</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>2</Count>
+    </item>
+    <item>
+      <EFDB_Name>updateTime</EFDB_Name>
+      <Description>MISSING</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_LimitsConfiguration using level 1 for category Limits-->
+  <!--=======================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_LimitsConfiguration</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 904113391L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_warnHi</EFDB_Name>
+      <Description>VPC filter delta pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_warnLo</EFDB_Name>
+      <Description>VPC filter delta pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_limitHi</EFDB_Name>
+      <Description>VPC filter delta pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapressfilt_limitLo</EFDB_Name>
+      <Description>VPC filter delta pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_warnHi</EFDB_Name>
+      <Description>VPC total delta pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_warnLo</EFDB_Name>
+      <Description>VPC total delta pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_limitHi</EFDB_Name>
+      <Description>VPC total delta pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltapresstotal_limitLo</EFDB_Name>
+      <Description>VPC total delta pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_warnHi</EFDB_Name>
+      <Description>VPC actual delta temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_warnLo</EFDB_Name>
+      <Description>VPC actual delta temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_limitHi</EFDB_Name>
+      <Description>VPC actual delta temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltatempact_limitLo</EFDB_Name>
+      <Description>VPC actual delta temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_warnHi</EFDB_Name>
+      <Description>VPC fan accumulated run time high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_warnLo</EFDB_Name>
+      <Description>VPC fan accumulated run time low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_limitHi</EFDB_Name>
+      <Description>VPC fan accumulated run time high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanruntime_limitLo</EFDB_Name>
+      <Description>VPC fan accumulated run time low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_warnHi</EFDB_Name>
+      <Description>VPC fan speed high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_warnLo</EFDB_Name>
+      <Description>VPC fan speed low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_limitHi</EFDB_Name>
+      <Description>VPC fan speed high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanspeed_limitLo</EFDB_Name>
+      <Description>VPC fan speed low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrcurrent_warnHi</EFDB_Name>
+      <Description>VPC heater current high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrcurrent_warnLo</EFDB_Name>
+      <Description>VPC heater current low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrcurrent_limitHi</EFDB_Name>
+      <Description>VPC heater current high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrcurrent_limitLo</EFDB_Name>
+      <Description>VPC heater current low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_warnHi</EFDB_Name>
+      <Description>VPC relative humidity high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_warnLo</EFDB_Name>
+      <Description>VPC relative humidity low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_limitHi</EFDB_Name>
+      <Description>VPC relative humidity high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity_limitLo</EFDB_Name>
+      <Description>VPC relative humidity low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_warnHi</EFDB_Name>
+      <Description>VPC pre-filter air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_warnLo</EFDB_Name>
+      <Description>VPC pre-filter air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_limitHi</EFDB_Name>
+      <Description>VPC pre-filter air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>prefiltpress_limitLo</EFDB_Name>
+      <Description>VPC pre-filter air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_warnHi</EFDB_Name>
+      <Description>VPC return air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_warnLo</EFDB_Name>
+      <Description>VPC return air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_limitHi</EFDB_Name>
+      <Description>VPC return air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnairtemp_limitLo</EFDB_Name>
+      <Description>VPC return air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_warnHi</EFDB_Name>
+      <Description>VPC return air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_warnLo</EFDB_Name>
+      <Description>VPC return air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_limitHi</EFDB_Name>
+      <Description>VPC return air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnpress_limitLo</EFDB_Name>
+      <Description>VPC return air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_warnHi</EFDB_Name>
+      <Description>VPC supply air temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_warnLo</EFDB_Name>
+      <Description>VPC supply air temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_limitHi</EFDB_Name>
+      <Description>VPC supply air temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairtemp_limitLo</EFDB_Name>
+      <Description>VPC supply air temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairvel_warnHi</EFDB_Name>
+      <Description>VPC supply air velocity high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairvel_warnLo</EFDB_Name>
+      <Description>VPC supply air velocity low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairvel_limitHi</EFDB_Name>
+      <Description>VPC supply air velocity high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyairvel_limitLo</EFDB_Name>
+      <Description>VPC supply air velocity low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_warnHi</EFDB_Name>
+      <Description>VPC supply air pressure high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_warnLo</EFDB_Name>
+      <Description>VPC supply air pressure low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_limitHi</EFDB_Name>
+      <Description>VPC supply air pressure high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splypress_limitLo</EFDB_Name>
+      <Description>VPC supply air pressure low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_warnHi</EFDB_Name>
+      <Description>VPC coolant valve position high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_warnLo</EFDB_Name>
+      <Description>VPC coolant valve position low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_limitHi</EFDB_Name>
+      <Description>VPC coolant valve position high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valveposn_limitLo</EFDB_Name>
+      <Description>VPC coolant valve position low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
   </SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -789,7 +789,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Reb</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3712155700L -->
+    <!--CCS: Dictionary_Checksum: 72957452L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO</EFDB_Name>
@@ -1137,7 +1137,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Rebps</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 2375833259L -->
+    <!--CCS: Dictionary_Checksum: 187346552L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
       <EFDB_Name>boardTemp0</EFDB_Name>
@@ -1729,9 +1729,9 @@
     </item>
     <item>
       <EFDB_Name>fanSpeed</EFDB_Name>
-      <Description>Fan Speed (RPM)</Description>
+      <Description>Fan Speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -1855,9 +1855,9 @@
     </item>
     <item>
       <EFDB_Name>fanSpeed</EFDB_Name>
-      <Description>Fan Speed (RPM)</Description>
+      <Description>Fan Speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -1995,9 +1995,9 @@
     </item>
     <item>
       <EFDB_Name>fanSpeed</EFDB_Name>
-      <Description>Fan Speed (RPM)</Description>
+      <Description>Fan Speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -2121,9 +2121,9 @@
     </item>
     <item>
       <EFDB_Name>fanSpeed</EFDB_Name>
-      <Description>Fan Speed (RPM)</Description>
+      <Description>Fan Speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -2261,9 +2261,9 @@
     </item>
     <item>
       <EFDB_Name>fanSpeed</EFDB_Name>
-      <Description>Fan Speed (RPM)</Description>
+      <Description>Fan Speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -2387,9 +2387,9 @@
     </item>
     <item>
       <EFDB_Name>fanSpeed</EFDB_Name>
-      <Description>Fan Speed (RPM)</Description>
+      <Description>Fan Speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -2640,9 +2640,9 @@
     </item>
     <item>
       <EFDB_Name>turboSpeed</EFDB_Name>
-      <Description>Cryo turbo pump speed (RPM)</Description>
+      <Description>Cryo turbo pump speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -2766,9 +2766,9 @@
     </item>
     <item>
       <EFDB_Name>turboSpeed</EFDB_Name>
-      <Description>HX turbo pump speed (RPM)</Description>
+      <Description>HX turbo pump speed</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -4013,7 +4013,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Autochanger_AutochangerTrucks_Trending</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 1312796863L -->
+    <!--CCS: Dictionary_Checksum: 2202000250L -->
     <item>
       <EFDB_Name>actruckxminus_handoffInError</EFDB_Name>
       <Description>are autochanger truck position sensors at handoff in error</Description>
@@ -4039,13 +4039,6 @@
       <EFDB_Name>actruckxminus_onlineSensorValue</EFDB_Name>
       <Description>is the autochanger truck at online position</Description>
       <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxminus_position</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -4088,13 +4081,6 @@
       <EFDB_Name>actruckxplus_onlineSensorValue</EFDB_Name>
       <Description>is the autochanger truck at online position</Description>
       <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>actruckxplus_position</EFDB_Name>
-      <Description>MISSING</Description>
-      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -5556,23 +5542,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -5584,9 +5570,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -5675,23 +5661,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -5703,9 +5689,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -5717,21 +5703,21 @@
     <!--CCS: Dictionary_Checksum: 2319033051L -->
     <item>
       <EFDB_Name>accelerationX</EFDB_Name>
-      <Description>angular acceleration along the X axis (RPM)</Description>
+      <Description>angular acceleration along the X axis</Description>
       <IDL_Type>double</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>accelerationY</EFDB_Name>
-      <Description>angular acceleration along the Y axis (RPM)</Description>
+      <Description>angular acceleration along the Y axis</Description>
       <IDL_Type>double</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>accelerationZ</EFDB_Name>
-      <Description>angular acceleration along the Z axis (RPM)</Description>
+      <Description>angular acceleration along the Z axis</Description>
       <IDL_Type>double</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
@@ -5745,23 +5731,23 @@
     </item>
     <item>
       <EFDB_Name>angularVelocityX</EFDB_Name>
-      <Description>angular velocity along the X axis (RPM)</Description>
+      <Description>angular velocity along the X axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>angularVelocityY</EFDB_Name>
-      <Description>angular velocity along the Y axis (RPM)</Description>
+      <Description>angular velocity along the Y axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>angularVelocityZ</EFDB_Name>
-      <Description>angular velocity along the Z axis (RPM)</Description>
+      <Description>angular velocity along the Z axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -6858,23 +6844,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -6886,9 +6872,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -6977,23 +6963,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7005,9 +6991,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -7096,23 +7082,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7124,9 +7110,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -7243,23 +7229,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7271,9 +7257,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -7362,23 +7348,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7390,9 +7376,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -7481,23 +7467,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7509,9 +7495,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -7600,23 +7586,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7628,9 +7614,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -7719,23 +7705,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7747,9 +7733,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -8048,23 +8034,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -8076,9 +8062,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -8167,23 +8153,23 @@
     </item>
     <item>
       <EFDB_Name>profileAcceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileAcceleration : index 0x6083 subindex 0. Set to slowAcceleration or fast acceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileDeceleration</EFDB_Name>
-      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration. (RPM)</Description>
+      <Description>value of controller parameter ProfileDeceleration index 0x6084 subindex 0. Set to slowDeceleration or fastDeceleration.</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>rpm/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>profileVelocity</EFDB_Name>
-      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity (RPM)</Description>
+      <Description>value of controller parameter ProfileVelocity : index 0x6081 subindex 0. Set to either slowVelocity or fastVelocity</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -8195,9 +8181,9 @@
     </item>
     <item>
       <EFDB_Name>velocity</EFDB_Name>
-      <Description>velocity read on controller : index 0x2028 subindex 0 (RPM)</Description>
+      <Description>velocity read on controller : index 0x2028 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>rpm</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -10922,19 +10908,12 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_chiller_Chiller</EFDB_Topic>
-    <!--CCS: Dictionary_Checksum: 3463176001L -->
+    <!--CCS: Dictionary_Checksum: 632526995L -->
     <item>
       <EFDB_Name>chillerPumpLife</EFDB_Name>
       <Description>chiller pump hours</Description>
       <IDL_Type>double</IDL_Type>
       <Units>h</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>chillerStatus</EFDB_Name>
-      <Description>Chiller status register</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -11592,6 +11571,580 @@
       <Description>Heater PS Temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_utiltrunk_Body using level 1-->
+  <!--=======================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_utiltrunk_Body</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 2891718329L -->
+    <item>
+      <EFDB_Name>ambAirtemp</EFDB_Name>
+      <Description>Ambient air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>averageTemp</EFDB_Name>
+      <Description>Camera average temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backFlngXMinusTemp</EFDB_Name>
+      <Description>Back flange X- in temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backFlngXPlusTemp</EFDB_Name>
+      <Description>Back flange X+ in temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>backFlngYMinusTemp</EFDB_Name>
+      <Description>Back flange Y- in temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camBodyXPlusTemp</EFDB_Name>
+      <Description>Camera body X+ air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camBodyYMinusTemp</EFDB_Name>
+      <Description>Camera body Y- air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camBodyYPlusTemp</EFDB_Name>
+      <Description>Camera body Y+ air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camHousXMinusTemp</EFDB_Name>
+      <Description>Camera housing X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camHousXPlusTemp</EFDB_Name>
+      <Description>Camera housing X+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camHousYMinusTemp</EFDB_Name>
+      <Description>Camera housing Y- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>camHousYPlusTemp</EFDB_Name>
+      <Description>Camera housing Y+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgrYMinusRtnAirTemp</EFDB_Name>
+      <Description>Autochanger Y- return air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>chgrYMinusRtnAirVel</EFDB_Name>
+      <Description>Autochanger Y- return air velocity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeXMinusTemp</EFDB_Name>
+      <Description>Dome X- air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeYMinusTemp</EFDB_Name>
+      <Description>Dome Y- air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1XMinusTemp</EFDB_Name>
+      <Description>L1 X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l1YMinusTemp</EFDB_Name>
+      <Description>L1 Y- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2XMinusTemp</EFDB_Name>
+      <Description>L2 X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2XPlusTemp</EFDB_Name>
+      <Description>L2 X+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2YMinusTemp</EFDB_Name>
+      <Description>L2 Y- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>l2YPlusTemp</EFDB_Name>
+      <Description>L2 Y+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdRngXMinusTemp</EFDB_Name>
+      <Description>Shroud ring X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdRngXPlusTemp</EFDB_Name>
+      <Description>Shroud ring X+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdRngYMinusTemp</EFDB_Name>
+      <Description>Shroud ring Y- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shrdRngYPlusTemp</EFDB_Name>
+      <Description>Shroud ring Y+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrEboxRtnAirTemp</EFDB_Name>
+      <Description>Shutter electronics return air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrEboxRtnAirVel</EFDB_Name>
+      <Description>Shutter electronics return air velocity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrMtrRtnAirTemp</EFDB_Name>
+      <Description>Shutter motors return air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>shtrMtrRtnAirVel</EFDB_Name>
+      <Description>Shutter motors return air velocity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>vPPlenumInTemp</EFDB_Name>
+      <Description>VP plenum in temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_utiltrunk_MPC using level 1-->
+  <!--======================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_utiltrunk_MPC</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 3295711856L -->
+    <item>
+      <EFDB_Name>avgAirtempOut</EFDB_Name>
+      <Description>MPC average air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaPressFilt</EFDB_Name>
+      <Description>MPC filter delta pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaPressTotal</EFDB_Name>
+      <Description>MPC total delta pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaTempAct</EFDB_Name>
+      <Description>MPC actual delta temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanRunTime</EFDB_Name>
+      <Description>MPC fan accumulated run time</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanSpeed</EFDB_Name>
+      <Description>MPC fan speed</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity</EFDB_Name>
+      <Description>MPC relative humidity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>preFiltPress</EFDB_Name>
+      <Description>MPC pre-filter air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnAirTemp</EFDB_Name>
+      <Description>MPC return air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnPress</EFDB_Name>
+      <Description>MPC return air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyAirTemp</EFDB_Name>
+      <Description>MPC supply air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyPress</EFDB_Name>
+      <Description>MPC supply air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valvePosn</EFDB_Name>
+      <Description>MPC coolant valve position</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_utiltrunk_UT using level 1-->
+  <!--=====================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_utiltrunk_UT</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 987895038L -->
+    <item>
+      <EFDB_Name>averageTemp</EFDB_Name>
+      <Description>UT weighted average temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolFlowRate</EFDB_Name>
+      <Description>UT coolant flow rate</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolPipeRetnTemp</EFDB_Name>
+      <Description>UT coolant pipe return temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolPipeSplyTemp</EFDB_Name>
+      <Description>UT coolant pipe supply temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolReturnPrs</EFDB_Name>
+      <Description>UT coolant return pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>coolSupplyPrs</EFDB_Name>
+      <Description>UT coolant supply pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeXMinusTemp</EFDB_Name>
+      <Description>Telescope dome X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>domeYMinusTemp</EFDB_Name>
+      <Description>Telescope dome Y- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanInletTemp</EFDB_Name>
+      <Description>UT fan inlet temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanRunTime</EFDB_Name>
+      <Description>UT fan accumulated run time</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanSpeed</EFDB_Name>
+      <Description>UT fan speed</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midXMinusTemp</EFDB_Name>
+      <Description>UT Mid-plate X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>midXPlusTemp</EFDB_Name>
+      <Description>UT Mid-plate X+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppXMinusTemp</EFDB_Name>
+      <Description>UT Support ring X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppXPlusTemp</EFDB_Name>
+      <Description>UT Support ring X+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topXMinusTemp</EFDB_Name>
+      <Description>UT Top end X- temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>topXPlusTemp</EFDB_Name>
+      <Description>UT Top end X+ temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valvePosn</EFDB_Name>
+      <Description>UT coolant valve position</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w2Q1Temp</EFDB_Name>
+      <Description>UT W2 Q1 temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>w4Q3Temp</EFDB_Name>
+      <Description>UT W4 Q3 temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_utiltrunk_VPC using level 1-->
+  <!--======================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_utiltrunk_VPC</EFDB_Topic>
+    <!--CCS: Dictionary_Checksum: 1724543484L -->
+    <item>
+      <EFDB_Name>deltaPressFilt</EFDB_Name>
+      <Description>VPC filter delta pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaPressTotal</EFDB_Name>
+      <Description>VPC total delta pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaTempAct</EFDB_Name>
+      <Description>VPC actual delta temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanRunTime</EFDB_Name>
+      <Description>VPC fan accumulated run time</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>hour</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanSpeed</EFDB_Name>
+      <Description>VPC fan speed</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>htrCurrent</EFDB_Name>
+      <Description>VPC heater current</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>humidity</EFDB_Name>
+      <Description>VPC relative humidity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>preFiltPress</EFDB_Name>
+      <Description>VPC pre-filter air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnAirTemp</EFDB_Name>
+      <Description>VPC return air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>retnPress</EFDB_Name>
+      <Description>VPC return air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyAirTemp</EFDB_Name>
+      <Description>VPC supply air temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyAirVel</EFDB_Name>
+      <Description>VPC supply air velocity</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>splyPress</EFDB_Name>
+      <Description>VPC supply air pressure</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valvePosn</EFDB_Name>
+      <Description>VPC coolant valve position</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>

--- a/tests/test_Units.py
+++ b/tests/test_Units.py
@@ -13,9 +13,9 @@ NONSTANDARD_UNITS = {"unitless", "psia", "psig", "VA", "carousel steps", "in. Hâ
 # Enable colloquial Imperial units.
 astropy.units.imperial.enable()
 # Add rpm and gpm (gallon/min).
-rpm = astropy.units.def_unit("rpm", astropy.units.cycle * 60 / astropy.units.s)
+rpm = astropy.units.def_unit("rpm", astropy.units.cycle / (60 * astropy.units.s))
 gpm = astropy.units.def_unit(
-    "gallon/min", astropy.units.imperial.gallon * 60 / astropy.units.s
+    "gallon/min", astropy.units.imperial.gallon / (60 *astropy.units.s)
 )
 astropy.units.add_enabled_units([rpm, gpm])
 

--- a/tests/test_Units.py
+++ b/tests/test_Units.py
@@ -9,11 +9,11 @@ import pytest
 
 # These nonstandard units are explicitly allowed.
 # Remove entries if and when astropy adds support for them.
-NONSTANDARD_UNITS = {"unitless", "psia", "psig", "VA", "carousel steps"}
+NONSTANDARD_UNITS = {"unitless", "psia", "psig", "VA", "carousel steps", "in. H₂O"}
 # Enable colloquial Imperial units.
 astropy.units.imperial.enable()
 # Add rpm and gpm (gallon/min).
-rpm = astropy.units.def_unit("rpm", astropy.units.cycle / astropy.units.s)
+rpm = astropy.units.def_unit("rpm", astropy.units.cycle * 60 / astropy.units.s)
 gpm = astropy.units.def_unit(
     "gallon/min", astropy.units.imperial.gallon * 60 / astropy.units.s
 )


### PR DESCRIPTION
Updated AT/CC/MT camera to the latest version (1.0.3) of org-lsst-ccs-camera-sal-xml
Release notes are here: https://jira.slac.stanford.edu/issues/?jql=project%20%3D%20LCOBM%20AND%20fixVersion%20%3D%20XML-1.0.3

Updated tests/test_Units.py to include one more non-standard unit used by camera.
Also fixed definition of rpm to include factor of 60 for minutes->seconds (someone should check this, I am really not sure if the 60 belongs in the numerator or the denominator, but I copied from gallon/min)