### PR TITLE
Update Filter exchange system telemetry

### DIFF
--- a/doc/news/interface_changes/CAP-1064.mtcamera.rst
+++ b/doc/news/interface_changes/CAP-1064.mtcamera.rst
@@ -1,1 +1,1 @@
-Fix filter changer descriptions and states
+Fix filter changer descriptions and states and update the telemetry

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -4727,67 +4727,82 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Temperatures using level 2-->
-  <!--=====================================================================================================-->
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Temperatures_Trending for category Trending using level 2-->
+  <!--====================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Autochanger_Temperatures</EFDB_Topic>
-    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_Temperatures</Description>
-    <!--CCS: Dictionary_Checksum: 1800035090L -->
+    <EFDB_Topic>MTCamera_fcs_Autochanger_Temperatures_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_Temperatures_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 4263283835L -->
     <item>
-      <EFDB_Name>tempCellXminus</EFDB_Name>
-      <Description>autochanger tempCellXminus on Seneca2</Description>
+      <EFDB_Name>cellXMinus</EFDB_Name>
+      <Description>Temperature of AC Cell Xminus</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempClampMotorXminus</EFDB_Name>
-      <Description>autochanger tempClampMotorXminus on Seneca2</Description>
+      <EFDB_Name>clampMotorXMinus</EFDB_Name>
+      <Description>Temperature of AC Clamp Motor Xminus</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempClampMotorXplus</EFDB_Name>
-      <Description>autochanger tempClampMotorXplus on Seneca1</Description>
+      <EFDB_Name>clampMotorXPlus</EFDB_Name>
+      <Description>Temperature of AC Clamp Motor Xplus</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempClampMotorYminus</EFDB_Name>
-      <Description>autochanger tempClampMotorYminus on Seneca1</Description>
+      <EFDB_Name>clampMotorYMinus</EFDB_Name>
+      <Description>Temperature of AC Clamp Motor Yminus</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempFrontBox</EFDB_Name>
-      <Description>autochanger tempFrontBox on Seneca2</Description>
+      <EFDB_Name>frontBox</EFDB_Name>
+      <Description>Temperature of AC Front Box</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempLinearRailMotorXminus</EFDB_Name>
-      <Description>autochanger tempLinearRailMotorXminus on Seneca1</Description>
+      <EFDB_Name>linearRailMotorXMinus</EFDB_Name>
+      <Description>Temperature of AC Linear rail Motor Xminus</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempLinearRailMotorXplus</EFDB_Name>
-      <Description>autochanger tempLinearRailMotorXplus on Seneca1</Description>
+      <EFDB_Name>linearRailMotorXPlus</EFDB_Name>
+      <Description>Temperature of AC Linear rail Motor Xplus</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>tempRearBox</EFDB_Name>
-      <Description>autochanger tempRearBox on Seneca2</Description>
+      <EFDB_Name>rearBox</EFDB_Name>
+      <Description>Temperature of AC Rear Box</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Autochanger_Trending for category Trending using level 2-->
+  <!--=======================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Autochanger_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 2755050877L -->
+    <item>
+      <EFDB_Name>id</EFDB_Name>
+      <Description>Identifier of autochangerusing serialNB of plutoGateway device</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -4797,63 +4812,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_AcSensorsGateway_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_AcSensorsGateway_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 454556600L -->
-    <item>
-      <EFDB_Name>acAF0b</EFDB_Name>
-      <Description>Value of Digital Sensor acAF0b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF0s</EFDB_Name>
-      <Description>Value of Digital Sensor acAF0s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF1b</EFDB_Name>
-      <Description>Value of Digital Sensor acAF1b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF1s</EFDB_Name>
-      <Description>Value of Digital Sensor acAF1s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF3b</EFDB_Name>
-      <Description>Value of Digital Sensor acAF3b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF3s</EFDB_Name>
-      <Description>Value of Digital Sensor acAF3s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAP2b</EFDB_Name>
-      <Description>Value of Digital Sensor acAP2b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAP2s</EFDB_Name>
-      <Description>Value of Digital Sensor acAP2s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
+    <!--CCS: Dictionary_Checksum: 3464869995L -->
     <item>
       <EFDB_Name>carouselHoldingFilterSensor0</EFDB_Name>
       <Description>Value of Digital Sensor carouselHoldingFilterSensor0</Description>
@@ -4906,13 +4865,6 @@
     <item>
       <EFDB_Name>carousel_CF1_C</EFDB_Name>
       <Description>Value of Digital Sensor carousel_CF1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor clampedStatusSensor</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5030,20 +4982,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>forceSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor forceSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>forceSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor forceSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>handoffPositionSensorBXminus</EFDB_Name>
       <Description>Value of Digital Sensor handoffPositionSensorBXminus</Description>
       <IDL_Type>long</IDL_Type>
