### PR TITLE
OSW-29: Updated commands for DIMM

### DIFF
--- a/doc/news/interface_changes/OSW-29.dimm.1.rst
+++ b/doc/news/interface_changes/OSW-29.dimm.1.rst
@@ -1,0 +1,1 @@
+Updated DIMM commands: `gotoRaDec`, `gotoAltAz`, `moveDome`

--- a/doc/news/interface_changes/OSW-29.dimm.2.rst
+++ b/doc/news/interface_changes/OSW-29.dimm.2.rst
@@ -1,0 +1,1 @@
+New DIMM events: `automationState`. `scopeEvents`

--- a/doc/news/interface_changes/OSW-29.dimm.rst
+++ b/doc/news/interface_changes/OSW-29.dimm.rst
@@ -1,0 +1,1 @@
+New commands for DIMM: `controllerCommand`, `recover`, `park`

--- a/python/lsst/ts/xml/data/sal_interfaces/DIMM/DIMM_Commands.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/DIMM/DIMM_Commands.xml
@@ -50,6 +50,30 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <!-- Optional item that may be omitted. -->
+      <EFDB_Name>mag</EFDB_Name>
+      <Description>Magnitude of target. (optional)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mag</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <!-- Optional item that may be omitted. -->
+      <EFDB_Name>bv</EFDB_Name>
+      <Description>B-V color index of target. (optional)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mag</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <!-- Optional item that may be omitted. -->
+      <EFDB_Name>stype</EFDB_Name>
+      <Description>Stellar classification of target. (optional)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALCommand>
   <SALCommand>
     <Subsystem>DIMM</Subsystem>
@@ -76,6 +100,30 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <!-- Optional item that may be omitted. -->
+      <EFDB_Name>mag</EFDB_Name>
+      <Description>Magnitude of target. (optional)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mag</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <!-- Optional item that may be omitted. -->
+      <EFDB_Name>bv</EFDB_Name>
+      <Description>B-V color index of target. (optional)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>mag</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <!-- Optional item that may be omitted. -->
+      <EFDB_Name>stype</EFDB_Name>
+      <Description>Stellar classification of target. (optional)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALCommand>
   <SALCommand>
     <Subsystem>DIMM</Subsystem>
@@ -92,8 +140,48 @@
   </SALCommand>
   <SALCommand>
     <Subsystem>DIMM</Subsystem>
+    <EFDB_Topic>DIMM_command_controllerCommand</EFDB_Topic>
+    <Description>Send a generic command string to the specified controller.</Description>
+    <item>
+      <EFDB_Name>cmd</EFDB_Name>
+      <Description>Command to send (e.g., "get scope.status.list").</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>parameters</EFDB_Name>
+      <Description>Special command parameters as a JSON string.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALCommand>
+  <SALCommand>
+    <Subsystem>DIMM</Subsystem>
+    <EFDB_Topic>DIMM_command_recover</EFDB_Topic>
+    <Description>Run a predefined internal recovery sequence.</Description>
+  </SALCommand>
+  <SALCommand>
+    <Subsystem>DIMM</Subsystem>
+    <EFDB_Topic>DIMM_command_park</EFDB_Topic>
+    <Description>Stop observations and park the telescope.</Description>
+  </SALCommand>
+  <SALCommand>
+    <Subsystem>DIMM</Subsystem>
     <EFDB_Topic>DIMM_command_moveDome</EFDB_Topic>
     <Description>Manually move the first dome side to the requested position.</Description>
+    <item>
+      <EFDB_Name>open</EFDB_Name>
+      <Description>
+        If true, `sideA` and `sideB` below are ignored and the dome is fully opened as though
+        1.0 were supplied for both `sideA` and `sideB`. If false, the targeted dome position
+        will be determined using the `sideA` and `sideB` arguments.
+      </Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>sideA</EFDB_Name>
       <Description>

--- a/python/lsst/ts/xml/data/sal_interfaces/DIMM/DIMM_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/DIMM/DIMM_Events.xml
@@ -9,6 +9,33 @@
   <Enumeration>ScopeMotion_Park,ScopeMotion_Slew,ScopeMotion_Stand,ScopeMotion_Tracking</Enumeration>
   <SALEvent>
     <Subsystem>DIMM</Subsystem>
+    <EFDB_Topic>DIMM_logevent_automationState</EFDB_Topic>
+    <Description>Most recent automation state commanded by the CSC.</Description>
+    <item>
+      <EFDB_Name>state</EFDB_Name>
+      <Description>Most recent automation state commanded by the CSC, an AmebaMode enumeration.</Description>
+      <IDL_Type>int</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <SALEvent>
+    <Subsystem>DIMM</Subsystem>
+    <EFDB_Topic>DIMM_logevent_scopeEvents</EFDB_Topic>
+    <Description>Reported error events from the telescope.</Description>
+    <item>
+      <EFDB_Name>eventList</EFDB_Name>
+      <Description>
+        A comma separated list of all saved error events in the format
+        &lt;error&gt;:&lt;status&gt;:&lt;device&gt;[:&lt;comment&gt;][,...].
+      </Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <SALEvent>
+    <Subsystem>DIMM</Subsystem>
     <EFDB_Topic>DIMM_logevent_moduleStatus</EFDB_Topic>
     <Description>Module statuses</Description>
     <item>


### PR DESCRIPTION
New commands:

- `controllerCommand`
- `recover`
- `park`

Updated commands:

- `gotoRaDec` and `gotoAltAz` now have optional items `mag`, `bv`, `stype`.
- `moveDome` now has item `open`.

New events:

- `automationState`, the current AMEBA state
- `scopeEvents` a list of error events from the scope