### PR TITLE
DM-51223 Update DREAM interface so that it is indexed.

### DIFF
--- a/doc/news/interface_changes/DM-51223.dream.rst
+++ b/doc/news/interface_changes/DM-51223.dream.rst
@@ -1,0 +1,1 @@
+ * Updated DREAM interface so that it is indexed.

--- a/python/lsst/ts/xml/data/sal_interfaces/SALSubsystems.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/SALSubsystems.xml
@@ -202,7 +202,7 @@
   <SALSubsystem>
     <Name>DREAM</Name>
     <Description>CSC for the DREAM (Dutch Rubin Enhanced Atmospheric Monitor) all-sky camera.</Description>
-    <IndexEnumeration>no</IndexEnumeration>
+    <IndexEnumeration>any</IndexEnumeration>
     <AddedGenerics>csc, configurable, logevent_largeFileObjectAvailable</AddedGenerics>
     <ActiveDevelopers>Petr Kubanek</ActiveDevelopers>
     <Github>https://github.com/lsst-ts/ts_dream</Github>


### PR DESCRIPTION
Backs out PR #959 and makes DREAM an indexed CSC, consistent with past deployments.