### PR TITLE
Add descriptions to all atcamera/mtcamera/cccamera items

### DIFF
--- a/doc/news/interface_changes/DM-43793.atcamera.rst
+++ b/doc/news/interface_changes/DM-43793.atcamera.rst
@@ -1,0 +1,1 @@
+Fix missing descriptions.

--- a/doc/news/interface_changes/DM-43804.cccamera.rst
+++ b/doc/news/interface_changes/DM-43804.cccamera.rst
@@ -1,0 +1,1 @@
+Fix missing descriptions.

--- a/doc/news/interface_changes/DM-43816.mtcamera.rst
+++ b/doc/news/interface_changes/DM-43816.mtcamera.rst
@@ -1,0 +1,1 @@
+Fix missing descriptions.

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Commands.xml
@@ -3,6 +3,7 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_discardRows</EFDB_Topic>
+    <Description>LSE-71 discardRows command</Description>
     <item>
       <EFDB_Name>nRows</EFDB_Name>
       <Description>Number of rows to discard</Description>
@@ -14,6 +15,7 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_startImage</EFDB_Topic>
+    <Description>LSE-71 startImage command</Description>
     <item>
       <EFDB_Name>shutter</EFDB_Name>
       <Description>True if the shutter should be opened/closed</Description>
@@ -56,10 +58,12 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_disableCalibration</EFDB_Topic>
+    <Description>LSE-71 disableCalibration command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_initGuiders</EFDB_Topic>
+    <Description>LSE-71 initGuiders command</Description>
     <item>
       <EFDB_Name>roiSpec</EFDB_Name>
       <Description>Specification for region of interest</Description>
@@ -72,10 +76,12 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_enableCalibration</EFDB_Topic>
+    <Description>LSE-71 enableCalibration command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_initImage</EFDB_Topic>
+    <Description>LSE-71 initImage command</Description>
     <item>
       <EFDB_Name>deltaT</EFDB_Name>
       <Description>Estimate of time period before takeImages will be issued</Description>
@@ -87,10 +93,12 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_endImage</EFDB_Topic>
+    <Description>LSE-71 endImage command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_clear</EFDB_Topic>
+    <Description>LSE-71 clear command</Description>
     <item>
       <EFDB_Name>nClears</EFDB_Name>
       <Description>Number of consecutive clear operations to perform</Description>
@@ -102,6 +110,7 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_takeImages</EFDB_Topic>
+    <Description>LSE-71 takeImages command</Description>
     <item>
       <EFDB_Name>numImages</EFDB_Name>
       <Description>Number of consecutive images to take</Description>
@@ -151,11 +160,13 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_stop</EFDB_Topic>
+    <Description>LSE-71 stop command</Description>
   </SALCommand>
   <!-- Playlist related commands, only valid when using emulated DAQ -->
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_play</EFDB_Topic>
+    <Description>Play specified playlist</Description>
     <item>
       <EFDB_Name>playlist</EFDB_Name>
       <Description>Name of an existing DAQ playlist to play</Description>
@@ -174,6 +185,7 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_playlist</EFDB_Topic>
+    <Description>Define a new playlist</Description>
     <item>
       <EFDB_Name>playlist</EFDB_Name>
       <Description>Name of a DAQ playlist to be defined (replaced if exists)</Description>
@@ -200,6 +212,7 @@
   <SALCommand>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_command_alert</EFDB_Topic>
+    <Description>Experimental command -- not currently implemented</Description>
     <item>
       <EFDB_Name>alertId</EFDB_Name>
       <Description>The alertId for which this command applies (or *)</Description>

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -3,6 +3,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_offlineDetailedState</EFDB_Topic>
+    <Description>Event generated when the OFFLINE state changes</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -120,6 +121,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_endTakeImage</EFDB_Topic>
+    <Description>Event generated at the end of an image</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -131,6 +133,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_imageReadinessDetailedState</EFDB_Topic>
+    <Description>Event which reflects the readiness of the camera to take an image with no additional time overhead</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -150,6 +153,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_notReadyToTakeImage</EFDB_Topic>
+    <Description>Event which indicates camera is not ready to take an image without overhead</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -161,6 +165,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_startShutterClose</EFDB_Topic>
+    <Description>Event indicating the start of a shutter close operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -172,6 +177,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_endShutterClose</EFDB_Topic>
+    <Description>Event indicating the end of a shutter close operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -318,6 +324,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_calibrationDetailedState</EFDB_Topic>
+    <Description>Event indicating the calibration state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -337,6 +344,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_shutterDetailedState</EFDB_Topic>
+    <Description>Event reflecting the shutter state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -356,6 +364,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_readyToTakeImage</EFDB_Topic>
+    <Description>Event indicating the camera is ready to take an image with no time overhead</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -367,6 +376,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ccsCommandState</EFDB_Topic>
+    <Description>Event indicating the camera command state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Substate of the CCS command.</Description>
@@ -386,6 +396,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_prepareToTakeImage</EFDB_Topic>
+    <Description>????</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -397,6 +408,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_endShutterOpen</EFDB_Topic>
+    <Description>Event issued when the shutter open operation completes</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -515,6 +527,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_startShutterOpen</EFDB_Topic>
+    <Description>Event issued when we start to open the shutter</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -526,6 +539,7 @@
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_raftsDetailedState</EFDB_Topic>
+    <Description>Event indicating the state of the focal-plane</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -873,11 +887,12 @@
     </item>
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 1999895231L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -912,11 +927,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Ccd_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Ccd_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4151740477L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1149,11 +1165,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration for category General using level 1-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 462997926L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1177,11 +1194,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 145840325L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1226,11 +1244,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration using level 1 for category Instrument-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration for category Instrument using level 1-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration for category Instrument</Description>
     <!--CCS: Dictionary_Checksum: 931959526L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1261,11 +1280,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration using level 1 for category Monitoring-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration for category Monitoring using level 1-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration for category Monitoring</Description>
     <!--CCS: Dictionary_Checksum: 3420731577L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1289,11 +1309,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2894028502L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1345,11 +1366,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 579141703L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1401,11 +1423,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Raft_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 3926285547L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1431,11 +1454,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration using level 1 for category RaftTempControl-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration for category RaftTempControl using level 1-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration for category RaftTempControl</Description>
     <!--CCS: Dictionary_Checksum: 4133472458L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1569,11 +1593,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration using level 1 for category RaftTempControlStatus-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration for category RaftTempControlStatus using level 1-->
   <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration for category RaftTempControlStatus</Description>
     <!--CCS: Dictionary_Checksum: 2438003286L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1599,11 +1624,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 195009230L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1641,11 +1667,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1036526110L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1671,11 +1698,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 808911443L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1701,11 +1729,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 380473643L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1731,11 +1760,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2232731179L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2940,11 +2970,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsConfiguration using level 1 for category Rafts-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsConfiguration for category Rafts using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsConfiguration for category Rafts</Description>
     <!--CCS: Dictionary_Checksum: 1695348347L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3078,11 +3109,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration using level 1 for category RaftsLimits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration for category RaftsLimits using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration for category RaftsLimits</Description>
     <!--CCS: Dictionary_Checksum: 3195072898L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3279,11 +3311,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration using level 1 for category RaftsPower-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration for category RaftsPower using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration for category RaftsPower</Description>
     <!--CCS: Dictionary_Checksum: 832633820L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3849,11 +3882,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_timersConfiguration for category timers using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_Reb_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_Reb_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1268300520L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3969,11 +4003,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1137543519L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4004,11 +4039,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2639071278L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4046,11 +4082,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration using level 1 for category DAQ-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration for category DAQ using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration for category DAQ</Description>
     <!--CCS: Dictionary_Checksum: 1076697870L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4109,11 +4146,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration using level 1 for category Guider-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider</Description>
     <!--CCS: Dictionary_Checksum: 1714148447L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4137,11 +4175,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration using level 1 for category Sequencer-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer</Description>
     <!--CCS: Dictionary_Checksum: 4112623107L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4340,11 +4379,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration using level 1 for category Visualization-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration for category Visualization using level 1-->
   <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration for category Visualization</Description>
     <!--CCS: Dictionary_Checksum: 2530037792L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4361,11 +4401,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1214896848L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4403,11 +4444,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2317372607L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4473,11 +4515,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration using level 1 for category Statistics-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics</Description>
     <!--CCS: Dictionary_Checksum: 1384850593L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4557,11 +4600,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_StoreConfiguration using level 1 for category Store-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_StoreConfiguration for category Store using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_StoreConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_StoreConfiguration for category Store</Description>
     <!--CCS: Dictionary_Checksum: 934933523L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4585,11 +4629,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_DevicesConfiguration for category Devices using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Store_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1755898606L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4606,11 +4651,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_LimitsConfiguration for category Limits using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Store_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1587359078L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4634,11 +4680,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_StoreConfiguration using level 1 for category Store-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_StoreConfiguration for category Store using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Store_StoreConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_Store_StoreConfiguration for category Store</Description>
     <!--CCS: Dictionary_Checksum: 2879348445L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4676,11 +4723,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Analog_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Analog_I_LimitsConfiguration for category Limits using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Analog_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Analog_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3263351699L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4718,11 +4766,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Analog_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Analog_V_LimitsConfiguration for category Limits using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Analog_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Analog_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2732905341L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4760,11 +4809,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Aux_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Aux_I_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Aux_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Aux_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2517148510L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4802,11 +4852,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Aux_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Aux_V_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Aux_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Aux_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4134452144L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4844,11 +4895,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_I_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkHigh_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3271489191L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4886,11 +4938,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_V_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkHigh_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_ClkHigh_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2727931465L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4928,11 +4981,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_I_LimitsConfiguration for category Limits using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkLow_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3725800645L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4970,11 +5024,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_V_LimitsConfiguration for category Limits using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_ClkLow_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_ClkLow_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3195350059L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5012,11 +5067,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_I_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_DPHI_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 732772257L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5054,11 +5110,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_V_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_DPHI_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_DPHI_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1271607119L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5096,11 +5153,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Digital_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Digital_I_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Digital_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Digital_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 340132556L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5138,11 +5196,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Digital_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Digital_V_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Digital_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Digital_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1948260898L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5180,11 +5239,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Fan_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Fan_I_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Fan_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Fan_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3146808836L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5222,11 +5282,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Fan_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Fan_V_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Fan_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Fan_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3690358506L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5264,11 +5325,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1448442192L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5292,11 +5354,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_I_LimitsConfiguration for category Limits using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_HVBias_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1458416643L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5334,11 +5397,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_V_LimitsConfiguration for category Limits using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_HVBias_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_HVBias_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 915125485L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5376,11 +5440,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg1_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2468661842L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5397,11 +5462,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_PowerConfiguration using level 1 for category Power-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_PowerConfiguration for category Power using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg1_PowerConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Hameg1_PowerConfiguration for category Power</Description>
     <!--CCS: Dictionary_Checksum: 2216190387L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5516,11 +5582,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg2_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1886223856L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5537,11 +5604,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_PowerConfiguration using level 1 for category Power-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_PowerConfiguration for category Power using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg2_PowerConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Hameg2_PowerConfiguration for category Power</Description>
     <!--CCS: Dictionary_Checksum: 272422401L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5656,11 +5724,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg3_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2558192977L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5677,11 +5746,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_PowerConfiguration using level 1 for category Power-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_PowerConfiguration for category Power using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Hameg3_PowerConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Hameg3_PowerConfiguration for category Power</Description>
     <!--CCS: Dictionary_Checksum: 1515990302L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5796,11 +5866,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_DevicesConfiguration for category Devices using level 1-->
   <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Keithley_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2286950710L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5817,11 +5888,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_PowerConfiguration using level 1 for category Power-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_PowerConfiguration for category Power using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_Keithley_PowerConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_Keithley_PowerConfiguration for category Power</Description>
     <!--CCS: Dictionary_Checksum: 1173451930L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5880,11 +5952,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OD_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OD_I_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OD_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_OD_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2693541552L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5922,11 +5995,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OD_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OD_V_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OD_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_OD_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3236574814L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5964,11 +6038,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OTM_I_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OTM_I_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OTM_I_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_OTM_I_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3329983717L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6006,11 +6081,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OTM_V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_OTM_V_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_OTM_V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_OTM_V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2786958347L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6048,11 +6124,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2602586973L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6090,11 +6167,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3856424617L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6160,11 +6238,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_power_StatusAggregator_GeneralConfiguration for category General using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_power_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_power_StatusAggregator_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1864836358L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6181,11 +6260,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DeviceConfiguration for category Device using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_CryoCon_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 4153392157L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6202,11 +6282,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_CryoCon_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_CryoCon_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 897533576L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6223,11 +6304,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3433939485L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6265,11 +6347,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1188361967L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6328,11 +6411,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_Pfeiffer_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1442941572L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6349,11 +6433,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_Pfeiffer_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_Pfeiffer_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2265226990L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6370,11 +6455,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCCDSetPoint_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCCDSetPoint_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempCCDSetPoint_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_TempCCDSetPoint_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 877906658L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6412,11 +6498,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCCD_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCCD_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempCCD_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_TempCCD_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3466789953L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6454,11 +6541,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempColdPlate_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempColdPlate_LimitsConfiguration for category Limits using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempColdPlate_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_TempColdPlate_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2224871970L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6496,11 +6584,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCryoHead_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_TempCryoHead_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_TempCryoHead_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_TempCryoHead_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4209597592L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6538,11 +6627,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Vacuum_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_ats_Vacuum_LimitsConfiguration for category Limits using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_ats_Vacuum_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_ats_Vacuum_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1447408296L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6580,11 +6670,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_DevicesConfiguration for category Devices using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_Device_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3182176033L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6601,11 +6692,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_GeneralConfiguration for category General using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_Device_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3046614962L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6622,11 +6714,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_Device_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_bonn_shutter_Device_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1496071801L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6692,11 +6785,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_bonn_shutter_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1882339325L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6727,11 +6821,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 4275057977L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6769,11 +6864,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3276326788L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6825,11 +6921,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_FitsService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_FitsService_GeneralConfiguration for category General using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_FitsService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2436812217L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6853,11 +6950,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration for category Commands using level 1-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_CommandsConfiguration for category Commands</Description>
     <!--CCS: Dictionary_Checksum: 3328040053L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6909,11 +7007,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_DAQConfiguration for category DAQ using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_DAQConfiguration for category DAQ</Description>
     <!--CCS: Dictionary_Checksum: 1553212165L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6993,11 +7092,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration using level 1 for category FitsHandling-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration for category FitsHandling using level 1-->
   <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration for category FitsHandling</Description>
     <!--CCS: Dictionary_Checksum: 3545217339L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7070,11 +7170,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration using level 1 for category Guider-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration for category Guider using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_ImageHandler_GuiderConfiguration for category Guider</Description>
     <!--CCS: Dictionary_Checksum: 3453225660L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7112,11 +7213,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2547892980L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7140,11 +7242,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1044283836L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7175,11 +7278,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3104697549L -->
     <item>
       <EFDB_Name>version</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Telemetry.xml
