### PR TITLE
DM-42183: Update Scheduler to improve support for additional indices

### DIFF
--- a/doc/news/interface_changes/DM-42183.scheduler.rst
+++ b/doc/news/interface_changes/DM-42183.scheduler.rst
@@ -1,0 +1,2 @@
+Update SalIndex Scheduler enumeration to include the "OCS" instance of the scheduler, with index=3.
+

--- a/doc/news/interface_changes/DM-42183.scriptqueue.rst
+++ b/doc/news/interface_changes/DM-42183.scriptqueue.rst
@@ -1,0 +1,2 @@
+Update SalIndex ScriptQueue enumeration to include the "OCS" instance with index=3.
+

--- a/python/lsst/ts/xml/data/sal_interfaces/SALSubsystems.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/SALSubsystems.xml
@@ -806,7 +806,7 @@
   <SALSubsystem>
     <Name>Scheduler</Name>
     <Description>The CSC for the Scheduler of both the Main and Auxiliary Telescope</Description>
-    <IndexEnumeration>MainTel,AuxTel</IndexEnumeration>
+    <IndexEnumeration>MainTel,AuxTel,OCS</IndexEnumeration>
     <AddedGenerics>csc, configurable, logevent_largeFileObjectAvailable</AddedGenerics>
     <ActiveDevelopers>Tiago Ribeiro</ActiveDevelopers>
     <Github>https://github.com/lsst-ts/ts_scheduler</Github>

--- a/python/lsst/ts/xml/data/sal_interfaces/SALSubsystems.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/SALSubsystems.xml
@@ -842,7 +842,7 @@
   <SALSubsystem>
     <Name>ScriptQueue</Name>
     <Description>A CSC that manages SAL Scripts (see the Script subsystem).</Description>
-    <IndexEnumeration>MainTel,AuxTel</IndexEnumeration>
+    <IndexEnumeration>MainTel,AuxTel,OCS</IndexEnumeration>
     <AddedGenerics>csc</AddedGenerics>
     <ActiveDevelopers>Tiago Ribeiro, Wouter van Reeven</ActiveDevelopers>
     <Github>https://github.com/lsst-ts/ts_scriptqueue</Github>

--- a/python/lsst/ts/xml/enums/Scheduler.py
+++ b/python/lsst/ts/xml/enums/Scheduler.py
@@ -31,6 +31,7 @@ class SalIndex(enum.IntEnum):
 
     MAIN_TEL = 1
     AUX_TEL = 2
+    OCS = 3
 
 
 class DetailedState(enum.IntEnum):

--- a/python/lsst/ts/xml/enums/ScriptQueue.py
+++ b/python/lsst/ts/xml/enums/ScriptQueue.py
@@ -42,6 +42,7 @@ class SalIndex(enum.IntEnum):
 
     MAIN_TEL = 1
     AUX_TEL = 2
+    OCS = 3
 
 
 class ScriptProcessState(enum.IntEnum):

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -6,7 +6,7 @@ filename = "doc/version-history.rst"
 directory = "doc/news"
 filename_format = "{name}.{type}.rst|{name}.{type}.md"
 title_format = "{version} ({project_date})"
-issue_format = "`{issue} <https://jira.lsstcorp.org/browse/{issue}>`_"
+issue_format = "`{issue} <https://rubinobs.atlassian.net/browse/{issue}>`_"
 
 [[tool.towncrier.section]]
 name = "Package Level"


### PR DESCRIPTION
Update Scheduler and ScriptQueue sal index enumerations to support a 3rd instance of each CSC.