### PR TITLE
Tickets/cap 1050

### DIFF
--- a/doc/news/interface_changes/CAP-1050.atcamera.rst
+++ b/doc/news/interface_changes/CAP-1050.atcamera.rst
@@ -1,0 +1,1 @@
+Remove obsolete ATCamera_logevent_shutterMotionProfile

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -641,17 +641,6 @@
   </SALEvent>
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
-    <EFDB_Topic>ATCamera_logevent_shutterMotionProfile</EFDB_Topic>
-    <item>
-      <EFDB_Name>measuredExposureTime</EFDB_Name>
-      <Description>The measured average exposure time</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>second</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <SALEvent>
-    <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_imageReadoutParameters</EFDB_Topic>
     <Description>Event sent describing image readout parameters.
         Note: all : delimited strings (aka string arrays) follow the escaping convention defined in CAP-572</Description>


### PR DESCRIPTION
Remove obsolete AT specific event. (Now replaced with more general measuredShutterTime in EndOfImageTelemetry)