@@ -5,6 +5,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_Ccd</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_focal_plane_Ccd</Description>
     <!--CCS: Dictionary_Checksum: 3323840614L -->
     <!--CCSMETA: Array gDV indexed by location-->
     <item>
@@ -73,6 +74,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_Reb</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_focal_plane_Reb</Description>
     <!--CCS: Dictionary_Checksum: 3470282761L -->
     <!--CCSMETA: Array anaI indexed by location-->
     <item>
@@ -384,6 +386,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_RebTotalPower</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_focal_plane_RebTotalPower</Description>
     <!--CCS: Dictionary_Checksum: 2608570576L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
@@ -398,6 +401,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_focal_plane_RebsAverageTemp6</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_focal_plane_RebsAverageTemp6</Description>
     <!--CCS: Dictionary_Checksum: 894432032L -->
     <item>
       <EFDB_Name>rebsAverageTemp6</EFDB_Name>
@@ -407,11 +411,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_daq_monitor_Reb_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_daq_monitor_Reb_Trending for category Trending using level 1-->
   <!--=======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_daq_monitor_Reb_Trending</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_daq_monitor_Reb_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2805192593L -->
     <!--CCSMETA: Array driver_errors indexed by location-->
     <item>
@@ -885,6 +890,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_daq_monitor_Store</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_daq_monitor_Store</Description>
     <!--CCS: Dictionary_Checksum: 1170090743L -->
     <item>
       <EFDB_Name>capacity</EFDB_Name>
@@ -908,11 +914,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_daq_monitor_Sum_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_daq_monitor_Sum_Trending for category Trending using level 1-->
   <!--=======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_daq_monitor_Sum_Trending</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_daq_monitor_Sum_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 385642950L -->
     <item>
       <EFDB_Name>driver_errors</EFDB_Name>
@@ -1074,6 +1081,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_power</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_power</Description>
     <!--CCS: Dictionary_Checksum: 1269524998L -->
     <item>
       <EFDB_Name>analog_I</EFDB_Name>
@@ -1221,6 +1229,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_vacuum</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_vacuum</Description>
     <!--CCS: Dictionary_Checksum: 1376639655L -->
     <item>
       <EFDB_Name>tempCCD</EFDB_Name>
@@ -1263,6 +1272,7 @@
   <SALTelemetry>
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_bonn_shutter_Device</EFDB_Topic>
+    <Description>subsystem ATCamera class ATCamera_bonn_shutter_Device</Description>
     <!--CCS: Dictionary_Checksum: 1759124350L -->
     <item>
       <EFDB_Name>bonn_V36</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Commands.xml
@@ -3,6 +3,7 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_discardRows</EFDB_Topic>
+    <Description>LSE-71 discardRows command</Description>
     <item>
       <EFDB_Name>nRows</EFDB_Name>
       <Description>Number of rows to discard</Description>
@@ -14,6 +15,7 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_startImage</EFDB_Topic>
+    <Description>LSE-71 startImage command</Description>
     <item>
       <EFDB_Name>shutter</EFDB_Name>
       <Description>True if the shutter should be opened/closed</Description>
@@ -56,10 +58,12 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_disableCalibration</EFDB_Topic>
+    <Description>LSE-71 disableCalibration command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_initGuiders</EFDB_Topic>
+    <Description>LSE-71 initGuiders command</Description>
     <item>
       <EFDB_Name>roiSpec</EFDB_Name>
       <Description>Specification for region of interest</Description>
@@ -72,10 +76,12 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_enableCalibration</EFDB_Topic>
+    <Description>LSE-71 enableCalibration command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_initImage</EFDB_Topic>
+    <Description>LSE-71 initImage command</Description>
     <item>
       <EFDB_Name>deltaT</EFDB_Name>
       <Description>Estimate of time period before takeImages will be issued</Description>
@@ -87,10 +93,12 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_endImage</EFDB_Topic>
+    <Description>LSE-71 endImage command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_setFilter</EFDB_Topic>
+    <Description>LSE-71 setFilter command</Description>
     <item>
       <EFDB_Name>name</EFDB_Name>
       <Description>The filter name to install</Description>
@@ -103,6 +111,7 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_clear</EFDB_Topic>
+    <Description>LSE-71 clear command</Description>
     <item>
       <EFDB_Name>nClears</EFDB_Name>
       <Description>Number of consecutive clear operations to perform</Description>
@@ -114,6 +123,7 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_takeImages</EFDB_Topic>
+    <Description>LSE-71 takeImages command</Description>
     <item>
       <EFDB_Name>numImages</EFDB_Name>
       <Description>Number of consecutive images to take</Description>
@@ -163,11 +173,13 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_stop</EFDB_Topic>
+    <Description>LSE-71 stop command</Description>
   </SALCommand>
   <!-- Playlist related commands, only valid when using emulated DAQ -->
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_play</EFDB_Topic>
+    <Description>Play specified playlist</Description>
     <item>
       <EFDB_Name>playlist</EFDB_Name>
       <Description>Name of an existing DAQ playlist to play</Description>
@@ -186,6 +198,7 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_playlist</EFDB_Topic>
+    <Description>Define a new playlist</Description>
     <item>
       <EFDB_Name>playlist</EFDB_Name>
       <Description>Name of a DAQ playlist to be defined (replaced if exists)</Description>
@@ -212,6 +225,7 @@
   <SALCommand>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_command_alert</EFDB_Topic>
+    <Description>Experimental command -- not currently implemented</Description>
     <item>
       <EFDB_Name>alertId</EFDB_Name>
       <Description>The alertId for which this command applies (or *)</Description>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -3,6 +3,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_offlineDetailedState</EFDB_Topic>
+    <Description>Event generated when the OFFLINE state changes</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -120,6 +121,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endTakeImage</EFDB_Topic>
+    <Description>Event generated at the end of an image</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -131,6 +133,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_imageReadinessDetailedState</EFDB_Topic>
+    <Description>Event which reflects the readiness of the camera to take an image with no additional time overhead</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -150,6 +153,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_startSetFilter</EFDB_Topic>
+    <Description>Event generated at the begining of a setFilter operation</Description>
     <item>
       <EFDB_Name>filterName</EFDB_Name>
       <Description>The name of the filter being installed (e.g. U-001)</Description>
@@ -171,6 +175,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_startUnloadFilter</EFDB_Topic>
+    <Description>Event generated when a filter is starting to be unloaded.</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -182,6 +187,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_notReadyToTakeImage</EFDB_Topic>
+    <Description>Event which indicates camera is not ready to take an image without overhead</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -193,6 +199,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_startShutterClose</EFDB_Topic>
+    <Description>Event indicating the start of a shutter close operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -204,6 +211,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endInitializeGuider</EFDB_Topic>
+    <Description>???</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -215,6 +223,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endShutterClose</EFDB_Topic>
+    <Description>Event generated at the end of a shutter close operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -361,6 +370,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endUnloadFilter</EFDB_Topic>
+    <Description>Event generated at the end of an unload filter operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -372,6 +382,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_calibrationDetailedState</EFDB_Topic>
+    <Description>Event indicating the calibration state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -391,6 +402,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endRotateCarousel</EFDB_Topic>
+    <Description>Event generated at the end of a carousel rotation operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -402,6 +414,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_startLoadFilter</EFDB_Topic>
+    <Description>Event generated at the beginning of a filter load operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -413,6 +426,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_filterChangerDetailedState</EFDB_Topic>
+    <Description>Event reflecting the filter changer state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>The filter changer state</Description>
@@ -432,6 +446,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_shutterDetailedState</EFDB_Topic>
+    <Description>Event reflecting the shutter state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -451,6 +466,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_readyToTakeImage</EFDB_Topic>
+    <Description>Event indicating the camera is ready to take an image with no time overhead</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -462,6 +478,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_ccsCommandState</EFDB_Topic>
+    <Description>Event indicating the camera command state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Substate of the CCS command.</Description>
@@ -481,6 +498,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_prepareToTakeImage</EFDB_Topic>
+    <Description>????</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -492,6 +510,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_ccsConfigured</EFDB_Topic>
+    <Description>???</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -503,6 +522,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endLoadFilter</EFDB_Topic>
+    <Description>Event indicating the camera has finished loading a filter</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -514,6 +534,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endShutterOpen</EFDB_Topic>
+    <Description>Event issued when the shutter open operation completes</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -632,6 +653,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_endInitializeImage</EFDB_Topic>
+    <Description>???</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -681,6 +703,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_startShutterOpen</EFDB_Topic>
+    <Description>Event issued when we start to open the shutter</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -692,6 +715,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_raftsDetailedState</EFDB_Topic>
+    <Description>Event indicating the state of the focal-plane</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -711,6 +735,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_availableFilters</EFDB_Topic>
+    <Description>Event listing the filters available to be selected</Description>
     <item>
       <EFDB_Name>filterNames</EFDB_Name>
       <Description>A list of names of available filters (comma delimited, U-001,G-004,R-010,Z-012,Y-014, NONE), in the same order as the list of filter types.</Description>