@@ -5086,104 +5024,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>keyEng</EFDB_Name>
-      <Description>Value of Digital Sensor keyEng</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyEngb</EFDB_Name>
-      <Description>Value of Digital Sensor keyEngb</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyLock</EFDB_Name>
-      <Description>Value of Digital Sensor keyLock</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyLockb</EFDB_Name>
-      <Description>Value of Digital Sensor keyLockb</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lps_0</EFDB_Name>
-      <Description>Value of Digital Sensor LPS_0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lps_1</EFDB_Name>
-      <Description>Value of Digital Sensor LPS_1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lrh_0</EFDB_Name>
-      <Description>Value of Digital Sensor LRH_0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lrh_1</EFDB_Name>
-      <Description>Value of Digital Sensor LRH_1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCarrierRelayStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCarrierRelayStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderChainPresenceSensor</EFDB_Name>
-      <Description>Value of Digital Sensor loaderChainPresenceSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor2</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor3</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor4</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>loaderConnectedSensor</EFDB_Name>
       <Description>Value of Digital Sensor loaderConnectedSensor</Description>
       <IDL_Type>long</IDL_Type>
@@ -5198,69 +5038,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderDefaultStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderDefaultStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderEngagedPositionSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderEngagedPositionSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderEngagedPositionSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderEngagedPositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterDistanceSensor</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterDistanceSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterGoodPositionStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterGoodPositionStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterPresenceSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterPresenceSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterPresenceSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterPresenceSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHandoffPositionSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHandoffPositionSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHandoffPositionSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHandoffPositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>loaderHoldingFilterSensor0</EFDB_Name>
       <Description>Value of Digital Sensor loaderHoldingFilterSensor0</Description>
       <IDL_Type>long</IDL_Type>
@@ -5270,83 +5047,6 @@
     <item>
       <EFDB_Name>loaderHoldingFilterSensor1</EFDB_Name>
       <Description>Value of Digital Sensor loaderHoldingFilterSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHooksRelayStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHooksRelayStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOnCameraSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOnCameraSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOnCameraSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOnCameraSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor2</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor3</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor4</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderStoragePositionSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderStoragePositionSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderStoragePositionSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderStoragePositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LFD</EFDB_Name>
-      <Description>Value of Digital Sensor loader_LFD</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LFS</EFDB_Name>
-      <Description>Value of Digital Sensor loader_LFS</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5639,13 +5339,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>overClampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor overClampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>presenceLoader</EFDB_Name>
       <Description>Value of Digital Sensor presenceLoader</Description>
       <IDL_Type>long</IDL_Type>
@@ -5683,20 +5376,6 @@
     <item>
       <EFDB_Name>standbyPositionSensorXplus</EFDB_Name>
       <Description>Value of Digital Sensor standbyPositionSensorXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unclampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor unclampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>underClampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor underClampedStatusSensor</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5948,26 +5627,26 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Accelerobf_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Accelerobf_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 2319033051L -->
+    <!--CCS: Dictionary_Checksum: 4017741849L -->
     <item>
       <EFDB_Name>accelerationX</EFDB_Name>
       <Description>Angular acceleration along the X axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>rpm/s</Units>
+      <Units>g0</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>accelerationY</EFDB_Name>
       <Description>Angular acceleration along the Y axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>rpm/s</Units>
+      <Units>g0</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>accelerationZ</EFDB_Name>
       <Description>Angular acceleration along the Z axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>rpm/s</Units>
+      <Units>g0</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -5981,21 +5660,21 @@
       <EFDB_Name>angularVelocityX</EFDB_Name>
       <Description>Angular velocity along the X axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>rpm</Units>
+      <Units>deg/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>angularVelocityY</EFDB_Name>
       <Description>Angular velocity along the Y axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>rpm</Units>
+      <Units>deg/s</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>angularVelocityZ</EFDB_Name>
       <Description>Angular velocity along the Z axis</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>rpm</Units>
+      <Units>deg/s</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -6030,7 +5709,7 @@
       <EFDB_Name>gravity</EFDB_Name>
       <Description>Camera body norm of the gravity vector</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>g0</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -6052,6 +5731,34 @@
       <Description>Name of the last error corresponding to lastErrorCode</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>normalizedAccelerationX</EFDB_Name>
