### PR TITLE
DM-46165: adding optical configuration to TunableLaser XML

### DIFF
--- a/doc/news/interface_changes/DM-46165.tunablelaser.rst
+++ b/doc/news/interface_changes/DM-46165.tunablelaser.rst
@@ -1,0 +1,1 @@
+Adding in Optical Configuration enum for TunableLaser

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Commands.xml
@@ -31,10 +31,10 @@
   <SALCommand>
     <Subsystem>TunableLaser</Subsystem>
     <EFDB_Topic>TunableLaser_command_setOpticalConfiguration</EFDB_Topic>
-    <Description>Set the optical configuration.</Description>
+    <Description>Set the optical configuration; an OpticalConfiguration enum.</Description>
     <item>
       <EFDB_Name>configuration</EFDB_Name>
-      <Description>Optical alignment configuration to be set.</Description>
+      <Description>Optical alignment configuration to be set; an OpticalConfiguration enum.</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
@@ -8,6 +8,14 @@ LaserErrorCode_GENERAL_ERROR = 7302,
 LaserErrorCode_TIMEOUT_ERROR = 7303,
 LaserErrorCode_HW_CPU_ERROR = 7304
   </Enumeration>
+  <Enumeration>
+OpticalConfiguration_SCU,
+OpticalConfiguration_F1_SCU,
+OpticalConfiguration_F2_SCU,
+OpticalConfiguration_NO_SCU,
+OpticalConfiguration_F1_NO_SCU,
+OpticalConfiguration_F2_NO_SCU
+  </Enumeration>
   <SALEvent>
     <Subsystem>TunableLaser</Subsystem>
     <EFDB_Topic>TunableLaser_logevent_laserInstabilityFlag</EFDB_Topic>

--- a/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/TunableLaser/TunableLaser_Events.xml
@@ -48,10 +48,10 @@ OpticalConfiguration_F2_NO_SCU
   <SALEvent>
     <Subsystem>TunableLaser</Subsystem>
     <EFDB_Topic>TunableLaser_logevent_opticalConfiguration</EFDB_Topic>
-    <Description>The optical configuration.</Description>
+    <Description>The optical configuration; an OpticalConfiguration enum.</Description>
     <item>
       <EFDB_Name>configuration</EFDB_Name>
-      <Description>The new optical alignment configuration.</Description>
+      <Description>The optical alignment configuration; a OpticalConfiguration enum.</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>

--- a/python/lsst/ts/xml/enums/TunableLaser.py
+++ b/python/lsst/ts/xml/enums/TunableLaser.py
@@ -28,6 +28,7 @@ class LaserDetailedState(enum.IntEnum):
     PROPAGATING_CONTINUOUS_MODE = 3
     PROPAGATING_BURST_MODE = 4
 
+
 class OpticalConfiguration(enum.StrEnum):
     """Configuration of the optical output
 
@@ -55,6 +56,7 @@ class OpticalConfiguration(enum.StrEnum):
     NO_SCU = "No SCU"
     F1_NO_SCU = "F1 No SCU"
     F2_NO_SCU = "F2 No SCU"
+
 
 class LaserErrorCode(enum.IntEnum):
     """Laser error codes"""

--- a/python/lsst/ts/xml/enums/TunableLaser.py
+++ b/python/lsst/ts/xml/enums/TunableLaser.py
@@ -28,6 +28,21 @@ class LaserDetailedState(enum.IntEnum):
     PROPAGATING_CONTINUOUS_MODE = 3
     PROPAGATING_BURST_MODE = 4
 
+class OpticalConfiguration(enum.StrEnum):
+    """Configuration of the optical output"""
+
+    SCU = "SCU"
+    """Pass the beam straight-through the SCU."""
+    F1_SCU = "F1 SCU"
+    """Direct the beam through the F1 after passing through the SCU."""
+    F2_SCU = "F2 SCU"
+    """Direct the beam through the F2 after passing through the SCU."""
+    NO_SCU = "No SCU"
+    """Pass the beam straight-through."""
+    F1_NO_SCU = "F1 No SCU"
+    """Pass the beam to F1 output."""
+    F2_NO_SCU = "F2 No SCU"
+    """Pass the beam to F2 output."""
 
 class LaserErrorCode(enum.IntEnum):
     """Laser error codes"""

--- a/python/lsst/ts/xml/enums/TunableLaser.py
+++ b/python/lsst/ts/xml/enums/TunableLaser.py
@@ -29,20 +29,32 @@ class LaserDetailedState(enum.IntEnum):
     PROPAGATING_BURST_MODE = 4
 
 class OpticalConfiguration(enum.StrEnum):
-    """Configuration of the optical output"""
+    """Configuration of the optical output
+
+    Attributes
+    ----------
+
+    SCU: `str`
+        Pass the beam straight-through the SCU.
+    F1_SCU: `str`
+        Direct the beam through the F1 after passing through the SCU.
+    F2_SCU: `str`
+        Direct the beam through the F2 after passing through the SCU.
+    NO_SCU: `str`
+        Pass the beam straight-through.
+    F1_NO_SCU: `str`
+        Pass the beam to F1 output.
+    F2_NO_SCU: `str`
+        Pass the beam to F2 output.
+
+    """
 
     SCU = "SCU"
-    """Pass the beam straight-through the SCU."""
     F1_SCU = "F1 SCU"
-    """Direct the beam through the F1 after passing through the SCU."""
     F2_SCU = "F2 SCU"
-    """Direct the beam through the F2 after passing through the SCU."""
     NO_SCU = "No SCU"
-    """Pass the beam straight-through."""
     F1_NO_SCU = "F1 No SCU"
-    """Pass the beam to F1 output."""
     F2_NO_SCU = "F2 No SCU"
-    """Pass the beam to F2 output."""
 
 class LaserErrorCode(enum.IntEnum):
     """Laser error codes"""

--- a/python/lsst/ts/xml/enums/TunableLaser.py
+++ b/python/lsst/ts/xml/enums/TunableLaser.py
@@ -1,4 +1,4 @@
-__all__ = ["LaserDetailedState", "LaserErrorCode"]
+__all__ = ["LaserDetailedState", "OpticalConfiguration", "LaserErrorCode"]
 import enum
 
 


### PR DESCRIPTION
Need to move the Optical Configuration enum from ts_TunableLaser to ts_xml so that we can change the optical configuration in scripts. This is necessary because we will swap between F1, F2 and direct for different tests.