@@ -856,6 +881,7 @@
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_startRotateCarousel</EFDB_Topic>
+    <Description>Event generated when the filter changer carousel starts to rotate</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -1098,11 +1124,12 @@
     </item>
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_GeneralConfiguration for category General using level 1-->
   <!--===============================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 177498527L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1189,11 +1216,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_DevicesConfiguration for category Devices using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_LinearEncoder_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 402932488L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1210,11 +1238,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_LinearEncoder_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_LinearEncoder_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1177922513L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1231,11 +1260,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 4049810286L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1273,11 +1303,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3281060040L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1329,11 +1360,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 129012656L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1350,11 +1382,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_GeneralConfiguration for category General using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2863423268L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1371,11 +1404,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 587810611L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1399,11 +1433,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_MotorConfiguration using level 1 for category Motor-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_MotorConfiguration for category Motor using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_fcs_StepperMotor_MotorConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_fcs_StepperMotor_MotorConfiguration for category Motor</Description>
     <!--CCS: Dictionary_Checksum: 656342921L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1511,11 +1546,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_DevicesConfiguration for category Devices using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_Device_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1899674305L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1532,11 +1568,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_GeneralConfiguration for category General using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_Device_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1964148534L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1553,11 +1590,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_Device_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_bonn_shutter_Device_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1369580573L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1623,11 +1661,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_bonn_shutter_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 718269393L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1658,11 +1697,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2858353959L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1700,11 +1740,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_bonn_shutter_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3814009004L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1756,11 +1797,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 420408614L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1798,11 +1840,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3019136670L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1868,11 +1911,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Stats_StatisticsConfiguration using level 1 for category Statistics-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics</Description>
     <!--CCS: Dictionary_Checksum: 1197481613L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1952,11 +1996,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_StoreConfiguration using level 1 for category Store-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_StoreConfiguration for category Store using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_StoreConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_StoreConfiguration for category Store</Description>
     <!--CCS: Dictionary_Checksum: 2888189970L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1980,11 +2025,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_DevicesConfiguration for category Devices using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Store_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1030676591L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2001,11 +2047,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_LimitsConfiguration for category Limits using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Store_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3586793202L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2029,11 +2076,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_StoreConfiguration using level 1 for category Store-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_StoreConfiguration for category Store using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_daq_monitor_Store_StoreConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_daq_monitor_Store_StoreConfiguration for category Store</Description>
     <!--CCS: Dictionary_Checksum: 2176996133L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2071,11 +2119,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3935330107L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2092,11 +2141,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_GeneralConfiguration for category General using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2305091023L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2127,11 +2177,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 508712045L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2183,11 +2234,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 4147396540L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2260,11 +2312,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration for category Limits using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3592222472L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2302,11 +2355,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Reb_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Reb_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Reb_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Reb_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2327678282L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2331,11 +2385,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Reb_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Reb_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Reb_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4066292126L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3440,11 +3495,12 @@
       <Count>6</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_DevicesConfiguration for category Devices using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1287318876L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3470,11 +3526,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_GeneralConfiguration for category General using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 4105572892L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3500,11 +3557,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1122639152L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3809,11 +3867,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_PowerConfiguration using level 1 for category Power-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_PowerConfiguration for category Power using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_PowerConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_PowerConfiguration for category Power</Description>
     <!--CCS: Dictionary_Checksum: 4095085868L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3848,11 +3907,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_buildConfiguration using level 1 for category build-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_buildConfiguration for category build using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_rebpower_Rebps_buildConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_rebpower_Rebps_buildConfiguration for category build</Description>
     <!--CCS: Dictionary_Checksum: 3504572576L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3878,11 +3938,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_CryoconConfiguration using level 1 for category Cryocon-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_CryoconConfiguration for category Cryocon using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold1_CryoconConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_CryoconConfiguration for category Cryocon</Description>
     <!--CCS: Dictionary_Checksum: 3096116489L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3913,11 +3974,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold1_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2962678614L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3934,11 +3996,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold1_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cold1_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3536441556L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4186,11 +4249,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_CryoconConfiguration using level 1 for category Cryocon-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_CryoconConfiguration for category Cryocon using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold2_CryoconConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_CryoconConfiguration for category Cryocon</Description>
     <!--CCS: Dictionary_Checksum: 1394652596L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4221,11 +4285,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold2_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1407145204L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4242,11 +4307,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cold2_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cold2_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 57321546L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4494,11 +4560,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_CryoconConfiguration using level 1 for category Cryocon-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_CryoconConfiguration for category Cryocon using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cryo_CryoconConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_CryoconConfiguration for category Cryocon</Description>
     <!--CCS: Dictionary_Checksum: 504527416L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4529,11 +4596,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cryo_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2797631718L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4550,11 +4618,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Cryo_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Cryo_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4228367874L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4802,11 +4871,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_CryoConfiguration for category Cryo using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_IonPumps_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 2731350552L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4844,11 +4914,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_IonPumps_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 162968392L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4865,11 +4936,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_IonPumps_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_IonPumps_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2595718281L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4935,11 +5007,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 302302131L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4977,11 +5050,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2166055173L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5047,11 +5121,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DeviceConfiguration for category Device using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Rtds_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 4091982545L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5075,11 +5150,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Rtds_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 959829602L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5096,11 +5172,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Rtds_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Rtds_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1372314865L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5194,11 +5271,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1485792936L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5215,11 +5293,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3955323662L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5264,11 +5343,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1219716956L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5404,11 +5484,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_buildConfiguration using level 1 for category build-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_buildConfiguration for category build using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_Turbo_buildConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_Turbo_buildConfiguration for category build</Description>
     <!--CCS: Dictionary_Checksum: 1257163577L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5425,11 +5506,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_CryoConfiguration for category Cryo using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VQMonitor_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 3602168792L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5460,11 +5542,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2969595748L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5481,11 +5564,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VQMonitor_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_VQMonitor_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4106696061L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5523,11 +5607,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DeviceConfiguration for category Device using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VacPluto_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 3444967668L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5544,11 +5629,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VacPluto_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_VacPluto_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3095500826L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5565,11 +5651,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacuumConfiguration using level 1 for category Vacuum-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_vacuum_VacuumConfiguration for category Vacuum using level 1-->
   <!--================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_vacuum_VacuumConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_vacuum_VacuumConfiguration for category Vacuum</Description>
     <!--CCS: Dictionary_Checksum: 1726312746L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5635,11 +5722,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_BFR_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_BFR_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3602386531L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5656,11 +5744,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_BFR_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_BFR_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1388589038L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5894,11 +5983,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_BFR_QuadboxConfiguration for category Quadbox using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_BFR_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_BFR_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 1073754593L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5915,11 +6005,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1394263366L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5936,11 +6027,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2496062068L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6762,11 +6854,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration for category Quadbox using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 2302178379L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6783,11 +6876,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2800696546L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6804,11 +6898,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4213993875L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7014,11 +7109,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration for category Quadbox using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 1277575729L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7035,11 +7131,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_48V_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 901519920L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7056,11 +7153,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_48V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3535542928L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7434,11 +7532,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration for category Quadbox using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 2075951956L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7455,11 +7554,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_DevicesConfiguration for category Devices using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 638908239L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7476,11 +7576,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3923793477L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7546,11 +7647,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration for category Quadbox using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 3342013421L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7567,11 +7669,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 951203098L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7609,11 +7712,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_quadbox_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_quadbox_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2062114513L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7665,11 +7769,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 870842743L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7702,11 +7807,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Ccd_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Ccd_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1282336460L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7883,11 +7989,12 @@
       <Count>9</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration for category General using level 1-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3966880200L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7911,11 +8018,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1820292887L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7960,11 +8068,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration using level 1 for category Instrument-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration for category Instrument using level 1-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration for category Instrument</Description>
     <!--CCS: Dictionary_Checksum: 2262490442L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7995,11 +8104,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration using level 1 for category Monitoring-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration for category Monitoring using level 1-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration for category Monitoring</Description>
     <!--CCS: Dictionary_Checksum: 2605392367L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8023,11 +8133,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2558579456L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8079,11 +8190,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1582128896L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8135,11 +8247,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Raft_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 4170714371L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8165,11 +8278,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration using level 1 for category RaftTempControl-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration for category RaftTempControl using level 1-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration for category RaftTempControl</Description>
     <!--CCS: Dictionary_Checksum: 663431800L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8303,11 +8417,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration using level 1 for category RaftTempControlStatus-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration for category RaftTempControlStatus using level 1-->
   <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration for category RaftTempControlStatus</Description>
     <!--CCS: Dictionary_Checksum: 1317421370L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8333,11 +8448,12 @@
       <IsJavaArray>yes</IsJavaArray>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 958204913L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8375,11 +8491,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1232484397L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8404,11 +8521,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2781647658L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8433,11 +8551,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 1058351474L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8462,11 +8581,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1292968762L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -9859,11 +9979,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsConfiguration using level 1 for category Rafts-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsConfiguration for category Rafts using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsConfiguration for category Rafts</Description>
     <!--CCS: Dictionary_Checksum: 3352229690L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10064,11 +10185,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration using level 1 for category RaftsLimits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration for category RaftsLimits using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration for category RaftsLimits</Description>
     <!--CCS: Dictionary_Checksum: 698001149L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10373,11 +10495,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration using level 1 for category RaftsPower-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration for category RaftsPower using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration for category RaftsPower</Description>
     <!--CCS: Dictionary_Checksum: 542347311L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11186,11 +11309,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_timersConfiguration for category timers using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Reb_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Reb_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2280700147L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11311,11 +11435,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2546914247L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11346,11 +11471,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3650548710L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11388,11 +11514,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Segment_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_Segment_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_Segment_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_Segment_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3464766984L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11441,11 +11568,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration using level 1 for category DAQ-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration for category DAQ using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration for category DAQ</Description>
     <!--CCS: Dictionary_Checksum: 3286780070L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11504,11 +11632,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration using level 1 for category Guider-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider</Description>
     <!--CCS: Dictionary_Checksum: 534651081L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11532,11 +11661,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration using level 1 for category Sequencer-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer</Description>
     <!--CCS: Dictionary_Checksum: 247729283L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11735,11 +11865,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration using level 1 for category Visualization-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration for category Visualization using level 1-->
   <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration for category Visualization</Description>
     <!--CCS: Dictionary_Checksum: 223538209L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11756,11 +11887,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_FitsService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_FitsService_GeneralConfiguration for category General using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_FitsService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3143876673L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11784,11 +11916,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration for category Commands using level 1-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_CommandsConfiguration for category Commands</Description>
     <!--CCS: Dictionary_Checksum: 843025526L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11840,11 +11973,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_DAQConfiguration for category DAQ using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_DAQConfiguration for category DAQ</Description>
     <!--CCS: Dictionary_Checksum: 3508616947L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11924,11 +12058,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration using level 1 for category FitsHandling-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration for category FitsHandling using level 1-->
   <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration for category FitsHandling</Description>
     <!--CCS: Dictionary_Checksum: 2066138206L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12001,11 +12136,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration using level 1 for category Guider-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration for category Guider using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_ImageHandler_GuiderConfiguration for category Guider</Description>
     <!--CCS: Dictionary_Checksum: 1728381398L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12043,11 +12179,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3197235453L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12071,11 +12208,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3929922340L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12106,11 +12244,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1829680725L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12127,11 +12266,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3752204175L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12169,11 +12309,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_mpm_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1363999428L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12232,11 +12373,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DeviceConfiguration for category Device using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_Pluto_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 538856650L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12253,11 +12395,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DevicesConfiguration for category Devices using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_mpm_Pluto_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_mpm_Pluto_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1617359185L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12274,11 +12417,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold1_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 2187049303L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12330,11 +12474,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold1_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 18995751L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12365,11 +12510,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold1_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1917751078L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13163,11 +13309,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_PicConfiguration for category Pic using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold1_PicConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold1_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 1939745585L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13261,11 +13408,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold2_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1232535576L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13317,11 +13465,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold2_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 4084462604L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13352,11 +13501,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold2_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 965266985L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14150,11 +14300,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_PicConfiguration for category Pic using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cold2_PicConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cold2_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 1463501244L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14248,11 +14399,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_ColdCompLimits_CompLimitsConfiguration using level 1 for category CompLimits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_ColdCompLimits_CompLimitsConfiguration for category CompLimits using level 1-->
   <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_ColdCompLimits_CompLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_ColdCompLimits_CompLimitsConfiguration for category CompLimits</Description>
     <!--CCS: Dictionary_Checksum: 773851517L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14353,11 +14505,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CoolMaq20_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CoolMaq20_DeviceConfiguration for category Device using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_CoolMaq20_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CoolMaq20_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 2605418343L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14381,11 +14534,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CoolMaq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CoolMaq20_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_CoolMaq20_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CoolMaq20_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 536001946L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14402,11 +14556,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo1_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1755998804L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14437,11 +14592,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo1_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 268699736L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14465,11 +14621,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo1_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo1_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2428077541L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14955,11 +15112,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo2_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1763906306L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14990,11 +15148,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo2_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 4222501093L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15018,11 +15177,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo2_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3417555947L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15564,11 +15724,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_PicConfiguration for category Pic using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo2_PicConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo2_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 2167014123L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15662,11 +15823,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo3_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 3748972047L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15697,11 +15859,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo3_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2731047054L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15725,11 +15888,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo3_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4177642521L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16271,11 +16435,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_PicConfiguration for category Pic using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo3_PicConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo3_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 2638816400L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16369,11 +16534,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo4_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1781653934L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16404,11 +16570,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo4_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 4153137118L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16432,11 +16599,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo4_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo4_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 498296405L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16922,11 +17090,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo5_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 3697685667L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16957,11 +17126,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo5_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2934828981L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16985,11 +17155,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo5_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo5_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2187439642L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17475,11 +17646,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_DeviceConfiguration for category Device using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo6_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 3723447797L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17510,11 +17682,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_DevicesConfiguration for category Devices using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo6_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1162323720L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17538,11 +17711,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_LimitsConfiguration for category Limits using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_Cryo6_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_Cryo6_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4184338570L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -18028,11 +18202,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CryoCompLimits_CompLimitsConfiguration using level 1 for category CompLimits-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CryoCompLimits_CompLimitsConfiguration for category CompLimits using level 1-->
   <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_CryoCompLimits_CompLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_CryoCompLimits_CompLimitsConfiguration for category CompLimits</Description>
     <!--CCS: Dictionary_Checksum: 1953953015L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -18161,11 +18336,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 608818486L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -18217,11 +18393,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_PicConfiguration for category Pic using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_PeriodicTasks_PicConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 2252880418L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -18259,11 +18436,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_logevent_pathfinder_refrig_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_logevent_pathfinder_refrig_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 439653494L -->
     <item>
       <EFDB_Name>version</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Telemetry.xml
@@ -5,6 +5,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_fcs</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_fcs</Description>
     <!--CCS: Dictionary_Checksum: 3032430353L -->
     <item>
       <EFDB_Name>linearencoder_LinearPosition</EFDB_Name>
@@ -33,6 +34,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_bonn_shutter_Device</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_bonn_shutter_Device</Description>
     <!--CCS: Dictionary_Checksum: 470595085L -->
     <item>
       <EFDB_Name>bonn_V36</EFDB_Name>
@@ -49,11 +51,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_daq_monitor_Reb_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_daq_monitor_Reb_Trending for category Trending using level 1-->
   <!--=======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_daq_monitor_Reb_Trending</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_daq_monitor_Reb_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3684271513L -->
     <!--CCSMETA: Array driver_errors indexed by location-->
     <item>
@@ -476,6 +479,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_daq_monitor_Store</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_daq_monitor_Store</Description>
     <!--CCS: Dictionary_Checksum: 822096068L -->
     <item>
       <EFDB_Name>capacity</EFDB_Name>
@@ -499,11 +503,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_daq_monitor_Sum_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem CCCamera class CCCamera_daq_monitor_Sum_Trending for category Trending using level 1-->
   <!--=======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_daq_monitor_Sum_Trending</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_daq_monitor_Sum_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 4053115936L -->
     <item>
       <EFDB_Name>driver_errors</EFDB_Name>
@@ -665,6 +670,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_Reb</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_rebpower_Reb</Description>
     <!--CCS: Dictionary_Checksum: 2252133633L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
@@ -959,6 +965,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_RebTotalPower</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_rebpower_RebTotalPower</Description>
     <!--CCS: Dictionary_Checksum: 765746799L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
@@ -973,6 +980,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_rebpower_Rebps</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_rebpower_Rebps</Description>
     <!--CCS: Dictionary_Checksum: 2343408552L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
@@ -1059,6 +1067,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Cold1</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_Cold1</Description>
     <!--CCS: Dictionary_Checksum: 3866169720L -->
     <item>
       <EFDB_Name>autoOffEnabled</EFDB_Name>
@@ -1122,6 +1131,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Cold2</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_Cold2</Description>
     <!--CCS: Dictionary_Checksum: 2590548572L -->
     <item>
       <EFDB_Name>autoOffEnabled</EFDB_Name>
@@ -1185,6 +1195,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Cryo</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_Cryo</Description>
     <!--CCS: Dictionary_Checksum: 1660760227L -->
     <item>
       <EFDB_Name>autoOffEnabled</EFDB_Name>
@@ -1248,6 +1259,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_IonPumps</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_IonPumps</Description>
     <!--CCS: Dictionary_Checksum: 1305365654L -->
     <item>
       <EFDB_Name>current</EFDB_Name>
@@ -1269,6 +1281,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Rtds</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_Rtds</Description>
     <!--CCS: Dictionary_Checksum: 197947832L -->
     <item>
       <EFDB_Name>temperatureCold1</EFDB_Name>
@@ -1297,6 +1310,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_Turbo</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_Turbo</Description>
     <!--CCS: Dictionary_Checksum: 228701385L -->
     <item>
       <EFDB_Name>cntrlrAirTemperature</EFDB_Name>
@@ -1367,6 +1381,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_vacuum_VQMonitor</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_vacuum_VQMonitor</Description>
     <!--CCS: Dictionary_Checksum: 3797016354L -->
     <item>
       <EFDB_Name>vqmpressure</EFDB_Name>
@@ -1381,6 +1396,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_BFR</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_quadbox_BFR</Description>
     <!--CCS: Dictionary_Checksum: 4234786309L -->
     <item>
       <EFDB_Name>clean_5_24V_I</EFDB_Name>
@@ -1444,6 +1460,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_24VC</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_quadbox_PDU_24VC</Description>
     <!--CCS: Dictionary_Checksum: 2262228976L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
@@ -1654,6 +1671,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_24VD</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_quadbox_PDU_24VD</Description>
     <!--CCS: Dictionary_Checksum: 1578563142L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
@@ -1710,6 +1728,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_48V</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_quadbox_PDU_48V</Description>
     <!--CCS: Dictionary_Checksum: 745874751L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
@@ -1808,6 +1827,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_quadbox_PDU_5V</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_quadbox_PDU_5V</Description>
     <!--CCS: Dictionary_Checksum: 577849488L -->
     <item>
       <EFDB_Name>otm_3_B_I</EFDB_Name>
@@ -1829,6 +1849,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_Ccd</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_focal_plane_Ccd</Description>
     <!--CCS: Dictionary_Checksum: 441659878L -->
     <!--CCSMETA: Array gDV indexed by location-->
     <item>
@@ -1883,6 +1904,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_Reb</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_focal_plane_Reb</Description>
     <!--CCS: Dictionary_Checksum: 4091643716L -->
     <!--CCSMETA: Array anaI indexed by location-->
     <item>