+      <Description>Angular acceleration along the X axis in normalized (converted) units</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s^2</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>normalizedAccelerationY</EFDB_Name>
+      <Description>Angular acceleration along the Y axis in normalized (converted) units</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s^2</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>normalizedAccelerationZ</EFDB_Name>
+      <Description>Angular acceleration along the Z axis in normalized (converted) units</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s^2</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>normalizedGravity</EFDB_Name>
+      <Description>Camera body norm of the gravity vector in normalized (converted) units</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>m/s^2</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -6098,924 +5805,13 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending for category Trending using level 2-->
-  <!--======================================================================================================================================-->
-  <SALTelemetry>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending</EFDB_Topic>
-    <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_BrakeSystemGateway_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 153145976L -->
-    <item>
-      <EFDB_Name>acAF0b</EFDB_Name>
-      <Description>Value of Digital Sensor acAF0b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF0s</EFDB_Name>
-      <Description>Value of Digital Sensor acAF0s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF1b</EFDB_Name>
-      <Description>Value of Digital Sensor acAF1b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF1s</EFDB_Name>
-      <Description>Value of Digital Sensor acAF1s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF3b</EFDB_Name>
-      <Description>Value of Digital Sensor acAF3b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAF3s</EFDB_Name>
-      <Description>Value of Digital Sensor acAF3s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAP2b</EFDB_Name>
-      <Description>Value of Digital Sensor acAP2b</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>acAP2s</EFDB_Name>
-      <Description>Value of Digital Sensor acAP2s</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselHoldingFilterSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor carouselHoldingFilterSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselHoldingFilterSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor carouselHoldingFilterSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselStoppedAtStandby</EFDB_Name>
-      <Description>Value of Digital Sensor carouselStoppedAtStandby</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselStoppedAtStandbyC</EFDB_Name>
-      <Description>Value of Digital Sensor carouselStoppedAtStandbyC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF0</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF0_C</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF0_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF1</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF1_C</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>clampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor clampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorBLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorBLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorBLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorBLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringKey</EFDB_Name>
-      <Description>Value of Digital Sensor engineeringKey</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_C</EFDB_Name>
-      <Description>Value of Digital Sensor engineeringKey_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorBLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorBLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorBLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorBLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor2</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor3</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor4</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor5</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor5</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>forceSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor forceSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>forceSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor forceSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorBXminus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorBXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorBXplus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorBXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorXminus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorXplus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inclinometerXminus</EFDB_Name>
-      <Description>Value of Digital Sensor inclinometerXminus</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inclinometerXplus</EFDB_Name>
-      <Description>Value of Digital Sensor inclinometerXplus</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyEng</EFDB_Name>
-      <Description>Value of Digital Sensor keyEng</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyEngb</EFDB_Name>
-      <Description>Value of Digital Sensor keyEngb</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyLock</EFDB_Name>
-      <Description>Value of Digital Sensor keyLock</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>keyLockb</EFDB_Name>
-      <Description>Value of Digital Sensor keyLockb</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lps_0</EFDB_Name>
-      <Description>Value of Digital Sensor LPS_0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lps_1</EFDB_Name>
-      <Description>Value of Digital Sensor LPS_1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lrh_0</EFDB_Name>
-      <Description>Value of Digital Sensor LRH_0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lrh_1</EFDB_Name>
-      <Description>Value of Digital Sensor LRH_1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCarrierRelayStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCarrierRelayStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderChainPresenceSensor</EFDB_Name>
-      <Description>Value of Digital Sensor loaderChainPresenceSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor2</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor3</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderCloseSensor4</EFDB_Name>
-      <Description>Value of Digital Sensor loaderCloseSensor4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderConnectedSensor</EFDB_Name>
-      <Description>Value of Digital Sensor loaderConnectedSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderConnectedSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor loaderConnectedSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderDefaultStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderDefaultStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderEngagedPositionSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderEngagedPositionSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderEngagedPositionSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderEngagedPositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterDistanceSensor</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterDistanceSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterGoodPositionStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterGoodPositionStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterPresenceSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterPresenceSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderFilterPresenceSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderFilterPresenceSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHandoffPositionSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHandoffPositionSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHandoffPositionSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHandoffPositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHoldingFilterSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHoldingFilterSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHoldingFilterSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHoldingFilterSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHooksRelayStatus</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHooksRelayStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOnCameraSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOnCameraSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOnCameraSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOnCameraSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor2</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor3</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderOpenSensor4</EFDB_Name>
-      <Description>Value of Digital Sensor loaderOpenSensor4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderStoragePositionSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderStoragePositionSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderStoragePositionSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderStoragePositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LFD</EFDB_Name>
-      <Description>Value of Digital Sensor loader_LFD</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loader_LFS</EFDB_Name>
-      <Description>Value of Digital Sensor loader_LFS</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockOut</EFDB_Name>
-      <Description>Value of Digital Sensor lockOut</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockOutShunt</EFDB_Name>
-      <Description>Value of Digital Sensor lockOutShunt</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_C</EFDB_Name>
-      <Description>Value of Digital Sensor lockOut_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmLatchesStatus</EFDB_Name>
-      <Description>Value of Digital Sensor lpmLatchesStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmLinearRail1Status</EFDB_Name>
-      <Description>Value of Digital Sensor lpmLinearRail1Status</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmLinearRail2Status</EFDB_Name>
-      <Description>Value of Digital Sensor lpmLinearRail2Status</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmOnlineClampsStatus</EFDB_Name>
-      <Description>Value of Digital Sensor lpmOnlineClampsStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF0_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF3_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AIN</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AIN</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AOL</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AOL</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP2_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP3_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusCloseSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusCloseSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusCloseSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusCloseSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusOpenSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusOpenSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusOpenSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusOpenSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusCloseSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusCloseSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusCloseSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusCloseSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusOpenSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusOpenSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusOpenSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusOpenSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusCloseSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusCloseSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusCloseSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusCloseSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusOpenSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusOpenSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusOpenSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusOpenSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorBXminus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorBXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorBXplus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorBXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorXminus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorXplus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorBLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorBLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorBLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorBLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>overClampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor overClampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>presenceLoader</EFDB_Name>
-      <Description>Value of Digital Sensor presenceLoader</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>presenceloader_C</EFDB_Name>
-      <Description>Value of Digital Sensor presenceLoader_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorBXminus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorBXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorBXplus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorBXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorXminus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorXplus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>unclampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor unclampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>underClampedStatusSensor</EFDB_Name>
-      <Description>Value of Digital Sensor underClampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-  </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Canbus0_CarouselController_Trending for category Trending using level 2-->
   <!--======================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_CarouselController_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_CarouselController_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 1196028887L -->
