### PR TITLE
Add guide to documenteer dependency grouping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install -e .[dev]
-          python -m pip install -e .[test]
+          python -m pip install -e .[dev,test]
           python -m pip install ltd-conveyor
-          python -m pip install sphinxext-rediraffe
-          python -m pip install myst_nb
       - name: Build documentation
         run: |
           cd doc

--- a/doc/news/DM-43861.doc.rst
+++ b/doc/news/DM-43861.doc.rst
@@ -1,0 +1,1 @@
+Add guide dependency group to documenteer dependency.

--- a/doc/news/DM-43861.misc.rst
+++ b/doc/news/DM-43861.misc.rst
@@ -1,0 +1,1 @@
+Remove myst_nb and sphinx-rediraffe from ci.yaml and make package install one line by installing both groups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ get_component_info = "lsst.ts.xml.get_component_info:get_component_info"
 
 [project.optional-dependencies]
 dev = [
-  "documenteer[pipelines]",
+  "documenteer[pipelines,guide]",
 ]
 test = [
   "astropy", "lxml"


### PR DESCRIPTION
The pipelines config that is available now imports from the guide
config. This means that the config expects to have any guide
dependency available but the documenteer pipeline group does not
have guide's group dependencies listed. So if we have only pipelines
listed, we don't get the guide's dependencies and thus missing
package errors start to appear. The solution is to add the
guide group to our install call which will catch any missing
packages in the future. Also simplified package install to one line
to save an unnecessary install step.