@@ -2241,6 +2263,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_RebTotalPower</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_focal_plane_RebTotalPower</Description>
     <!--CCS: Dictionary_Checksum: 886963829L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
@@ -2255,6 +2278,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_RebsAverageTemp6</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_focal_plane_RebsAverageTemp6</Description>
     <!--CCS: Dictionary_Checksum: 1100570195L -->
     <item>
       <EFDB_Name>rebsAverageTemp6</EFDB_Name>
@@ -2269,6 +2293,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_focal_plane_Segment</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_focal_plane_Segment</Description>
     <!--CCS: Dictionary_Checksum: 49742677L -->
     <!--CCSMETA: Array i indexed by location-->
     <item>
@@ -2291,6 +2316,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cold1</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cold1</Description>
     <!--CCS: Dictionary_Checksum: 4177697756L -->
     <item>
       <EFDB_Name>ambientTmp</EFDB_Name>
@@ -2494,6 +2520,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cold2</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cold2</Description>
     <!--CCS: Dictionary_Checksum: 2912979557L -->
     <item>
       <EFDB_Name>ambientTmp</EFDB_Name>
@@ -2697,6 +2724,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cryo1</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cryo1</Description>
     <!--CCS: Dictionary_Checksum: 843516038L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -2823,6 +2851,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cryo2</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cryo2</Description>
     <!--CCS: Dictionary_Checksum: 1392459008L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -2963,6 +2992,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cryo3</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cryo3</Description>
     <!--CCS: Dictionary_Checksum: 953517925L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -3103,6 +3133,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cryo4</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cryo4</Description>
     <!--CCS: Dictionary_Checksum: 381149540L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -3229,6 +3260,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cryo5</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cryo5</Description>
     <!--CCS: Dictionary_Checksum: 1892187579L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -3355,6 +3387,7 @@
   <SALTelemetry>
     <Subsystem>CCCamera</Subsystem>
     <EFDB_Topic>CCCamera_pathfinder_refrig_Cryo6</EFDB_Topic>
+    <Description>subsystem CCCamera class CCCamera_pathfinder_refrig_Cryo6</Description>
     <!--CCS: Dictionary_Checksum: 3662207194L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Commands.xml
@@ -3,6 +3,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_discardRows</EFDB_Topic>
+    <Description>LSE-71 discardRows command</Description>
     <item>
       <EFDB_Name>nRows</EFDB_Name>
       <Description>Number of rows to discard</Description>
@@ -14,6 +15,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_startImage</EFDB_Topic>
+    <Description>LSE-71 startImage command</Description>
     <item>
       <EFDB_Name>shutter</EFDB_Name>
       <Description>True if the shutter should be opened/closed</Description>
@@ -56,10 +58,12 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_disableCalibration</EFDB_Topic>
+    <Description>LSE-71 disableCalibration command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_initGuiders</EFDB_Topic>
+    <Description>LSE-71 initGuiders command</Description>
     <item>
       <EFDB_Name>roiSpec</EFDB_Name>
       <Description>Specification for region of interest</Description>
@@ -72,10 +76,12 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_enableCalibration</EFDB_Topic>
+    <Description>LSE-71 enableCalibration command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_initImage</EFDB_Topic>
+    <Description>LSE-71 initImage command</Description>
     <item>
       <EFDB_Name>deltaT</EFDB_Name>
       <Description>Estimate of time period before takeImages will be issued</Description>
@@ -87,10 +93,12 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_endImage</EFDB_Topic>
+    <Description>LSE-71 endImage command</Description>
   </SALCommand>
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_setFilter</EFDB_Topic>
+    <Description>LSE-71 setFilter command</Description>
     <item>
       <EFDB_Name>name</EFDB_Name>
       <Description>The filter name to install</Description>
@@ -103,6 +111,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_clear</EFDB_Topic>
+    <Description>LSE-71 clear command</Description>
     <item>
       <EFDB_Name>nClears</EFDB_Name>
       <Description>Number of consecutive clear operations to perform</Description>
@@ -114,6 +123,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_takeImages</EFDB_Topic>
+    <Description>LSE-71 takeImages command</Description>
     <item>
       <EFDB_Name>numImages</EFDB_Name>
       <Description>Number of consecutive images to take</Description>
@@ -163,11 +173,13 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_stop</EFDB_Topic>
+    <Description>LSE-71 stop command</Description>
   </SALCommand>
   <!-- Playlist related commands, only valid when using emulated DAQ -->
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_play</EFDB_Topic>
+    <Description>Play specified playlist</Description>
     <item>
       <EFDB_Name>playlist</EFDB_Name>
       <Description>Name of an existing DAQ playlist to play</Description>
@@ -186,6 +198,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_playlist</EFDB_Topic>
+    <Description>Define a new playlist</Description>
     <item>
       <EFDB_Name>playlist</EFDB_Name>
       <Description>Name of a DAQ playlist to be defined (replaced if exists)</Description>
@@ -212,6 +225,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_alert</EFDB_Topic>
+    <Description>Experimental command -- not currently implemented</Description>
     <item>
       <EFDB_Name>alertId</EFDB_Name>
       <Description>The alertId for which this command applies (or *)</Description>
@@ -230,6 +244,7 @@
   <SALCommand>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_command_wakeFilterChanger</EFDB_Topic>
+    <Description>Command to wake the filter changer</Description>
     <item>
       <EFDB_Name>mode</EFDB_Name>
       <Description>0=low power, 1=prepare for setFilter, 2=high power</Description>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -3,6 +3,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_offlineDetailedState</EFDB_Topic>
+    <Description>Event generated when the OFFLINE state changes</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -120,6 +121,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endTakeImage</EFDB_Topic>
+    <Description>Event generated at the end of an image</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -131,6 +133,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_imageReadinessDetailedState</EFDB_Topic>
+    <Description>Event which reflects the readiness of the camera to take an image with no additional time overhead</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -150,6 +153,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startSetFilter</EFDB_Topic>
+    <Description>Event generated at the begining of a setFilter operation</Description>
     <item>
       <EFDB_Name>filterName</EFDB_Name>
       <Description>The name of the filter being installed (e.g. U-001)</Description>
@@ -171,6 +175,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startUnloadFilter</EFDB_Topic>
+    <Description>Event generated when a filter is starting to be unloaded.</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -182,6 +187,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_notReadyToTakeImage</EFDB_Topic>
+    <Description>Event which indicates camera is not ready to take an image without overhead</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -193,6 +199,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startShutterClose</EFDB_Topic>
+    <Description>Event indicating the start of a shutter close operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -204,6 +211,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endInitializeGuider</EFDB_Topic>
+    <Description>???</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -215,6 +223,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endShutterClose</EFDB_Topic>
+    <Description>Event generated at the end of a shutter close operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -361,6 +370,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endUnloadFilter</EFDB_Topic>
+    <Description>Event generated at the end of an unload filter operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -372,6 +382,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_calibrationDetailedState</EFDB_Topic>
+    <Description>Event indicating the calibration state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -391,6 +402,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endRotateCarousel</EFDB_Topic>
+    <Description>Event generated at the end of a carousel rotation operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -402,6 +414,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startLoadFilter</EFDB_Topic>
+    <Description>Event generated at the beginning of a filter load operation</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -413,6 +426,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_filterChangerDetailedState</EFDB_Topic>
+    <Description>Event reflecting the filter changer state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>substate</Description>
@@ -432,6 +446,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_shutterDetailedState</EFDB_Topic>
+    <Description>Event reflecting the shutter state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -451,6 +466,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_readyToTakeImage</EFDB_Topic>
+    <Description>Event indicating the camera is ready to take an image with no time overhead</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -462,6 +478,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_ccsCommandState</EFDB_Topic>
+    <Description>Event indicating the camera command state</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Substate of the CCS command.</Description>
@@ -481,6 +498,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_prepareToTakeImage</EFDB_Topic>
+    <Description>????</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -492,6 +510,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_ccsConfigured</EFDB_Topic>
+    <Description>???</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -503,6 +522,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endLoadFilter</EFDB_Topic>
+    <Description>Event indicating the camera has finished loading a filter</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -514,6 +534,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endShutterOpen</EFDB_Topic>
+    <Description>Event issued when the shutter open operation completes</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -632,6 +653,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_endInitializeImage</EFDB_Topic>
+    <Description>???</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -681,6 +703,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startShutterOpen</EFDB_Topic>
+    <Description>Event issued when we start to open the shutter</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -692,6 +715,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_raftsDetailedState</EFDB_Topic>
+    <Description>Event indicating the state of the focal-plane</Description>
     <item>
       <EFDB_Name>substate</EFDB_Name>
       <Description>Enumeration of valid substates</Description>
@@ -711,6 +735,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_availableFilters</EFDB_Topic>
+    <Description>Event listing the filters available to be selected</Description>
     <item>
       <EFDB_Name>filterNames</EFDB_Name>
       <Description>A list of names of available filters (comma delimited, U-001,G-004,R-010,Z-012,Y-014, NONE), in the same order as the list of filter types.</Description>
@@ -856,6 +881,7 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startRotateCarousel</EFDB_Topic>
+    <Description>Event generated when the filter changer carousel starts to rotate</Description>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>
       <Description>The time at which the state transition occurred</Description>
