### PR TITLE
Filter exchange system changes for Cycle 40

### DIFF
--- a/doc/news/interface_changes/CAP-1064.cccamera.rst
+++ b/doc/news/interface_changes/CAP-1064.cccamera.rst
@@ -1,0 +1,1 @@
+Fix filter changer descriptions and states

--- a/doc/news/interface_changes/CAP-1064.mtcamera.rst
+++ b/doc/news/interface_changes/CAP-1064.mtcamera.rst
@@ -1,0 +1,1 @@
+Fix filter changer descriptions and states

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -433,7 +433,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>UNLOADING,LOADING,LOADED,UNLOADED,ROTATING</Enumeration>
+      <Enumeration>UNLOADING,LOADING,LOADED,UNLOADED,ROTATING,NOFILTER,UNKNOWN</Enumeration>
     </item>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -35782,7 +35782,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>LOW_POWER,HIGH_POWER</Enumeration>
+      <Enumeration>LOW_POWER,REGULAR</Enumeration>
     </item>
   </SALEvent>
 </SALEventSet>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -153,10 +153,10 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_startSetFilter</EFDB_Topic>
-    <Description>Event generated at the begining of a setFilter operation</Description>
+    <Description>Event generated at the beginning of a setFilter operation</Description>
     <item>
       <EFDB_Name>filterName</EFDB_Name>
-      <Description>The name of the filter being installed (e.g. U-001)</Description>
+      <Description>The name of the filter being installed (e.g. u_24)</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>
@@ -668,7 +668,7 @@
     <Description>Event issued once the new filter is in its final position</Description>
     <item>
       <EFDB_Name>filterName</EFDB_Name>
-      <Description>The name of the filter being installed (e.g. U-001)</Description>
+      <Description>The name of the filter being installed (e.g. u_24)</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>
@@ -685,7 +685,7 @@
     </item>
     <item>
       <EFDB_Name>filterSlot</EFDB_Name>
-      <Description>The slot which the filter is in (ComCam) or came from (Main Camera)</Description>
+      <Description>The slot which the filter is in (ComCam) or carousel socket it came from (Main Camera).</Description>
       <IDL_Type>int</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>unitless</Units>
@@ -693,7 +693,7 @@
     </item>
     <item>
       <EFDB_Name>filterPosition</EFDB_Name>
-      <Description>For ComCam this is the measured linear encoder position once the filter in in place. For Main Camera it may be unused.</Description>
+      <Description>For ComCam this is the measured linear encoder position once the filter in in place. For then Main Camera it is the value of the proximity sensor positioned at online.</Description>
       <IDL_Type>double</IDL_Type>
       <IDL_Size>1</IDL_Size>
       <Units>mm</Units>
@@ -735,10 +735,10 @@
   <SALEvent>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_availableFilters</EFDB_Topic>
-    <Description>Event listing the filters available to be selected</Description>
+    <Description>Event listing the filters available to be selected, including NONE which corresponds to no filter.</Description>
     <item>
       <EFDB_Name>filterNames</EFDB_Name>
-      <Description>A list of names of available filters (comma delimited, U-001,G-004,R-010,Z-012,Y-014, NONE), in the same order as the list of filter types.</Description>
+      <Description>A list of names of available filters (e.g. u_24,g_6,ef_43,NONE), in the same order as the list of filter types (comma delimited).</Description>
       <IDL_Type>string</IDL_Type>
       <IDL_Size>256</IDL_Size>
       <Units>unitless</Units>
@@ -768,7 +768,7 @@
     </item>
     <item>
       <EFDB_Name>maxSlowChangeTime</EFDB_Name>
-      <Description>The maximum estimated time (in seconds) for a setFilter command, when in degraded (slow) mode (per filter).</Description>
+      <Description>The maximum estimated time (in seconds) for a setFilter command, when in degraded mode (per filter).</Description>
       <IDL_Type>double</IDL_Type>
       <Units>second</Units>
       <Count>6</Count>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -433,7 +433,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>UNLOADING,LOADING,LOADED,UNLOADED,ROTATING</Enumeration>
+      <Enumeration>UNLOADING,LOADING,LOADED,UNLOADED,ROTATING,NOFILTER,UNKNOWN</Enumeration>
     </item>
     <item>
       <EFDB_Name>timestampTransition</EFDB_Name>

--- a/tests/test_Units.py
+++ b/tests/test_Units.py
@@ -3,6 +3,7 @@
 import pathlib
 import xml.etree.ElementTree as et
 
+import astropy.constants
 import astropy.units
 import lsst.ts.xml as ts_xml
 import pytest
@@ -17,7 +18,8 @@ rpm = astropy.units.def_unit("rpm", (astropy.units.cycle * 60) / astropy.units.s
 gpm = astropy.units.def_unit(
     "gallon/min", (astropy.units.imperial.gallon * 60) / astropy.units.s
 )
-astropy.units.add_enabled_units([rpm, gpm])
+g0 = astropy.units.def_unit("g0", astropy.constants.g0)
+astropy.units.add_enabled_units([rpm, g0, gpm])
 
 
 def check_for_issues(csc: str, topic: str) -> str:


### PR DESCRIPTION
PR addressing changes required by the filter exchange system before Cycle 40 and described at
https://rubinobs.atlassian.net/browse/CAP-1064
including the addition of the new `g0` unit definition
https://rubinobs.atlassian.net/browse/CAP-1067