+    <!--CCS: Dictionary_Checksum: 4199528393L -->
     <item>
       <EFDB_Name>averageCurrent</EFDB_Name>
       <Description>Average current read on autochanger truck controller : index 0x2027</Description>
@@ -7091,6 +5887,13 @@
       <Description>Position read on controller : index 0x6064 subindex 0</Description>
       <IDL_Type>long</IDL_Type>
       <Units>micron</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>positionSensorType</EFDB_Name>
+      <Description>Position sensor type on carousel controller</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7375,26 +6178,292 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Hyttc580_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Hyttc580_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 4130876379L -->
+    <!--CCS: Dictionary_Checksum: 3071168627L -->
     <item>
-      <EFDB_Name>pdo1</EFDB_Name>
-      <Description>Value of the PDO1 read on the HYTTC580</Description>
-      <IDL_Type>long long</IDL_Type>
+      <EFDB_Name>plc_caAF3</EFDB_Name>
+      <Description>Value of Digital Sensor caAF3</Description>
+      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pdo2</EFDB_Name>
-      <Description>Value of the PDO2 read on the HYTTC580</Description>
-      <IDL_Type>long long</IDL_Type>
+      <EFDB_Name>plc_caAF3b</EFDB_Name>
+      <Description>Value of Digital Sensor caAF3b</Description>
+      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>pdo4</EFDB_Name>
-      <Description>Value of the PDO4 read on the HYTTC580</Description>
-      <IDL_Type>long long</IDL_Type>
+      <EFDB_Name>plc_caAP1</EFDB_Name>
+      <Description>Value of Digital Sensor caAP1</Description>
+      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP1b</EFDB_Name>
+      <Description>Value of Digital Sensor caAP1b</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2</EFDB_Name>
+      <Description>Value of Digital Sensor caAP2</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP2b</EFDB_Name>
+      <Description>Value of Digital Sensor caAP2b</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3</EFDB_Name>
+      <Description>Value of Digital Sensor caAP3</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caAP3b</EFDB_Name>
+      <Description>Value of Digital Sensor caAP3b</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caBrakesActivated</EFDB_Name>
+      <Description>Value of Digital Sensor caBrakesActivated</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0</EFDB_Name>
+      <Description>Value of Digital Sensor caCF0</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF0b</EFDB_Name>
+      <Description>Value of Digital Sensor caCF0b</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1</EFDB_Name>
+      <Description>Value of Digital Sensor caCF1</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCF1b</EFDB_Name>
+      <Description>Value of Digital Sensor caCF1b</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFC</EFDB_Name>
+      <Description>Value of Digital Sensor caCFC</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCFCb</EFDB_Name>
+      <Description>Value of Digital Sensor caCFCb</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCS</EFDB_Name>
+      <Description>Value of Digital Sensor caCS</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caCSb</EFDB_Name>
+      <Description>Value of Digital Sensor caCSb</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableBrakes</EFDB_Name>
+      <Description>Value of Digital Sensor caEnableBrakes</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableRotation</EFDB_Name>
+      <Description>Value of Digital Sensor caEnableRotation</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableShutter</EFDB_Name>
+      <Description>Value of Digital Sensor caEnableShutter</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEnableUnclamp</EFDB_Name>
+      <Description>Value of Digital Sensor caEnableUnclamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEng</EFDB_Name>
+      <Description>Value of Digital Sensor caEng</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caEngb</EFDB_Name>
+      <Description>Value of Digital Sensor caEngb</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockout</EFDB_Name>
+      <Description>Value of Digital Sensor caLockout</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caLockoutb</EFDB_Name>
+      <Description>Value of Digital Sensor caLockoutb</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caShutterInactive</EFDB_Name>
+      <Description>Value of Digital Sensor caShutterInactive</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_caSleep</EFDB_Name>
+      <Description>Value of Digital Sensor caSleep</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_enableShutterInterlock</EFDB_Name>
+      <Description>Value of Digital Sensor enableShutterInterlock</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDI</EFDB_Name>
+      <Description>Value of Digital Sensor okDI</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_okDIsafety</EFDB_Name>
+      <Description>Value of Digital Sensor okDIsafety</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_powerSave</EFDB_Name>
+      <Description>Value of Digital Sensor powerSave</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpCheckRotation</EFDB_Name>
+      <Description>Value of Digital Sensor tpCheckRotation</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopRotation</EFDB_Name>
+      <Description>Value of Digital Sensor tpStopRotation</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>plc_tpStopUnclamp</EFDB_Name>
+      <Description>Value of Digital Sensor tpStopUnclamp</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_averageClamps</EFDB_Name>
+      <Description>Average temperature clamps</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_internalHYTTC580</EFDB_Name>
+      <Description>Internal temperature of hyttc580</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_socket1</EFDB_Name>
+      <Description>Temperature of socket 1</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_socket2</EFDB_Name>
+      <Description>Temperature of socket 2</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_socket3</EFDB_Name>
+      <Description>Temperature of socket 3</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_socket4</EFDB_Name>
+      <Description>Temperature of socket 4</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperatures_socket5</EFDB_Name>
+      <Description>Temperature of socket 5</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
       <Count>1</Count>
     </item>
   </SALTelemetry>