@@ -1107,11 +1133,12 @@
     </item>
   </SALEvent>
   <!-- CONFIGURATION Do not remove this line -->
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_BFR_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_BFR_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1577558727L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1128,11 +1155,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_BFR_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_BFR_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1940619542L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1422,11 +1450,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_BFR_QuadboxConfiguration for category Quadbox using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_BFR_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_BFR_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 3714909306L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1443,11 +1472,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DeviceConfiguration for category Device using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_Maq20_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1931378380L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1471,11 +1501,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DevicesConfiguration for category Devices using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_Maq20_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_Maq20_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 664197741L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1492,11 +1523,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3965252035L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -1513,11 +1545,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 81620535L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2227,11 +2260,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration for category Quadbox using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VC_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 1828439805L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2248,11 +2282,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 430770279L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2269,11 +2304,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration for category Limits using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1522668218L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2815,11 +2851,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration for category Quadbox using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_24VD_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 2850418823L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2836,11 +2873,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2817100035L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -2857,11 +2895,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3927940510L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3291,11 +3330,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration for category Quadbox using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_48V_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 1840265369L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3312,11 +3352,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_DevicesConfiguration for category Devices using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2701746051L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -3333,11 +3374,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 843643995L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4019,11 +4061,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration for category Quadbox using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PDU_5V_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 2806487858L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4040,11 +4083,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1137115398L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4096,11 +4140,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3148416703L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4278,11 +4323,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration for category Devices using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 413846485L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4299,11 +4345,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1214246971L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4677,11 +4724,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration using level 1 for category Quadbox-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration for category Quadbox using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_quadbox_REB_Bulk_PS_QuadboxConfiguration for category Quadbox</Description>
     <!--CCS: Dictionary_Checksum: 3427238524L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4698,11 +4746,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_EmergencyResponseManager_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 370200845L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4719,11 +4768,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_GeneralConfiguration for category General using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 961719118L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4754,11 +4804,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3578539392L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -4810,11 +4861,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2646060098L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5195,11 +5247,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Power_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Power_timersConfiguration for category timers using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Power_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Power_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3720383903L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5232,11 +5285,12 @@
       <Count>63</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration for category Limits using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_RebTotalPower_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 33485532L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5274,11 +5328,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Reb_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Reb_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2277039115L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -5311,11 +5366,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Reb_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Reb_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1569289345L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6580,11 +6636,12 @@
       <Count>71</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_DevicesConfiguration for category Devices using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 208746333L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6609,11 +6666,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_GeneralConfiguration for category General using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1171629463L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6638,11 +6696,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3203409092L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6915,11 +6974,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_PowerConfiguration using level 1 for category Power-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_PowerConfiguration for category Power using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_PowerConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_PowerConfiguration for category Power</Description>
     <!--CCS: Dictionary_Checksum: 1165343399L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6952,11 +7012,12 @@
       <Count>13</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_buildConfiguration using level 1 for category build-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_buildConfiguration for category build using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Rebps_buildConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Rebps_buildConfiguration for category build</Description>
     <!--CCS: Dictionary_Checksum: 3235921322L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -6981,11 +7042,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold1_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold1_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cold1_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cold1_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 752767486L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7051,11 +7113,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold2_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cold2_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cold2_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cold2_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 231351449L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7121,11 +7184,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo1_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo1_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo1_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cryo1_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1731829745L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7387,11 +7451,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo2_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo2_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo2_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cryo2_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 380909151L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7653,11 +7718,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo3_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo3_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo3_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cryo3_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2401217786L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -7919,11 +7985,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo4_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo4_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo4_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cryo4_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4121912579L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8185,11 +8252,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo5_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo5_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo5_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cryo5_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1812266918L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8451,11 +8519,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo6_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Cryo6_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Cryo6_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Cryo6_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 495539720L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8717,11 +8786,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_GeneralConfiguration for category General using level 1-->
   <!--===============================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1133725269L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8745,11 +8815,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Maq20_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Maq20_DeviceConfiguration for category Device using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Maq20_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Maq20_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 2604156242L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8773,11 +8844,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Maq20_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_Maq20_DevicesConfiguration for category Devices using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_Maq20_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_Maq20_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3221628023L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8794,11 +8866,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1435761504L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8836,11 +8909,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 465559570L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8913,11 +8987,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_hex_StatusAggregator_GeneralConfiguration for category General using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_hex_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_hex_StatusAggregator_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 898812745L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8934,11 +9009,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 4127351797L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8969,11 +9045,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2067315501L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -8997,11 +9074,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2968384280L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -9487,11 +9565,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo2_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 4153088675L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -9522,11 +9601,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo2_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2425549712L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -9550,11 +9630,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo2_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo2_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3421220232L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10040,11 +10121,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1104990126L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10075,11 +10157,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3388263419L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10103,11 +10186,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 317401243L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10649,11 +10733,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_PicConfiguration for category Pic using level 1-->
   <!--================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 3402127099L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10747,11 +10832,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo4_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 4103727119L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10782,11 +10868,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo4_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2629264555L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -10810,11 +10897,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo4_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo4_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1038553256L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11300,11 +11388,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1120812290L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11335,11 +11424,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3318832320L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11363,11 +11453,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3175561399L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -11909,11 +12000,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_PicConfiguration for category Pic using level 1-->
   <!--================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo5_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo5_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 2206368737L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12007,11 +12099,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DeviceConfiguration for category Device using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo6_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1128744020L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12042,11 +12135,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DevicesConfiguration for category Devices using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo6_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 779818109L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12070,11 +12164,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo6_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo6_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3644032631L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12560,11 +12655,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_CryoCompLimits_CompLimitsConfiguration using level 1 for category CompLimits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_CryoCompLimits_CompLimitsConfiguration for category CompLimits using level 1-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_CryoCompLimits_CompLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_CryoCompLimits_CompLimitsConfiguration for category CompLimits</Description>
     <!--CCS: Dictionary_Checksum: 1390129142L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12693,11 +12789,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 173128568L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12749,11 +12846,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_PicConfiguration using level 1 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_PicConfiguration for category Pic using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_PeriodicTasks_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 1012741945L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -12777,11 +12875,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2216043242L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13120,11 +13219,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Cip_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Cip_LimitsConfiguration for category Limits using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Cip_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Cip_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1588160154L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13269,11 +13369,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_CryoConfiguration for category Cryo using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoFlineGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 1440439696L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13304,11 +13405,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration for category Devices using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoFlineGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3707390155L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13325,11 +13427,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_CryoConfiguration for category Cryo using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 615585091L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13360,11 +13463,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration for category Devices using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3197591169L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13381,11 +13485,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_DevicesConfiguration for category Devices using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboPump_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3062615108L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13402,11 +13507,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_GeneralConfiguration for category General using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoTurboPump_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoTurboPump_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2957539535L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13591,11 +13697,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_CryoConfiguration for category Cryo using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 459238043L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13626,11 +13733,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration for category Devices using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_CryoVacGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1011642694L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13647,11 +13755,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Cryo_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Cryo_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Cryo_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Cryo_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1720571420L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -13983,11 +14092,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HX_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HX_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HX_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HX_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 260760713L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14319,11 +14429,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_CryoConfiguration for category Cryo using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexFlineGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 3017857976L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14354,11 +14465,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration for category Devices using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexFlineGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 4068509213L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14375,11 +14487,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_CryoConfiguration for category Cryo using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 3263861611L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14410,11 +14523,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration for category Devices using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2431488087L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14431,11 +14545,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_DevicesConfiguration for category Devices using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboPump_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3995455558L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14452,11 +14567,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_GeneralConfiguration for category General using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexTurboPump_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexTurboPump_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3374434573L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14641,11 +14757,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_CryoConfiguration for category Cryo using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexVacGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 3246876108L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14676,11 +14793,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration for category Devices using level 1-->
   <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_HexVacGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3865510223L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14697,11 +14815,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hip_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Hip_LimitsConfiguration for category Limits using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Hip_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Hip_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1969113914L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14846,11 +14965,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_CryoConfiguration for category Cryo using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_InstVacGauge_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 365426368L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14881,11 +15001,12 @@
       <Count>3</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration for category Devices using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_InstVacGauge_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 562236644L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -14902,11 +15023,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Inst_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Inst_LimitsConfiguration for category Limits using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Inst_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Inst_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4040863154L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15126,11 +15248,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_CryoConfiguration for category Cryo using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_IonPumps_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 3589610490L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15315,11 +15438,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_IonPumps_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_IonPumps_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2615353467L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15336,11 +15460,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DeviceConfiguration for category Device using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Cryo_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1173523966L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15364,11 +15489,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DevicesConfiguration for category Devices using level 1-->
   <!--============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Cryo_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Cryo_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 68898138L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15385,11 +15511,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DeviceConfiguration for category Device using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Ut_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 1790601269L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15413,11 +15540,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DevicesConfiguration for category Devices using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_Maq20Ut_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_Maq20Ut_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2434341404L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15434,11 +15562,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PDU_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PDU_DevicesConfiguration for category Devices using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PDU_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PDU_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3909830192L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15455,11 +15584,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PDU_VacuumConfiguration using level 1 for category Vacuum-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PDU_VacuumConfiguration for category Vacuum using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PDU_VacuumConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PDU_VacuumConfiguration for category Vacuum</Description>
     <!--CCS: Dictionary_Checksum: 3124569595L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15476,11 +15606,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 803926824L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15532,11 +15663,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--==============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1626590675L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15833,11 +15965,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_CryoConfiguration using level 1 for category Cryo-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_CryoConfiguration for category Cryo using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PumpCart_CryoConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_CryoConfiguration for category Cryo</Description>
     <!--CCS: Dictionary_Checksum: 2020908612L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15868,11 +16001,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PumpCart_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2283535295L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15889,11 +16023,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DeviceConfiguration for category Device using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_VacPluto_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 2853580557L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15910,11 +16045,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_VacPluto_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_VacPluto_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 718539561L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -15931,11 +16067,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacuumConfiguration using level 1 for category Vacuum-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_vacuum_VacuumConfiguration for category Vacuum using level 1-->
   <!--================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_VacuumConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_vacuum_VacuumConfiguration for category Vacuum</Description>
     <!--CCS: Dictionary_Checksum: 2122196485L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16106,11 +16243,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1400138104L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16148,11 +16286,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1513603246L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16218,11 +16357,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration using level 1 for category Statistics-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics</Description>
     <!--CCS: Dictionary_Checksum: 3891351454L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16302,11 +16442,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_StoreConfiguration using level 1 for category Store-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_StoreConfiguration for category Store using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_StoreConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_StoreConfiguration for category Store</Description>
     <!--CCS: Dictionary_Checksum: 2545530055L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16330,11 +16471,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_DevicesConfiguration for category Devices using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Store_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2684605940L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16351,11 +16493,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_LimitsConfiguration for category Limits using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Store_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1488504894L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16379,11 +16522,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_StoreConfiguration using level 1 for category Store-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_StoreConfiguration for category Store using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Store_StoreConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_Store_StoreConfiguration for category Store</Description>
     <!--CCS: Dictionary_Checksum: 835696483L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16421,11 +16565,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 2249685560L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16458,11 +16603,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Ccd_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Ccd_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2108558626L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16671,11 +16817,12 @@
       <Count>201</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration for category General using level 1-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_ImageDatabaseService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2116957573L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16699,11 +16846,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_ImageNameService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3928761086L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16748,11 +16896,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration using level 1 for category Instrument-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration for category Instrument using level 1-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_InstrumentConfig_InstrumentConfiguration for category Instrument</Description>
     <!--CCS: Dictionary_Checksum: 3735281910L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16783,11 +16932,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration using level 1 for category Monitoring-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration for category Monitoring using level 1-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_MonitoringConfig_MonitoringConfiguration for category Monitoring</Description>
     <!--CCS: Dictionary_Checksum: 2991560953L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16811,11 +16961,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1028157412L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -16867,11 +17018,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3214895136L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17091,11 +17243,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Raft_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 2411177375L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17120,11 +17273,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration using level 1 for category RaftTempControl-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration for category RaftTempControl using level 1-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlConfiguration for category RaftTempControl</Description>
     <!--CCS: Dictionary_Checksum: 124194515L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17245,11 +17399,12 @@
       <Count>25</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration using level 1 for category RaftTempControlStatus-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration for category RaftTempControlStatus using level 1-->
   <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Raft_RaftTempControlStatusConfiguration for category RaftTempControlStatus</Description>
     <!--CCS: Dictionary_Checksum: 1630683015L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17274,11 +17429,12 @@
       <Count>25</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration for category Limits using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_RebTotalPower_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2163139035L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17316,11 +17472,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_DevicesConfiguration for category Devices using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1043448673L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17345,11 +17502,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1125789776L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17374,11 +17532,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_HardwareIdConfiguration using level 1 for category HardwareId-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_HardwareIdConfiguration for category HardwareId using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_HardwareIdConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_HardwareIdConfiguration for category HardwareId</Description>
     <!--CCS: Dictionary_Checksum: 395125619L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -17403,11 +17562,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3520767875L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -19056,11 +19216,12 @@
       <Count>71</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsConfiguration using level 1 for category Rafts-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsConfiguration for category Rafts using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsConfiguration for category Rafts</Description>
     <!--CCS: Dictionary_Checksum: 3517909367L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -19261,11 +19422,12 @@
       <Count>71</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration using level 1 for category RaftsLimits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration for category RaftsLimits using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsLimitsConfiguration for category RaftsLimits</Description>
     <!--CCS: Dictionary_Checksum: 1662452324L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -19570,11 +19732,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration using level 1 for category RaftsPower-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration for category RaftsPower using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_RaftsPowerConfiguration for category RaftsPower</Description>
     <!--CCS: Dictionary_Checksum: 3733685657L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20383,11 +20546,12 @@
       <Count>71</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_timersConfiguration for category timers using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Reb_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Reb_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3116175901L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20524,11 +20688,12 @@
       <Count>71</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_RebsAverageTemp6_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1056454019L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20559,11 +20724,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration for category Limits using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_RebsAverageTemp6_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1818855593L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20601,11 +20767,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Segment_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_Segment_LimitsConfiguration for category Limits using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_Segment_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_Segment_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1621673020L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20654,11 +20821,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration using level 1 for category DAQ-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration for category DAQ using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_DAQConfiguration for category DAQ</Description>
     <!--CCS: Dictionary_Checksum: 21927214L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20717,11 +20885,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration using level 1 for category Guider-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider</Description>
     <!--CCS: Dictionary_Checksum: 2245109041L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20745,11 +20914,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration using level 1 for category Sequencer-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer</Description>
     <!--CCS: Dictionary_Checksum: 1247479346L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20948,11 +21118,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration using level 1 for category Visualization-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration for category Visualization using level 1-->
   <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_WebHooksConfig_VisualizationConfiguration for category Visualization</Description>
     <!--CCS: Dictionary_Checksum: 919408884L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20969,11 +21140,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_FitsService_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_FitsService_GeneralConfiguration for category General using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_FitsService_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_FitsService_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 191767559L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -20997,11 +21169,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration using level 1 for category Commands-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration for category Commands using level 1-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_CommandsConfiguration for category Commands</Description>
     <!--CCS: Dictionary_Checksum: 806749796L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21053,11 +21226,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration using level 1 for category DAQ-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration for category DAQ using level 1-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_DAQConfiguration for category DAQ</Description>
     <!--CCS: Dictionary_Checksum: 2833262260L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21137,11 +21311,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration using level 1 for category FitsHandling-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration for category FitsHandling using level 1-->
   <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_FitsHandlingConfiguration for category FitsHandling</Description>
     <!--CCS: Dictionary_Checksum: 3953669377L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21214,11 +21389,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration using level 1 for category Guider-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration for category Guider using level 1-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_ImageHandler_GuiderConfiguration for category Guider</Description>
     <!--CCS: Dictionary_Checksum: 145954834L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21256,11 +21432,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 245874300L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21284,11 +21461,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1124810080L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21319,11 +21497,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration for category General using level 1-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_image_handling_StatusAggregator_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3292024849L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21340,11 +21519,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_03_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_03_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CLP_RTD_03_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_03_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 508960694L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21382,11 +21562,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_05_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_05_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CLP_RTD_05_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_05_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4144807496L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21424,11 +21605,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_50_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_50_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CLP_RTD_50_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_50_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 492931118L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21466,11 +21648,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_55_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_55_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CLP_RTD_55_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CLP_RTD_55_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2157345071L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21508,11 +21691,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_12_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_12_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CYP_RTD_12_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_12_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4088305854L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21550,11 +21734,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_14_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_14_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CYP_RTD_14_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_14_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 452213056L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21592,11 +21777,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_31_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_31_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CYP_RTD_31_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_31_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 126400232L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21634,11 +21820,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_43_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_43_LimitsConfiguration for category Limits using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_CYP_RTD_43_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_CYP_RTD_43_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 511733171L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21676,11 +21863,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3974466412L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21718,11 +21906,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 71268436L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21781,11 +21970,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_Pluto_DeviceConfiguration using level 1 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_Pluto_DeviceConfiguration for category Device using level 1-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_Pluto_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_Pluto_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 4046296215L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21802,11 +21992,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_Pluto_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_mpm_Pluto_DevicesConfiguration for category Devices using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_mpm_Pluto_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_mpm_Pluto_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 729289263L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -21823,11 +22014,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_LimitsConfiguration using level 1 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_LimitsConfiguration for category Limits using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3274512121L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -22061,11 +22253,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_autochangerConfiguration using level 1 for category autochanger-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_autochangerConfiguration for category autochanger using level 1-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_autochangerConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_autochangerConfiguration for category autochanger</Description>
     <!--CCS: Dictionary_Checksum: 2570098047L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -22649,11 +22842,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_readRateConfiguration using level 1 for category readRate-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_readRateConfiguration for category readRate using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_readRateConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_readRateConfiguration for category readRate</Description>
     <!--CCS: Dictionary_Checksum: 4074586327L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -22705,11 +22899,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_sensorConfiguration using level 1 for category sensor-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_sensorConfiguration for category sensor using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Autochanger_sensorConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Autochanger_sensorConfiguration for category sensor</Description>
     <!--CCS: Dictionary_Checksum: 2769748111L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24280,11 +24475,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_canbusConfiguration using level 1 for category canbus-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_canbusConfiguration for category canbus using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_canbusConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_canbusConfiguration for category canbus</Description>
     <!--CCS: Dictionary_Checksum: 3209700913L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24322,11 +24518,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_controllerConfiguration using level 1 for category controller-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_controllerConfiguration for category controller using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_controllerConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_controllerConfiguration for category controller</Description>
     <!--CCS: Dictionary_Checksum: 4124638781L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24560,11 +24757,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_nodeIDConfiguration using level 1 for category nodeID-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_nodeIDConfiguration for category nodeID using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_nodeIDConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_nodeIDConfiguration for category nodeID</Description>
     <!--CCS: Dictionary_Checksum: 3856037239L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24714,11 +24912,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_sensorConfiguration using level 1 for category sensor-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_sensorConfiguration for category sensor using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_sensorConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_sensorConfiguration for category sensor</Description>
     <!--CCS: Dictionary_Checksum: 3142019645L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24735,11 +24934,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_serialNBConfiguration using level 1 for category serialNB-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_serialNBConfiguration for category serialNB using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus0_serialNBConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus0_serialNBConfiguration for category serialNB</Description>
     <!--CCS: Dictionary_Checksum: 3304963596L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24889,11 +25089,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_canbusConfiguration using level 1 for category canbus-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_canbusConfiguration for category canbus using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_canbusConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_canbusConfiguration for category canbus</Description>
     <!--CCS: Dictionary_Checksum: 293655581L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24931,11 +25132,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_controllerConfiguration using level 1 for category controller-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_controllerConfiguration for category controller using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_controllerConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_controllerConfiguration for category controller</Description>
     <!--CCS: Dictionary_Checksum: 3375764732L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -24987,11 +25189,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_nodeIDConfiguration using level 1 for category nodeID-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_nodeIDConfiguration for category nodeID using level 1-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_nodeIDConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_nodeIDConfiguration for category nodeID</Description>
     <!--CCS: Dictionary_Checksum: 4179895460L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -25022,11 +25225,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_serialNBConfiguration using level 1 for category serialNB-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_serialNBConfiguration for category serialNB using level 1-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Canbus1_serialNBConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Canbus1_serialNBConfiguration for category serialNB</Description>
     <!--CCS: Dictionary_Checksum: 3860483647L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -25057,11 +25261,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_carouselConfiguration using level 1 for category carousel-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_carouselConfiguration for category carousel using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Carousel_carouselConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Carousel_carouselConfiguration for category carousel</Description>
     <!--CCS: Dictionary_Checksum: 3665931458L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -25680,11 +25885,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_readRateConfiguration using level 1 for category readRate-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_readRateConfiguration for category readRate using level 1-->
   <!--==========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Carousel_readRateConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Carousel_readRateConfiguration for category readRate</Description>
     <!--CCS: Dictionary_Checksum: 2670545188L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -25771,11 +25977,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_sensorConfiguration using level 1 for category sensor-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Carousel_sensorConfiguration for category sensor using level 1-->
   <!--======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Carousel_sensorConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Carousel_sensorConfiguration for category sensor</Description>
     <!--CCS: Dictionary_Checksum: 187822661L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -26674,11 +26881,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_FilterIdentificator_sensorConfiguration using level 1 for category sensor-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_FilterIdentificator_sensorConfiguration for category sensor using level 1-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_FilterIdentificator_sensorConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_FilterIdentificator_sensorConfiguration for category sensor</Description>
     <!--CCS: Dictionary_Checksum: 1620903783L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -26814,11 +27022,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_FilterManager_filterConfiguration using level 1 for category filter-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_FilterManager_filterConfiguration for category filter using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_FilterManager_filterConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_FilterManager_filterConfiguration for category filter</Description>
     <!--CCS: Dictionary_Checksum: 94796951L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -27416,11 +27625,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_loaderConfiguration using level 1 for category loader-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_loaderConfiguration for category loader using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Loader_loaderConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Loader_loaderConfiguration for category loader</Description>
     <!--CCS: Dictionary_Checksum: 4070873433L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -27605,11 +27815,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_readRateConfiguration using level 1 for category readRate-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_readRateConfiguration for category readRate using level 1-->
   <!--========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Loader_readRateConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Loader_readRateConfiguration for category readRate</Description>
     <!--CCS: Dictionary_Checksum: 951994315L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -27633,11 +27844,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration using level 1 for category sensor-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration for category sensor using level 1-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Loader_sensorConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Loader_sensorConfiguration for category sensor</Description>
     <!--CCS: Dictionary_Checksum: 193746652L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28634,11 +28846,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration using level 1 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3256921997L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28676,11 +28889,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration using level 1 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration for category timers using level 1-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1092279050L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28746,11 +28960,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Seneca1_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Seneca1_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Seneca1_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Seneca1_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1037762980L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28767,11 +28982,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Seneca2_DevicesConfiguration using level 1 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_fcs_Seneca2_DevicesConfiguration for category Devices using level 1-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_Seneca2_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_fcs_Seneca2_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3734156806L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28788,11 +29004,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_shutter_GeneralConfiguration using level 0 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_shutter_GeneralConfiguration for category General using level 0-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_shutter_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_shutter_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 2549365055L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28963,11 +29180,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_shutter_timersConfiguration using level 0 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_shutter_timersConfiguration for category timers using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_shutter_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_shutter_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2733398984L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -28998,11 +29216,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_DeviceConfiguration using level 0 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_DeviceConfiguration for category Device using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_chiller_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 461123390L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29033,11 +29252,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_DevicesConfiguration using level 0 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_DevicesConfiguration for category Devices using level 0-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_chiller_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3671244919L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29068,11 +29288,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_GeneralConfiguration using level 0 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_GeneralConfiguration for category General using level 0-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_chiller_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 3531999427L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29264,11 +29485,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_LimitsConfiguration using level 0 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_LimitsConfiguration for category Limits using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_chiller_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1457208418L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29320,11 +29542,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_PicConfiguration using level 0 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_PicConfiguration for category Pic using level 0-->
   <!--===========================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_chiller_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 3337261848L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29425,11 +29648,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_timersConfiguration using level 0 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_chiller_timersConfiguration for category timers using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_chiller_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 845686271L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29551,11 +29775,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_DeviceConfiguration using level 0 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_DeviceConfiguration for category Device using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 2671311423L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29586,11 +29811,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_DevicesConfiguration using level 0 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_DevicesConfiguration for category Devices using level 0-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1231670791L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29621,11 +29847,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_GeneralConfiguration using level 0 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_GeneralConfiguration for category General using level 0-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1114176838L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -29719,11 +29946,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_LimitsConfiguration using level 0 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_LimitsConfiguration for category Limits using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 597256671L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -30351,11 +30579,12 @@
       <Count>6</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_PicConfiguration using level 0 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_PicConfiguration for category Pic using level 0-->
   <!--===========================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 910380493L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -30673,11 +30902,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_RefrigConfiguration using level 0 for category Refrig-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_RefrigConfiguration for category Refrig using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_RefrigConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_RefrigConfiguration for category Refrig</Description>
     <!--CCS: Dictionary_Checksum: 1746649997L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -30813,11 +31043,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_ThermalLimitsConfiguration using level 0 for category ThermalLimits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_ThermalLimitsConfiguration for category ThermalLimits using level 0-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_ThermalLimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_ThermalLimitsConfiguration for category ThermalLimits</Description>
     <!--CCS: Dictionary_Checksum: 2027611568L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -30848,11 +31079,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_timersConfiguration using level 0 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_thermal_timersConfiguration for category timers using level 0-->
   <!--=================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_thermal_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_thermal_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3169345782L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -30995,11 +31227,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_DevicesConfiguration for category Devices using level 2-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_BFR_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 886197358L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31016,11 +31249,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_UtilConfiguration using level 2 for category Util-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_UtilConfiguration for category Util using level 2-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_BFR_UtilConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_BFR_UtilConfiguration for category Util</Description>
     <!--CCS: Dictionary_Checksum: 1038203116L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31037,11 +31271,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DeviceConfiguration using level 2 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DeviceConfiguration for category Device using level 2-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_BodyMaq20_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 3617243751L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31065,11 +31300,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DevicesConfiguration for category Devices using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_BodyMaq20_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_BodyMaq20_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 2418137123L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31086,11 +31322,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_AmbAirtemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_AmbAirtemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_AmbAirtemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_AmbAirtemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1055378894L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31128,11 +31365,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_AverageTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_AverageTemp_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_AverageTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_AverageTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3579720720L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31170,11 +31408,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_BackFlngXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2028062699L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31212,11 +31451,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 617135785L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31254,11 +31494,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngYMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_BackFlngYMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngYMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 511952455L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31296,11 +31537,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamBodyXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3239864273L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31338,11 +31580,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyYMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamBodyYMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyYMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1975037621L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31380,11 +31623,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyYPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyYPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamBodyYPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamBodyYPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2770731275L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31422,11 +31666,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamHousXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2354789469L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31464,11 +31709,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamHousXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4285236887L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31506,11 +31752,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousYMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamHousYMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousYMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3929619953L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31548,11 +31795,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousYPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousYPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_CamHousYPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_CamHousYPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2605834317L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31590,11 +31838,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1803746343L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31632,11 +31881,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirVel_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirVel_LimitsConfiguration for category Limits using level 2-->
   <!--============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirVel_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ChgrYMinusRtnAirVel_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2921622906L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31674,11 +31924,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_DomeXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_DomeXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_DomeXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_DomeXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3841341140L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31716,11 +31967,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_DomeYMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_DomeYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_DomeYMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_DomeYMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2190751608L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31758,11 +32010,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L1XMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L1XMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_L1XMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L1XMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1152083132L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31800,11 +32053,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L1YMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L1YMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_L1YMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L1YMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 583623952L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31842,11 +32096,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2XMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2XMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_L2XMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2XMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4275172539L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31884,11 +32139,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2XPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2XPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_L2XPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2XPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 719319907L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31926,11 +32182,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2YMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2YMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_L2YMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2YMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2561930519L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -31968,11 +32225,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2YPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2YPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_L2YPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_L2YPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1323668921L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32010,11 +32268,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShrdRngXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2656250433L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32052,11 +32311,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShrdRngXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1083493070L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32094,11 +32354,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4163972077L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32136,11 +32397,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShrdRngYPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 615427092L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32178,11 +32440,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2999285755L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32220,11 +32483,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirVel_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirVel_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirVel_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrEboxRtnAirVel_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2996703115L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32262,11 +32526,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3659180952L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32304,11 +32569,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirVel_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirVel_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirVel_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShtrMtrRtnAirVel_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 85740401L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32346,11 +32612,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_VPPlenumInTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_VPPlenumInTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_VPPlenumInTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_VPPlenumInTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2753756788L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32388,11 +32655,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DeviceConfiguration using level 2 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DeviceConfiguration for category Device using level 2-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_CryoMaq20_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 2109991521L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32416,11 +32684,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DevicesConfiguration for category Devices using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_CryoMaq20_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_CryoMaq20_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 242690159L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32437,11 +32706,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPCFan_PicConfiguration using level 2 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPCFan_PicConfiguration for category Pic using level 2-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPCFan_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPCFan_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 1755465279L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32549,11 +32819,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_AvgAirtempOut_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_AvgAirtempOut_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_AvgAirtempOut_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_AvgAirtempOut_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 159864000L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32591,11 +32862,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaPressFilt_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaPressFilt_LimitsConfiguration for category Limits using level 2-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_DeltaPressFilt_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaPressFilt_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2815499843L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32633,11 +32905,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaPressTotal_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaPressTotal_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_DeltaPressTotal_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaPressTotal_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 136287907L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32675,11 +32948,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaTempAct_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaTempAct_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_DeltaTempAct_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_DeltaTempAct_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2839825604L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32717,11 +32991,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanRunTime_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanRunTime_LimitsConfiguration for category Limits using level 2-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_FanRunTime_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanRunTime_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 623481360L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32759,11 +33034,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanSpeed_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanSpeed_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_FanSpeed_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanSpeed_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2798940880L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32801,11 +33077,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_Humidity_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_Humidity_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_Humidity_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_Humidity_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3790360311L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32843,11 +33120,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_PreFiltPress_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_PreFiltPress_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_PreFiltPress_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_PreFiltPress_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1733285331L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32885,11 +33163,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_RetnAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_RetnAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_RetnAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_RetnAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1997679546L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32927,11 +33206,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_RetnPress_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_RetnPress_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_RetnPress_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_RetnPress_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 672223181L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -32969,11 +33249,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_SplyAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_SplyAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_SplyAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_SplyAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1284839502L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33011,11 +33292,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_SplyPress_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_SplyPress_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_SplyPress_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_SplyPress_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1485331147L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33053,11 +33335,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_ValvePosn_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_ValvePosn_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_ValvePosn_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_ValvePosn_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2534837815L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33095,11 +33378,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_DevicesConfiguration for category Devices using level 2-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PDU_48V_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 437094716L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33116,11 +33400,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_UtilConfiguration using level 2 for category Util-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_UtilConfiguration for category Util using level 2-->
   <!--=======================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PDU_48V_UtilConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PDU_48V_UtilConfiguration for category Util</Description>
     <!--CCS: Dictionary_Checksum: 1944345152L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33137,11 +33422,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_AgentMonitorService_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_AgentMonitorService_timersConfiguration for category timers using level 2-->
   <!--=====================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_AgentMonitorService_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_AgentMonitorService_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2763508099L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33158,11 +33444,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_BodyMaq20_check_status_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_BodyMaq20_check_status_timersConfiguration for category timers using level 2-->
   <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_BodyMaq20_check_status_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_BodyMaq20_check_status_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 197810608L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33179,11 +33466,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_CryoMaq20_check_status_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_CryoMaq20_check_status_timersConfiguration for category timers using level 2-->
   <!--========================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_CryoMaq20_check_status_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_CryoMaq20_check_status_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 4212087235L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33200,11 +33488,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_MPCFan_PicConfiguration using level 2 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_MPCFan_PicConfiguration for category Pic using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_MPCFan_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_MPCFan_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 912177609L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33221,11 +33510,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_UTFan_PicConfiguration using level 2 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_UTFan_PicConfiguration for category Pic using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_UTFan_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_UTFan_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 3778730975L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33242,11 +33532,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_VPCFan_PicConfiguration using level 2 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_VPCFan_PicConfiguration for category Pic using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_VPCFan_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Fan_loop_VPCFan_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 3534059370L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33263,11 +33554,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Heartbeat_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Heartbeat_timersConfiguration for category timers using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Heartbeat_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Heartbeat_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3685084300L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33284,11 +33576,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_check_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_check_timersConfiguration for category timers using level 2-->
   <!--===============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_check_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_check_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3016586699L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33347,11 +33640,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_publish_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_publish_timersConfiguration for category timers using level 2-->
   <!--=================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_publish_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_publish_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1883185629L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33403,11 +33697,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_update_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_update_timersConfiguration for category timers using level 2-->
   <!--================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_update_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Monitor_update_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 165896484L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33459,11 +33754,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_RuntimeInfo_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_RuntimeInfo_timersConfiguration for category timers using level 2-->
   <!--=============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_RuntimeInfo_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_RuntimeInfo_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2250984292L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33480,11 +33776,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Schedulers_GeneralConfiguration using level 2 for category General-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Schedulers_GeneralConfiguration for category General using level 2-->
   <!--==============================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Schedulers_GeneralConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Schedulers_GeneralConfiguration for category General</Description>
     <!--CCS: Dictionary_Checksum: 1764061861L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33536,11 +33833,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UT_alarms_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UT_alarms_timersConfiguration for category timers using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_UT_alarms_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UT_alarms_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3764605163L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33557,11 +33855,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UT_state_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UT_state_timersConfiguration for category timers using level 2-->
   <!--==========================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_UT_state_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UT_state_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 2421457954L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33578,11 +33877,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UtMaq20_check_status_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UtMaq20_check_status_timersConfiguration for category timers using level 2-->
   <!--======================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_UtMaq20_check_status_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_UtMaq20_check_status_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 1220240246L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33599,11 +33899,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Vpc_loop_VPCHtrs_timersConfiguration using level 2 for category timers-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Vpc_loop_VPCHtrs_timersConfiguration for category timers using level 2-->
   <!--==================================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_PeriodicTasks_Vpc_loop_VPCHtrs_timersConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_PeriodicTasks_Vpc_loop_VPCHtrs_timersConfiguration for category timers</Description>
     <!--CCS: Dictionary_Checksum: 3710114883L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33620,11 +33921,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DeviceConfiguration using level 2 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DeviceConfiguration for category Device using level 2-->
   <!--=========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Pluto_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 415812354L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33641,11 +33943,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DevicesConfiguration for category Devices using level 2-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Pluto_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Pluto_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3820514651L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33662,11 +33965,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Telescope_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Telescope_DevicesConfiguration for category Devices using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_Telescope_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Telescope_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 3673323632L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33683,11 +33987,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UTFan_PicConfiguration using level 2 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UTFan_PicConfiguration for category Pic using level 2-->
   <!--===================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UTFan_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UTFan_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 1276280739L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33795,11 +34100,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_AverageTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_AverageTemp_LimitsConfiguration for category Limits using level 2-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_AverageTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_AverageTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 737421061L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33837,11 +34143,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolFlowRate_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolFlowRate_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_CoolFlowRate_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolFlowRate_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1467214249L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33879,11 +34186,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolPipeRetnTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolPipeRetnTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_CoolPipeRetnTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolPipeRetnTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 831883225L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33921,11 +34229,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolPipeSplyTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolPipeSplyTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_CoolPipeSplyTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolPipeSplyTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3262385884L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -33963,11 +34272,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolReturnPrs_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolReturnPrs_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_CoolReturnPrs_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolReturnPrs_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1351702081L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34005,11 +34315,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolSupplyPrs_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolSupplyPrs_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_CoolSupplyPrs_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_CoolSupplyPrs_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3030079617L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34047,11 +34358,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_DomeXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_DomeXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_DomeXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_DomeXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4044610625L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34089,11 +34401,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_DomeYMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_DomeYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_DomeYMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_DomeYMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2540821997L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34131,11 +34444,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanInletTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanInletTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_FanInletTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanInletTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3890380498L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34173,11 +34487,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanRunTime_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanRunTime_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_FanRunTime_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanRunTime_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1350232236L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34215,11 +34530,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanSpeed_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanSpeed_LimitsConfiguration for category Limits using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_FanSpeed_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanSpeed_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3005545907L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34257,11 +34573,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_MidXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_MidXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_MidXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_MidXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1939536665L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34299,11 +34616,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_MidXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_MidXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_MidXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_MidXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2047576843L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34341,11 +34659,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_SuppXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_SuppXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_SuppXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_SuppXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4068750060L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34383,11 +34702,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_SuppXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_SuppXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_SuppXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_SuppXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3372391592L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34425,11 +34745,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_TopXMinusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_TopXMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_TopXMinusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_TopXMinusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1380680518L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34467,11 +34788,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_TopXPlusTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_TopXPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_TopXPlusTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_TopXPlusTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 528965951L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34509,11 +34831,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_ValvePosn_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_ValvePosn_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_ValvePosn_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_ValvePosn_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3441004084L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34551,11 +34874,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_W2Q1Temp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_W2Q1Temp_LimitsConfiguration for category Limits using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_W2Q1Temp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_W2Q1Temp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1503198003L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34593,11 +34917,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_W4Q3Temp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_W4Q3Temp_LimitsConfiguration for category Limits using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_W4Q3Temp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_W4Q3Temp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 616257834L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34635,11 +34960,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DeviceConfiguration using level 2 for category Device-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DeviceConfiguration for category Device using level 2-->
   <!--===========================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UtMaq20_DeviceConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DeviceConfiguration for category Device</Description>
     <!--CCS: Dictionary_Checksum: 402201903L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34663,11 +34989,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DevicesConfiguration using level 2 for category Devices-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DevicesConfiguration for category Devices using level 2-->
   <!--=============================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UtMaq20_DevicesConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UtMaq20_DevicesConfiguration for category Devices</Description>
     <!--CCS: Dictionary_Checksum: 1898674034L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34684,11 +35011,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtilConfiguration using level 2 for category Util-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UtilConfiguration for category Util using level 2-->
   <!--===============================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_UtilConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UtilConfiguration for category Util</Description>
     <!--CCS: Dictionary_Checksum: 683618831L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34705,11 +35033,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCFan_PicConfiguration using level 2 for category Pic-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCFan_PicConfiguration for category Pic using level 2-->
   <!--====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPCFan_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCFan_PicConfiguration for category Pic</Description>
     <!--CCS: Dictionary_Checksum: 2328583603L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34817,11 +35146,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCHtrs_VpcConfiguration using level 2 for category Vpc-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCHtrs_VpcConfiguration for category Vpc using level 2-->
   <!--=====================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPCHtrs_VpcConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPCHtrs_VpcConfiguration for category Vpc</Description>
     <!--CCS: Dictionary_Checksum: 1596450467L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34845,11 +35175,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaPressFilt_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaPressFilt_LimitsConfiguration for category Limits using level 2-->
   <!--======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_DeltaPressFilt_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaPressFilt_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1977520886L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34887,11 +35218,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaPressTotal_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaPressTotal_LimitsConfiguration for category Limits using level 2-->
   <!--=======================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_DeltaPressTotal_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaPressTotal_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3016154668L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34929,11 +35261,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaTempAct_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaTempAct_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_DeltaTempAct_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_DeltaTempAct_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3449774087L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -34971,11 +35304,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanRunTime_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanRunTime_LimitsConfiguration for category Limits using level 2-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_FanRunTime_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanRunTime_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1907534186L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35013,11 +35347,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanSpeed_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanSpeed_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_FanSpeed_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanSpeed_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 366735869L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35055,11 +35390,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_HtrCurrent_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_HtrCurrent_LimitsConfiguration for category Limits using level 2-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_HtrCurrent_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_HtrCurrent_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3802134491L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35097,11 +35433,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_Humidity_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_Humidity_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_Humidity_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_Humidity_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1390661082L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35139,11 +35476,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_PreFiltPress_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_PreFiltPress_LimitsConfiguration for category Limits using level 2-->
   <!--====================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_PreFiltPress_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_PreFiltPress_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 60094736L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35181,11 +35519,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_RetnAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_RetnAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_RetnAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_RetnAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3348506787L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35223,11 +35562,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_RetnPress_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_RetnPress_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_RetnPress_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_RetnPress_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 1836915771L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35265,11 +35605,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyAirTemp_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyAirTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_SplyAirTemp_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyAirTemp_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 4228979543L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35307,11 +35648,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyAirVel_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyAirVel_LimitsConfiguration for category Limits using level 2-->
   <!--==================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_SplyAirVel_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyAirVel_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 2008191154L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35349,11 +35691,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyPress_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyPress_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_SplyPress_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_SplyPress_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 501483837L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
