### PR TITLE
Implement CAP-1062 (Generic command)

### DIFF
--- a/doc/news/interface_changes/CAP-1062.atcamera.rst
+++ b/doc/news/interface_changes/CAP-1062.atcamera.rst
@@ -1,0 +1,1 @@
+Implement generic command

--- a/doc/news/interface_changes/CAP-1062.cccamera.rst
+++ b/doc/news/interface_changes/CAP-1062.cccamera.rst
@@ -1,0 +1,1 @@
+Implement generic command

--- a/doc/news/interface_changes/CAP-1062.mtcamera.rst
+++ b/doc/news/interface_changes/CAP-1062.mtcamera.rst
@@ -1,0 +1,1 @@
+Implement generic command

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Commands.xml
@@ -228,4 +228,28 @@
       <Count>1</Count>
     </item>
   </SALCommand>
+  <!-- Generic command added for CAP-1062  -->
+  <!-- Example: generic resetFesPLC -->
+  <!-- This is to allow us to rapidly support new commands, which, if useful, maybe included explicitly in future cycle releases -->
+  <SALCommand>
+    <Subsystem>ATCamera</Subsystem>
+    <EFDB_Topic>ATCamera_command_generic</EFDB_Topic>
+    <Description>Generic command for sending arbitrary (but allowed by configuration) commands to the camera.</Description>
+    <item>
+      <EFDB_Name>command</EFDB_Name>
+      <Description>The command to be sent to the MCM. Must be listed as allowed in the ocs-bridge configuration.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>arguments</EFDB_Name>
+      <Description>Any arguments required by the command (empty string if none)</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALCommand>
 </SALCommandSet>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Commands.xml
@@ -241,4 +241,28 @@
       <Count>1</Count>
     </item>
   </SALCommand>
+  <!-- Generic command added for CAP-1062  -->
+  <!-- Example: generic resetFesPLC -->
+  <!-- This is to allow us to rapidly support new commands, which, if useful, maybe included explicitly in future cycle releases -->
+  <SALCommand>
+    <Subsystem>CCCamera</Subsystem>
+    <EFDB_Topic>CCCamera_command_generic</EFDB_Topic>
+    <Description>Generic command for sending arbitrary (but allowed by configuration) commands to the camera.</Description>
+    <item>
+      <EFDB_Name>command</EFDB_Name>
+      <Description>The command to be sent to the MCM. Must be listed as allowed in the ocs-bridge configuration.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>arguments</EFDB_Name>
+      <Description>Any arguments required by the command (empty string if none)</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALCommand>
 </SALCommandSet>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Commands.xml
@@ -253,4 +253,28 @@
       <Count>1</Count>
     </item>
   </SALCommand>
+  <!-- Generic command added for CAP-1062  -->
+  <!-- Example: generic resetFesPLC -->
+  <!-- This is to allow us to rapidly support new commands, which, if useful, maybe included explicitly in future cycle releases -->
+  <SALCommand>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_command_generic</EFDB_Topic>
+    <Description>Generic command for sending arbitrary (but allowed by configuration) commands to the camera.</Description>
+    <item>
+      <EFDB_Name>command</EFDB_Name>
+      <Description>The command to be sent to the MCM. Must be listed as allowed in the ocs-bridge configuration.</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>arguments</EFDB_Name>
+      <Description>Any arguments required by the command (empty string if none)</Description>
+      <IDL_Type>string</IDL_Type>
+      <IDL_Size>1</IDL_Size>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALCommand>
 </SALCommandSet>


### PR DESCRIPTION
This implements a generic command to allow us to issue "arbitrary" commands to the camera
Commands will only be accepted if the camera configuration allows it.
This is intended to give us a way to allow commands if an urgent need is discovered during commisioning/operations without waiting for an XML release.