@@ -8459,7 +7528,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Canbus1_LoaderPlutoGateway_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 3747844937L -->
+    <!--CCS: Dictionary_Checksum: 1975934525L -->
     <item>
       <EFDB_Name>acAF0b</EFDB_Name>
       <Description>Value of Digital Sensor acAF0b</Description>
@@ -8517,176 +7586,8 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>carouselHoldingFilterSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor carouselHoldingFilterSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselHoldingFilterSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor carouselHoldingFilterSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselStoppedAtStandby</EFDB_Name>
-      <Description>Value of Digital Sensor carouselStoppedAtStandby</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carouselStoppedAtStandbyC</EFDB_Name>
-      <Description>Value of Digital Sensor carouselStoppedAtStandbyC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF0</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF0_C</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF0_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF1</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>carousel_CF1_C</EFDB_Name>
-      <Description>Value of Digital Sensor carousel_CF1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>clampedStatusSensor</EFDB_Name>
       <Description>Value of Digital Sensor clampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorBLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorBLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorBLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorBLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>closeSensorLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor closeSensorLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringKey</EFDB_Name>
-      <Description>Value of Digital Sensor engineeringKey</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>engineeringkey_C</EFDB_Name>
-      <Description>Value of Digital Sensor engineeringKey_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorBLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorBLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorBLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorBLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterEngagedSensorLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor filterEngagedSensorLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor2</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor3</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor4</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor4</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>filterIDSensor5</EFDB_Name>
-      <Description>Value of Digital Sensor filterIDSensor5</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8702,48 +7603,6 @@
       <EFDB_Name>forceSensor1</EFDB_Name>
       <Description>Value of Digital Sensor forceSensor1</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorBXminus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorBXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorBXplus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorBXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorXminus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>handoffPositionSensorXplus</EFDB_Name>
-      <Description>Value of Digital Sensor handoffPositionSensorXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inclinometerXminus</EFDB_Name>
-      <Description>Value of Digital Sensor inclinometerXminus</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>inclinometerXplus</EFDB_Name>
-      <Description>Value of Digital Sensor inclinometerXplus</Description>
-      <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -8846,20 +7705,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>loaderConnectedSensor</EFDB_Name>
-      <Description>Value of Digital Sensor loaderConnectedSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderConnectedSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor loaderConnectedSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>loaderDefaultStatus</EFDB_Name>
       <Description>Value of Digital Sensor loaderDefaultStatus</Description>
       <IDL_Type>long</IDL_Type>
@@ -8918,20 +7763,6 @@
     <item>
       <EFDB_Name>loaderHandoffPositionSensor1</EFDB_Name>
       <Description>Value of Digital Sensor loaderHandoffPositionSensor1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHoldingFilterSensor0</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHoldingFilterSensor0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>loaderHoldingFilterSensor1</EFDB_Name>
-      <Description>Value of Digital Sensor loaderHoldingFilterSensor1</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9014,337 +7845,8 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>lockOut</EFDB_Name>
-      <Description>Value of Digital Sensor lockOut</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockOutShunt</EFDB_Name>
-      <Description>Value of Digital Sensor lockOutShunt</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lockout_C</EFDB_Name>
-      <Description>Value of Digital Sensor lockOut_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmLatchesStatus</EFDB_Name>
-      <Description>Value of Digital Sensor lpmLatchesStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmLinearRail1Status</EFDB_Name>
-      <Description>Value of Digital Sensor lpmLinearRail1Status</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmLinearRail2Status</EFDB_Name>
-      <Description>Value of Digital Sensor lpmLinearRail2Status</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>lpmOnlineClampsStatus</EFDB_Name>
-      <Description>Value of Digital Sensor lpmOnlineClampsStatus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF0</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF0_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF0_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF1_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AF3_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AF3_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AIN</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AIN</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AOL</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AOL</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP1</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP1_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP1_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP2</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP2_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP2_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP3</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>out_AP3_C</EFDB_Name>
-      <Description>Value of Digital Sensor OUT_AP3_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusCloseSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusCloseSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusCloseSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusCloseSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusOpenSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusOpenSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXminusOpenSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXminusOpenSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusCloseSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusCloseSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusCloseSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusCloseSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusOpenSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusOpenSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampXplusOpenSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampXplusOpenSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusCloseSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusCloseSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusCloseSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusCloseSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusOpenSensor</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusOpenSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlineClampYminusOpenSensorC</EFDB_Name>
-      <Description>Value of Digital Sensor onlineClampYminusOpenSensorC</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorBXminus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorBXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorBXplus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorBXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorXminus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>onlinePositionSensorXplus</EFDB_Name>
-      <Description>Value of Digital Sensor onlinePositionSensorXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorBLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorBLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorBLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorBLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorLatchXminus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorLatchXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>openSensorLatchXplus</EFDB_Name>
-      <Description>Value of Digital Sensor openSensorLatchXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>overClampedStatusSensor</EFDB_Name>
       <Description>Value of Digital Sensor overClampedStatusSensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>presenceLoader</EFDB_Name>