@@ -35391,11 +35734,12 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_ValvePosn_LimitsConfiguration using level 2 for category Limits-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_ValvePosn_LimitsConfiguration for category Limits using level 2-->
   <!--=================================================================================================================================================-->
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_ValvePosn_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_ValvePosn_LimitsConfiguration for category Limits</Description>
     <!--CCS: Dictionary_Checksum: 3531267521L -->
     <item>
       <EFDB_Name>version</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -5,6 +5,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_BFR</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_quadbox_BFR</Description>
     <!--CCS: Dictionary_Checksum: 3156915507L -->
     <item>
       <EFDB_Name>clean_5_24V_I</EFDB_Name>
@@ -82,6 +83,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_24VC</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_quadbox_PDU_24VC</Description>
     <!--CCS: Dictionary_Checksum: 3981611484L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
@@ -264,6 +266,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_24VD</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_quadbox_PDU_24VD</Description>
     <!--CCS: Dictionary_Checksum: 1245527488L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
@@ -404,6 +407,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_48V</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_quadbox_PDU_48V</Description>
     <!--CCS: Dictionary_Checksum: 202661958L -->
     <item>
       <EFDB_Name>board_T</EFDB_Name>
@@ -516,6 +520,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_PDU_5V</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_quadbox_PDU_5V</Description>
     <!--CCS: Dictionary_Checksum: 764407982L -->
     <item>
       <EFDB_Name>otm_0_A_I</EFDB_Name>
@@ -691,6 +696,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_quadbox_REB_Bulk_PS</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_quadbox_REB_Bulk_PS</Description>
     <!--CCS: Dictionary_Checksum: 1457295069L -->
     <item>
       <EFDB_Name>rebbulkps_0_2_I</EFDB_Name>
@@ -789,6 +795,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Reb</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_rebpower_Reb</Description>
     <!--CCS: Dictionary_Checksum: 72957452L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
@@ -1123,6 +1130,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_RebTotalPower</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_rebpower_RebTotalPower</Description>
     <!--CCS: Dictionary_Checksum: 4179052400L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
@@ -1137,6 +1145,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Rebps</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_rebpower_Rebps</Description>
     <!--CCS: Dictionary_Checksum: 187346552L -->
     <!--CCSMETA: Array boardTemp0 indexed by location-->
     <item>
@@ -1215,6 +1224,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cold1</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cold1</Description>
     <!--CCS: Dictionary_Checksum: 851925515L -->
     <item>
       <EFDB_Name>returnTmp</EFDB_Name>
@@ -1236,6 +1246,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cold2</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cold2</Description>
     <!--CCS: Dictionary_Checksum: 218899614L -->
     <item>
       <EFDB_Name>returnTmp</EFDB_Name>
@@ -1257,6 +1268,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo1</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cryo1</Description>
     <!--CCS: Dictionary_Checksum: 581887221L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
@@ -1327,6 +1339,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo2</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cryo2</Description>
     <!--CCS: Dictionary_Checksum: 3041049894L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
@@ -1397,6 +1410,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo3</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cryo3</Description>
     <!--CCS: Dictionary_Checksum: 1899394984L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
@@ -1467,6 +1481,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo4</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cryo4</Description>
     <!--CCS: Dictionary_Checksum: 1105922241L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
@@ -1537,6 +1552,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo5</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cryo5</Description>
     <!--CCS: Dictionary_Checksum: 2241839695L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
@@ -1607,6 +1623,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_hex_Cryo6</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_hex_Cryo6</Description>
     <!--CCS: Dictionary_Checksum: 309566364L -->
     <item>
       <EFDB_Name>c3ExitTmp</EFDB_Name>
@@ -1677,6 +1694,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo1</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_refrig_Cryo1</Description>
     <!--CCS: Dictionary_Checksum: 869246017L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -1803,6 +1821,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo2</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_refrig_Cryo2</Description>
     <!--CCS: Dictionary_Checksum: 2572091680L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -1929,6 +1948,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo3</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_refrig_Cryo3</Description>
     <!--CCS: Dictionary_Checksum: 773606185L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -2069,6 +2089,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo4</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_refrig_Cryo4</Description>
     <!--CCS: Dictionary_Checksum: 390024611L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -2195,6 +2216,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo5</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_refrig_Cryo5</Description>
     <!--CCS: Dictionary_Checksum: 2308100150L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -2335,6 +2357,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo6</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_refrig_Cryo6</Description>
     <!--CCS: Dictionary_Checksum: 3686822941L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
@@ -2461,6 +2484,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_Cip</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_vacuum_Cip</Description>
     <!--CCS: Dictionary_Checksum: 402968257L -->
     <!--CCSMETA: Array cryo_I indexed by location-->
     <item>
@@ -2507,6 +2531,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_Cryo</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_vacuum_Cryo</Description>
     <!--CCS: Dictionary_Checksum: 3213658240L -->
     <item>
       <EFDB_Name>airPressure</EFDB_Name>
@@ -2647,6 +2672,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_HX</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_vacuum_HX</Description>
     <!--CCS: Dictionary_Checksum: 1861318501L -->
     <item>
       <EFDB_Name>airPressure</EFDB_Name>
@@ -2787,6 +2813,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_Hip</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_vacuum_Hip</Description>
     <!--CCS: Dictionary_Checksum: 2046798497L -->
     <!--CCSMETA: Array hx_I indexed by location-->
     <item>
@@ -2833,6 +2860,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_vacuum_Inst</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_vacuum_Inst</Description>
     <!--CCS: Dictionary_Checksum: 2581776088L -->
     <item>
       <EFDB_Name>cryoFlineValveState</EFDB_Name>
@@ -2905,11 +2933,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_daq_monitor_Reb_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_daq_monitor_Reb_Trending for category Trending using level 1-->
   <!--=======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_daq_monitor_Reb_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_daq_monitor_Reb_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3441781493L -->
     <!--CCSMETA: Array driver_errors indexed by location-->
     <item>
@@ -3332,6 +3361,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_daq_monitor_Store</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_daq_monitor_Store</Description>
     <!--CCS: Dictionary_Checksum: 1179110280L -->
     <item>
       <EFDB_Name>capacity</EFDB_Name>
@@ -3355,11 +3385,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_daq_monitor_Sum_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_daq_monitor_Sum_Trending for category Trending using level 1-->
   <!--=======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_daq_monitor_Sum_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_daq_monitor_Sum_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2119011164L -->
     <item>
       <EFDB_Name>driver_errors</EFDB_Name>
@@ -3521,6 +3552,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_Ccd</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_focal_plane_Ccd</Description>
     <!--CCS: Dictionary_Checksum: 165558076L -->
     <!--CCSMETA: Array gDV indexed by location-->
     <item>
@@ -3583,6 +3615,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_Reb</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_focal_plane_Reb</Description>
     <!--CCS: Dictionary_Checksum: 4128750188L -->
     <!--CCSMETA: Array anaI indexed by location-->
     <item>
@@ -4005,6 +4038,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_RebTotalPower</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_focal_plane_RebTotalPower</Description>
     <!--CCS: Dictionary_Checksum: 3939455426L -->
     <item>
       <EFDB_Name>rebTotalPower</EFDB_Name>
@@ -4019,6 +4053,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_RebsAverageTemp6</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_focal_plane_RebsAverageTemp6</Description>
     <!--CCS: Dictionary_Checksum: 3374772983L -->
     <item>
       <EFDB_Name>rebsAverageTemp6</EFDB_Name>
@@ -4033,6 +4068,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_focal_plane_Segment</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_focal_plane_Segment</Description>
     <!--CCS: Dictionary_Checksum: 3706039522L -->
     <!--CCSMETA: Array i indexed by location-->
     <item>
@@ -4055,6 +4091,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CLP_RTD_03</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CLP_RTD_03</Description>
     <!--CCS: Dictionary_Checksum: 3595379108L -->
     <item>
       <EFDB_Name>clp_RTD_03</EFDB_Name>