-      <Description>Value of Digital Sensor presenceLoader</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>presenceloader_C</EFDB_Name>
-      <Description>Value of Digital Sensor presenceLoader_C</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorBXminus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorBXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorBXplus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorBXplus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorXminus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorXminus</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>standbyPositionSensorXplus</EFDB_Name>
-      <Description>Value of Digital Sensor standbyPositionSensorXplus</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9364,16 +7866,101 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Brakes_Trending for category Trending using level 2-->
+  <!--===========================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Carousel_Brakes_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Brakes_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 2368438977L -->
+    <item>
+      <EFDB_Name>brakeState1</EFDB_Name>
+      <Description>State of carousel brake bay I {CLOSED; NOBRAKE; NO_SENSOR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeState2</EFDB_Name>
+      <Description>State of carousel brake bay N {CLOSED; NOBRAKE; NO_SENSOR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>brakeState3</EFDB_Name>
+      <Description>State of carousel brake bay X {CLOSED; NOBRAKE; NO_SENSOR}</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>sensor1</EFDB_Name>
+      <Description>Carousel brake sensor bay I value</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>sensor2</EFDB_Name>
+      <Description>Carousel brake sensor bay N value</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>sensor3</EFDB_Name>
+      <Description>Carousel brake sensor bay X value</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperature1</EFDB_Name>
+      <Description>Temperature of carousel motor on bay D</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperature2</EFDB_Name>
+      <Description>Temperature of carousel brake bay I</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperature3</EFDB_Name>
+      <Description>Temperature of carousel brake bay N</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>temperature4</EFDB_Name>
+      <Description>Temperature of carousel brake bay X</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Carousel_Socket1_Trending for category Trending using level 2-->
   <!--============================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket1_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket1_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 2638884263L -->
+    <!--CCS: Dictionary_Checksum: 3039196703L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
       <Description>Socket is at standby position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>available</EFDB_Name>
+      <Description>Availability of socket</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9518,10 +8105,17 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket2_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket2_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 3796116839L -->
+    <!--CCS: Dictionary_Checksum: 1794514883L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
       <Description>Socket is at standby position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>available</EFDB_Name>
+      <Description>Availability of socket</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9666,10 +8260,17 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket3_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket3_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 2121195288L -->
+    <!--CCS: Dictionary_Checksum: 2526463304L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
       <Description>Socket is at standby position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>available</EFDB_Name>
+      <Description>Availability of socket</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9814,10 +8415,17 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket4_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket4_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 475542759L -->
+    <!--CCS: Dictionary_Checksum: 237488698L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
       <Description>Socket is at standby position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>available</EFDB_Name>
+      <Description>Availability of socket</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9962,10 +8570,17 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Carousel_Socket5_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Carousel_Socket5_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 2155007640L -->
+    <!--CCS: Dictionary_Checksum: 4064743601L -->
     <item>
       <EFDB_Name>atStandby</EFDB_Name>
       <Description>Socket is at standby position</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>available</EFDB_Name>
+      <Description>Availability of socket</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -10182,13 +8797,605 @@
       <Count>1</Count>
     </item>
   </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Counters_Autochanger_Trending for category Trending using level 2-->
+  <!--================================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Counters_Autochanger_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Counters_Autochanger_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 1345145492L -->
+    <item>
+      <EFDB_Name>autochangertrucks_ALIGN_FOLLOWER</EFDB_Name>
+      <Description>Counter for the action ALIGN_FOLLOWER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_MOVE_FOLLOWER_TRUCK_ALONE</EFDB_Name>
+      <Description>Counter for the action MOVE_FOLLOWER_TRUCK_ALONE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_MOVE_TO_ABSOLUTE_POSITION</EFDB_Name>
+      <Description>Counter for the action MOVE_TO_ABSOLUTE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_CLOSE</EFDB_Name>
+      <Description>Counter for the action CLOSE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXminus_OPEN</EFDB_Name>
+      <Description>Counter for the action OPEN</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_CLOSE</EFDB_Name>
+      <Description>Counter for the action CLOSE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>latches_latchXplus_OPEN</EFDB_Name>
+      <Description>Counter for the action OPEN</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action CLOSE_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>Counter for the action CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_LOCK_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action LOCK_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_REOPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action REOPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_UNLOCK_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action UNLOCK_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action CLOSE_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>Counter for the action CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_LOCK_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action LOCK_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_REOPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action REOPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_UNLOCK_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action UNLOCK_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action CLOSE_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>Counter for the action CLOSE_ONLINECLAMP_MODE_PROFILE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_LOCK_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action LOCK_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_PROFILE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_REOPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
+      <Description>Counter for the action REOPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_UNLOCK_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action UNLOCK_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Counters_Carousel_Trending for category Trending using level 2-->
+  <!--=============================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Counters_Carousel_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Counters_Carousel_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 770763357L -->
+    <item>
+      <EFDB_Name>rotate_CAROUSEL_TO_ABSOLUTE_POSITION</EFDB_Name>
+      <Description>Counter for the action ROTATE_CAROUSEL_TO_ABSOLUTE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rotate_CAROUSEL_TO_RELATIVE_POSITION</EFDB_Name>
+      <Description>Counter for the action ROTATE_CAROUSEL_TO_RELATIVE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_RELEASE_CLAMPS</EFDB_Name>
+      <Description>Counter for the action RELEASE_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_UNLOCK_CLAMPS</EFDB_Name>
+      <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_RELEASE_CLAMPS</EFDB_Name>
+      <Description>Counter for the action RELEASE_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_UNLOCK_CLAMPS</EFDB_Name>
+      <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_RELEASE_CLAMPS</EFDB_Name>
+      <Description>Counter for the action RELEASE_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_UNLOCK_CLAMPS</EFDB_Name>
+      <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_RELEASE_CLAMPS</EFDB_Name>
+      <Description>Counter for the action RELEASE_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_UNLOCK_CLAMPS</EFDB_Name>
+      <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_RELEASE_CLAMPS</EFDB_Name>
+      <Description>Counter for the action RELEASE_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_UNLOCK_CLAMPS</EFDB_Name>
+      <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_RELEASE</EFDB_Name>
+      <Description>Counter for the action RELEASE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_UNLOCK</EFDB_Name>
+      <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Counters_Loader_Trending for category Trending using level 2-->
+  <!--===========================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Counters_Loader_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Counters_Loader_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 769110380L -->
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_ABSOLUTEPOSITION</EFDB_Name>
+      <Description>Counter for the action MOVE_LOADERCARRIER_TO_ABSOLUTEPOSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_ENGAGED</EFDB_Name>
+      <Description>Counter for the action MOVE_LOADERCARRIER_TO_ENGAGED</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_HANDOFF</EFDB_Name>
+      <Description>Counter for the action MOVE_LOADERCARRIER_TO_HANDOFF</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>carrier_MOVE_LOADERCARRIER_TO_STORAGE</EFDB_Name>
+      <Description>Counter for the action MOVE_LOADERCARRIER_TO_STORAGE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_CLAMP_LOADER_HOOKS</EFDB_Name>
+      <Description>Counter for the action CLAMP_LOADER_HOOKS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_CLOSE_LOADER_HOOKS</EFDB_Name>
+      <Description>Counter for the action CLOSE_LOADER_HOOKS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_OPEN_HOMING_LOADER_HOOKS</EFDB_Name>
+      <Description>Counter for the action OPEN_HOMING_LOADER_HOOKS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>hooks_UNCLAMP_LOADER_HOOKS</EFDB_Name>
+      <Description>Counter for the action UNCLAMP_LOADER_HOOKS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Counters_Trending for category Trending using level 2-->
+  <!--====================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Counters_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Counters_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 671170734L -->
+    <item>
+      <EFDB_Name>connect_LOADER</EFDB_Name>
+      <Description>Counter for the action CONNECT_LOADER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disconnect_LOADER</EFDB_Name>
+      <Description>Counter for the action DISCONNECT_LOADER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disengage_FILTER_FROM_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action DISENGAGE_FILTER_FROM_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>grab_FILTER_AT_STANDBY</EFDB_Name>
+      <Description>Counter for the action GRAB_FILTER_AT_STANDBY</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>load_FILTER</EFDB_Name>
+      <Description>Counter for the action LOAD_FILTER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>move_AND_CLAMP_FILTER_ONLINE</EFDB_Name>
+      <Description>Counter for the action MOVE_AND_CLAMP_FILTER_ONLINE</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rotate_SOCKET_TO_STANDBY</EFDB_Name>
+      <Description>Counter for the action ROTATE_SOCKET_TO_STANDBY</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>set_FILTER</EFDB_Name>
+      <Description>Counter for the action SET_FILTER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>set_FILTER_AT_HANDOFF_FOR_LOADER</EFDB_Name>
+      <Description>Counter for the action SET_FILTER_AT_HANDOFF_FOR_LOADER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>set_NO_FILTER</EFDB_Name>
+      <Description>Counter for the action SET_NO_FILTER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>store_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>unload_FILTER</EFDB_Name>
+      <Description>Counter for the action UNLOAD_FILTER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending for category Trending using level 2-->
   <!--================================================================================================================================-->
   <SALTelemetry>
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Autochanger_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 79989557L -->
+    <!--CCS: Dictionary_Checksum: 2716061563L -->
     <item>
       <EFDB_Name>autochangertrucks_ALIGN_FOLLOWER</EFDB_Name>
       <Description>Duration of the action ALIGN_FOLLOWER</Description>
@@ -10207,6 +9414,13 @@
       <EFDB_Name>autochangertrucks_MOVE_TO_ABSOLUTE_POSITION</EFDB_Name>
       <Description>Duration of the action MOVE_TO_ABSOLUTE_POSITION</Description>
       <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>grab_FILTER_AT_STANDBY</EFDB_Name>
+      <Description>Duration of the action GRAB_FILTER_AT_STANDBY</Description>
+      <IDL_Type>double</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -10235,6 +9449,13 @@
       <EFDB_Name>latches_latchXplus_OPEN</EFDB_Name>
       <Description>Duration of the action OPEN</Description>
       <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>move_AND_CLAMP_FILTER_ONLINE</EFDB_Name>
+      <Description>Duration of the action MOVE_AND_CLAMP_FILTER_ONLINE</Description>
+      <IDL_Type>double</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -10688,10 +9909,73 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Duration_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 3648583864L -->
+    <!--CCS: Dictionary_Checksum: 252611752L -->
     <item>
-      <EFDB_Name>sETFILTER</EFDB_Name>
-      <Description>duration of command setFilter</Description>
+      <EFDB_Name>connect_LOADER</EFDB_Name>
+      <Description>Duration of CONNECT_LOADER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disconnect_LOADER</EFDB_Name>
+      <Description>Duration of DISCONNECT_LOADER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>disengage_FILTER_FROM_CAROUSEL</EFDB_Name>
+      <Description>Duration of DISENGAGE_FILTER_FROM_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>load_FILTER</EFDB_Name>
+      <Description>Duration of LOAD_FILTER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rotate_SOCKET_TO_STANDBY</EFDB_Name>
+      <Description>Duration of the action ROTATE_SOCKET_TO_STANDBY</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>set_FILTER</EFDB_Name>
+      <Description>Duration of SET_FILTER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>set_FILTER_AT_HANDOFF_FOR_LOADER</EFDB_Name>
+      <Description>Duration of SET_FILTER_AT_HANDOFF_FOR_LOADER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>set_NO_FILTER</EFDB_Name>
+      <Description>Duration of SET_NO_FILTER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>store_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Duration of STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>unload_FILTER</EFDB_Name>
+      <Description>Duration of UNLOAD_FILTER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -10703,14 +9987,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Fcs_Mcm_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Fcs_Mcm_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 3461632716L -->
-    <item>
-      <EFDB_Name>autochanger_trucks_location</EFDB_Name>
-      <Description>Known autochanger position (STANDBY, HANDOFF, ONLINE) or IN_TRAVEL</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
+    <!--CCS: Dictionary_Checksum: 104252808L -->
     <item>
       <EFDB_Name>autochanger_trucks_position</EFDB_Name>
       <Description>Absolute position of the autochanger trucks</Description>
@@ -10719,15 +9996,15 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>filter_on_autochanger_id</EFDB_Name>
-      <Description>ID of the filter currently on the autochanger</Description>
-      <IDL_Type>long</IDL_Type>
+      <EFDB_Name>autochanger_trucks_state</EFDB_Name>
+      <Description>Known autochanger position (STANDBY, HANDOFF, ONLINE) or IN_TRAVEL</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>filter_on_autochanger_name</EFDB_Name>
-      <Description>Name of the filter currently on the autochanger</Description>
+      <EFDB_Name>filter_on_autochanger</EFDB_Name>
+      <Description>OCS name of the filter currently on the autochanger</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -10750,6 +10027,21 @@
       <EFDB_Name>setfilter_percentage</EFDB_Name>
       <Description>Progress of the setFilter command [%]</Description>
       <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Fcs_Trending for category Trending using level 2-->
+  <!--===============================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Fcs_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Fcs_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 1480652705L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of fcs</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -10983,6 +10275,21 @@
       <EFDB_Name>statuspublishedbyhook4_unlockSensorOn</EFDB_Name>
       <Description>Loader hook unlocked</Description>
       <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_fcs_Loader_Trending for category Trending using level 2-->
+  <!--==================================================================================================================-->
+  <SALTelemetry>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_fcs_Loader_Trending</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_fcs_Loader_Trending for category Trending</Description>
+    <!--CCS: Dictionary_Checksum: 2490236096L -->
+    <item>
+      <EFDB_Name>id</EFDB_Name>
+      <Description>Identifier of loaderusing serialNB of plutoGateway device</Description>
+      <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>


### PR DESCRIPTION
This is a direct consequence of fixing the fcs data dictionary to remove the registration of fake sensors that never published, which went unseen up to now.

This file was created with 
org-lsst-ccs-camera-sal-xml for the cycle40 SAL release.