@@ -4069,6 +4106,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CLP_RTD_05</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CLP_RTD_05</Description>
     <!--CCS: Dictionary_Checksum: 420349417L -->
     <item>
       <EFDB_Name>clp_RTD_05</EFDB_Name>
@@ -4083,6 +4121,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CLP_RTD_50</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CLP_RTD_50</Description>
     <!--CCS: Dictionary_Checksum: 3172987535L -->
     <item>
       <EFDB_Name>clp_RTD_50</EFDB_Name>
@@ -4097,6 +4136,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CLP_RTD_55</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CLP_RTD_55</Description>
     <!--CCS: Dictionary_Checksum: 4165322692L -->
     <item>
       <EFDB_Name>clp_RTD_55</EFDB_Name>
@@ -4111,6 +4151,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CYP_RTD_12</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CYP_RTD_12</Description>
     <!--CCS: Dictionary_Checksum: 2865548629L -->
     <item>
       <EFDB_Name>cyp_RTD_12</EFDB_Name>
@@ -4125,6 +4166,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CYP_RTD_14</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CYP_RTD_14</Description>
     <!--CCS: Dictionary_Checksum: 1703930136L -->
     <item>
       <EFDB_Name>cyp_RTD_14</EFDB_Name>
@@ -4139,6 +4181,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CYP_RTD_31</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CYP_RTD_31</Description>
     <!--CCS: Dictionary_Checksum: 659289684L -->
     <item>
       <EFDB_Name>cyp_RTD_31</EFDB_Name>
@@ -4153,6 +4196,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_mpm_CYP_RTD_43</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_mpm_CYP_RTD_43</Description>
     <!--CCS: Dictionary_Checksum: 846200954L -->
     <item>
       <EFDB_Name>cyp_RTD_43</EFDB_Name>
@@ -4162,11 +4206,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_AutochangerTrucks_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_AutochangerTrucks_Trending for category Trending using level 2-->
   <!--=========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Autochanger_AutochangerTrucks_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_AutochangerTrucks_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2202000250L -->
     <item>
       <EFDB_Name>actruckxminus_handoffInError</EFDB_Name>
@@ -4316,11 +4361,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Latches_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Latches_Trending for category Trending using level 2-->
   <!--===============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Autochanger_Latches_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_Latches_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2238573684L -->
     <item>
       <EFDB_Name>filterId</EFDB_Name>
@@ -4463,11 +4509,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_OnlineClamps_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_OnlineClamps_Trending for category Trending using level 2-->
   <!--====================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Autochanger_OnlineClamps_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_OnlineClamps_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1280106459L -->
     <item>
       <EFDB_Name>lockStatus</EFDB_Name>
@@ -4685,6 +4732,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Autochanger_Temperatures</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_Temperatures</Description>
     <!--CCS: Dictionary_Checksum: 1800035090L -->
     <item>
       <EFDB_Name>tempCellXminus</EFDB_Name>
@@ -4743,11 +4791,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcSensorsGateway_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcSensorsGateway_Trending for category Trending using level 2-->
   <!--====================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_AcSensorsGateway_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_AcSensorsGateway_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 454556600L -->
     <item>
       <EFDB_Name>acAF0b</EFDB_Name>
@@ -5653,11 +5702,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXminusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXminusController_Trending for category Trending using level 2-->
   <!--===========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_AcTruckXminusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXminusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1622663564L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -5772,11 +5822,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXplusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXplusController_Trending for category Trending using level 2-->
   <!--==========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_AcTruckXplusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_AcTruckXplusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 313474385L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -5891,11 +5942,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Accelerobf_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Accelerobf_Trending for category Trending using level 2-->
   <!--==============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Accelerobf_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Accelerobf_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2319033051L -->
     <item>
       <EFDB_Name>accelerationX</EFDB_Name>
@@ -6003,11 +6055,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Ai814_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Ai814_Trending for category Trending using level 2-->
   <!--=========================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Ai814_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Ai814_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3931002535L -->
     <item>
       <EFDB_Name>errorHistoryNB</EFDB_Name>
@@ -6045,11 +6098,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending for category Trending using level 2-->
   <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 153145976L -->
     <item>
       <EFDB_Name>acAF0b</EFDB_Name>
@@ -6955,11 +7009,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_CarouselController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_CarouselController_Trending for category Trending using level 2-->
   <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_CarouselController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_CarouselController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1196028887L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7074,11 +7129,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXminusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXminusController_Trending for category Trending using level 2-->
   <!--=========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_ClampXminusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXminusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3247584423L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7193,11 +7249,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXplusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXplusController_Trending for category Trending using level 2-->
   <!--========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_ClampXplusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_ClampXplusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3610149437L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7312,11 +7369,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Hyttc580_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Hyttc580_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Hyttc580_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Hyttc580_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 4130876379L -->
     <item>
       <EFDB_Name>pdo1</EFDB_Name>
@@ -7340,11 +7398,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXminusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXminusController_Trending for category Trending using level 2-->
   <!--=========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_LatchXminusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXminusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1151376015L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7459,11 +7518,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXplusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXplusController_Trending for category Trending using level 2-->
   <!--========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_LatchXplusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_LatchXplusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2159047279L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7578,11 +7638,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXminusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXminusController_Trending for category Trending using level 2-->
   <!--===============================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineClampXminusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXminusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2363028241L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7697,11 +7758,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXplusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXplusController_Trending for category Trending using level 2-->
   <!--==============================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineClampXplusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampXplusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3589486380L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7816,11 +7878,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampYminusController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampYminusController_Trending for category Trending using level 2-->
   <!--===============================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineClampYminusController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineClampYminusController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1120629728L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -7935,11 +7998,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineStrainGauge_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineStrainGauge_Trending for category Trending using level 2-->
   <!--=====================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_OnlineStrainGauge_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_OnlineStrainGauge_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2171501237L -->
     <item>
       <EFDB_Name>errorHistoryNB</EFDB_Name>
@@ -7977,11 +8041,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ProximitySensorsDevice_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_ProximitySensorsDevice_Trending for category Trending using level 2-->
   <!--==========================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_ProximitySensorsDevice_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_ProximitySensorsDevice_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 217235361L -->
     <item>
       <EFDB_Name>errorHistoryNB</EFDB_Name>
@@ -8019,11 +8084,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Pt100_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_Pt100_Trending for category Trending using level 2-->
   <!--=========================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Pt100_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Pt100_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 510586873L -->
     <item>
       <EFDB_Name>errorHistoryNB</EFDB_Name>
@@ -8061,11 +8127,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice1_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice1_Trending for category Trending using level 2-->
   <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_TempSensorsDevice1_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice1_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1148841563L -->
     <item>
       <EFDB_Name>errorHistoryNB</EFDB_Name>
@@ -8103,11 +8170,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice2_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice2_Trending for category Trending using level 2-->
   <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_TempSensorsDevice2_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_TempSensorsDevice2_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 1971328537L -->
     <item>
       <EFDB_Name>errorHistoryNB</EFDB_Name>
@@ -8145,11 +8213,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_CarrierController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_CarrierController_Trending for category Trending using level 2-->
   <!--=====================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus1_CarrierController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus1_CarrierController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3913831446L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -8264,11 +8333,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_HooksController_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_HooksController_Trending for category Trending using level 2-->
   <!--===================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus1_HooksController_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus1_HooksController_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 474905309L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
@@ -8383,11 +8453,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending for category Trending using level 2-->
   <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3747844937L -->
     <item>
       <EFDB_Name>acAF0b</EFDB_Name>
@@ -9293,11 +9364,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket1_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket1_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket1_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket1_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2638884263L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
@@ -9440,11 +9512,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket2_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket2_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket2_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket2_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3796116839L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
@@ -9587,11 +9660,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket3_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket3_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket3_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket3_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2121195288L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
@@ -9734,11 +9808,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket4_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket4_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket4_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket4_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 475542759L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
@@ -9881,11 +9956,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket5_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket5_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket5_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket5_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2155007640L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
@@ -10028,11 +10104,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Trending for category Trending using level 2-->
   <!--====================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2209172173L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
@@ -10105,11 +10182,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending for category Trending using level 2-->
   <!--================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Autochanger_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 79989557L -->
     <item>
       <EFDB_Name>autochangertrucks_ALIGN_FOLLOWER</EFDB_Name>
@@ -10308,11 +10386,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Carousel_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Carousel_Trending for category Trending using level 2-->
   <!--=============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Carousel_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Duration_Carousel_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 932454045L -->
     <item>
       <EFDB_Name>rotate_CAROUSEL_TO_ABSOLUTE_POSITION</EFDB_Name>
@@ -10539,11 +10618,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Loader_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Loader_Trending for category Trending using level 2-->
   <!--===========================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Loader_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Duration_Loader_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2099256131L -->
     <item>
       <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_ABSOLUTEPOSITION</EFDB_Name>
@@ -10602,11 +10682,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Trending for category Trending using level 2-->
   <!--====================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Duration_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3648583864L -->
     <item>
       <EFDB_Name>sETFILTER</EFDB_Name>
@@ -10616,11 +10697,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Fcs_Mcm_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Fcs_Mcm_Trending for category Trending using level 2-->
   <!--===================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Fcs_Mcm_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Fcs_Mcm_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3461632716L -->
     <item>
       <EFDB_Name>autochanger_trucks_location</EFDB_Name>
@@ -10672,11 +10754,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Carrier_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Carrier_Trending for category Trending using level 2-->
   <!--==========================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Loader_Carrier_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Loader_Carrier_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3643041460L -->
     <item>
       <EFDB_Name>atEngaged</EFDB_Name>
@@ -10714,11 +10797,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Hooks_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Hooks_Trending for category Trending using level 2-->
   <!--========================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Loader_Hooks_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Loader_Hooks_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 3052938012L -->
     <item>
       <EFDB_Name>allHooksInStateCLOSED</EFDB_Name>
@@ -10903,11 +10987,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Trending using level 2 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Trending for category Trending using level 2-->
   <!--===========================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2294723773L -->
     <item>
       <EFDB_Name>canbus0</EFDB_Name>
@@ -10924,11 +11009,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_shutter_Trending using level 0 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_shutter_Trending for category Trending using level 0-->
   <!--===============================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_shutter_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_shutter_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 996357223L -->
     <item>
       <EFDB_Name>shutterstatus_axstatus_MINUSX_actPos</EFDB_Name>
@@ -11195,6 +11281,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_chiller_Chiller</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_chiller_Chiller</Description>
     <!--CCS: Dictionary_Checksum: 2045677159L -->
     <item>
       <EFDB_Name>cascadeSetPoint</EFDB_Name>
@@ -11351,11 +11438,12 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_chiller_FParam_Trending using level 1 for category Trending-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_chiller_FParam_Trending for category Trending using level 1-->
   <!--======================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_chiller_FParam_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_chiller_FParam_Trending for category Trending</Description>
     <!--CCS: Dictionary_Checksum: 2274492981L -->
     <item>
       <EFDB_Name>bubblev_TIME</EFDB_Name>
@@ -11545,6 +11633,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_chiller_Maq20</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_chiller_Maq20</Description>
     <!--CCS: Dictionary_Checksum: 1371898684L -->
     <item>
       <EFDB_Name>ambientTemp</EFDB_Name>
@@ -11783,6 +11872,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_thermal_Cold_Temp</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_thermal_Cold_Temp</Description>
     <!--CCS: Dictionary_Checksum: 2724887452L -->
     <item>
       <EFDB_Name>avgColdTemp</EFDB_Name>
@@ -11797,6 +11887,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_thermal_Cryo_Temp</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_thermal_Cryo_Temp</Description>
     <!--CCS: Dictionary_Checksum: 2041243352L -->
     <item>
       <EFDB_Name>avgCryoTemp</EFDB_Name>
@@ -11811,6 +11902,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_thermal_Rtd</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_thermal_Rtd</Description>
     <!--CCS: Dictionary_Checksum: 3847031717L -->
     <!--CCSMETA: Array cold_TempCLP indexed by location-->
     <item>
@@ -11865,6 +11957,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_thermal_Trim</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_thermal_Trim</Description>
     <!--CCS: Dictionary_Checksum: 2641718204L -->
     <item>
       <EFDB_Name>location</EFDB_Name>
@@ -11927,6 +12020,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_thermal_Trim_Htrs</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_thermal_Trim_Htrs</Description>
     <!--CCS: Dictionary_Checksum: 1982894119L -->
     <item>
       <EFDB_Name>coldtotal_P</EFDB_Name>
@@ -11983,6 +12077,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_Body</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_utiltrunk_Body</Description>
     <!--CCS: Dictionary_Checksum: 2891718329L -->
     <item>
       <EFDB_Name>ambAirtemp</EFDB_Name>
@@ -12207,6 +12302,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_MPC</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_utiltrunk_MPC</Description>
     <!--CCS: Dictionary_Checksum: 3295711856L -->
     <item>
       <EFDB_Name>avgAirtempOut</EFDB_Name>
@@ -12305,6 +12401,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_UT</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_utiltrunk_UT</Description>
     <!--CCS: Dictionary_Checksum: 987895038L -->
     <item>
       <EFDB_Name>averageTemp</EFDB_Name>
@@ -12452,6 +12549,7 @@
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_VPC</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_utiltrunk_VPC</Description>
     <!--CCS: Dictionary_Checksum: 1724543484L -->
     <item>
       <EFDB_Name>deltaPressFilt</EFDB_Name>

--- a/tests/test_TopicDescription.py
+++ b/tests/test_TopicDescription.py
@@ -9,12 +9,6 @@ import pytest
 
 def check_for_issues(csc: str, topic: str) -> str:
     match f"{csc}-{topic}":
-        case "ATCamera-Commands" | "ATCamera-Telemetry" | "ATCamera-Events":
-            return "DM-43793"
-        case "CCCamera-Commands" | "CCCamera-Telemetry" | "CCCamera-Events":
-            return "DM-43804"
-        case "MTCamera-Telemetry" | "MTCamera-Commands" | "MTCamera-Events":
-            return "DM-43816"
         case "MTMount-Events" | "MTMount-Telemetry":
             return "DM-43821"
         case _:


### PR DESCRIPTION
Descriptions have been added to all camera SAL topics.
The exceptions for the camera in  test_TopicDescription.py have been removed.
Many of these descriptions are auto-generated, so the content is what it is.
A few events have been marked with ??? indicating that I am not sure what they are for. I think these events are probably never issued and I will look into removing them (under a separate JIRA)