### PR TITLE
Implement CAP-1084

### DIFF
--- a/doc/news/interface_changes/CAP-1084.atcamera.rst
+++ b/doc/news/interface_changes/CAP-1084.atcamera.rst
@@ -1,0 +1,1 @@
+Automatically generated changes to bring ATCamera up to date with CCS dictionaries

--- a/doc/news/interface_changes/CAP-1084.cccamera.rst
+++ b/doc/news/interface_changes/CAP-1084.cccamera.rst
@@ -1,0 +1,1 @@
+Automatically generated changes to bring CCCamera up to date with CCS dictionaries

--- a/doc/news/interface_changes/CAP-1084.mtcamera.rst
+++ b/doc/news/interface_changes/CAP-1084.mtcamera.rst
@@ -1,0 +1,1 @@
+Automatically generated changes to bring MTCamera up to date with CCS dictionaries

--- a/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ATCamera/ATCamera_Events.xml
@@ -4152,10 +4152,24 @@
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration</EFDB_Topic>
     <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_GuiderConfiguration for category Guider</Description>
-    <!--CCS: Dictionary_Checksum: 1714148447L -->
+    <!--CCS: Dictionary_Checksum: 4142992035L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>commandedClearParameters</EFDB_Name>
+      <Description>The default parameters used for commanded clearing</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>extendedROIParameters</EFDB_Name>
+      <Description>Extended ROI parameters</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -4174,6 +4188,13 @@
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>idleClearParameters</EFDB_Name>
+      <Description>The parameters used for guider idle clearing</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer using level 1-->
   <!--===========================================================================================================================================================-->
@@ -4181,7 +4202,7 @@
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
     <Description>subsystem ATCamera class ATCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer</Description>
-    <!--CCS: Dictionary_Checksum: 4112623107L -->
+    <!--CCS: Dictionary_Checksum: 3662355493L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4204,17 +4225,38 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>idleFlushMain</EFDB_Name>
+      <EFDB_Name>clearRowsParameter</EFDB_Name>
+      <Description>Name of the clear rows parameter (used for idle clear)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>idleClearMain</EFDB_Name>
       <Description>Name of the idle flush main</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>idleFlushTimeout</EFDB_Name>
-      <Description>Idle time in milliseconds before sequencer will enter IDLE_FLUSH. Can be zero (enter immeidately) or negative (never)</Description>
+      <EFDB_Name>idleClearPeriod</EFDB_Name>
+      <Description>Period in milliseconds at which the periodic idle clear is run when focal-plane is in IDLE_CLEAR state</Description>
       <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>idleClearRows</EFDB_Name>
+      <Description>Value to set the idleRows parameter to during idle clear</Description>
+      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>idleClearTimeout</EFDB_Name>
+      <Description>QUIESCENT time in milliseconds before sequencer will transition to IDLE_CLEAR state. Can be zero (enter immediately) or negative (never)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -4347,13 +4389,6 @@
       <EFDB_Name>shiftCountParameter</EFDB_Name>
       <Description>Name of the shift count parameter</Description>
       <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>stepAfterIntegrate</EFDB_Name>
-      <Description>Perform a step rather than stop after integrate</Description>
-      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -4521,7 +4556,7 @@
     <Subsystem>ATCamera</Subsystem>
     <EFDB_Topic>ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
     <Description>subsystem ATCamera class ATCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics</Description>
-    <!--CCS: Dictionary_Checksum: 1384850593L -->
+    <!--CCS: Dictionary_Checksum: 2239708401L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -4596,6 +4631,13 @@
       <EFDB_Name>sumRmsStats</EFDB_Name>
       <Description>Rms Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppressReadErrorAlerts</EFDB_Name>
+      <Description>Suppress register reed errors by checking additional update</Description>
+      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -7680,7 +7722,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>WARNING, SERIOUS, CRITICAL, NOMINAL</Enumeration>
+      <Enumeration>NOMINAL,WARNING, ALARM</Enumeration>
     </item>
     <item>
       <EFDB_Name>highestSeverity</EFDB_Name>
@@ -7688,7 +7730,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <!-- <Enumeration>WARNING, SERIOUS, CRITICAL, NOMINAL</Enumeration> -->
+      <!-- <Enumeration>NOMINAL,WARNING, ALARM</Enumeration> -->
     </item>
     <item>
       <EFDB_Name>isCleared</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/CCCamera/CCCamera_Events.xml
@@ -19041,7 +19041,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <Enumeration>WARNING, SERIOUS, CRITICAL, NOMINAL</Enumeration>
+      <Enumeration>NOMINAL,WARNING, ALARM</Enumeration>
     </item>
     <item>
       <EFDB_Name>highestSeverity</EFDB_Name>
@@ -19049,7 +19049,7 @@
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
-      <!-- <Enumeration>WARNING, SERIOUS, CRITICAL, NOMINAL</Enumeration> -->
+      <!-- <Enumeration>NOMINAL,WARNING, ALARM</Enumeration> -->
     </item>
     <item>
       <EFDB_Name>isCleared</EFDB_Name>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -4832,6 +4832,49 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_HVRegulator_HVRegulationConfiguration for category HVRegulation using level 1-->
+  <!--==========================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_HVRegulator_HVRegulationConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_HVRegulator_HVRegulationConfiguration for category HVRegulation</Description>
+    <!--CCS: Dictionary_Checksum: 2435542193L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaI</EFDB_Name>
+      <Description>allowed excess current margin</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maxDeltaVolt</EFDB_Name>
+      <Description>allowed excess current margin</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>minUpdateDelay</EFDB_Name>
+      <Description>minimum time since last update (settle time)</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>staleMillis</EFDB_Name>
+      <Description>max time for data freshness in V/step calc</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_GeneralConfiguration for category General using level 1-->
   <!--==================================================================================================================================================-->
   <SALEvent>
@@ -4895,7 +4938,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_rebpower_PeriodicTasks_timersConfiguration for category timers</Description>
-    <!--CCS: Dictionary_Checksum: 2646060098L -->
+    <!--CCS: Dictionary_Checksum: 1763221121L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5261,8 +5304,8 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>reb_power_state_taskPeriodMillis</EFDB_Name>
-      <Description>period for task reb-power-state</Description>
+      <EFDB_Name>reb_hv_update_taskPeriodMillis</EFDB_Name>
+      <Description>period for task reb-hv-update</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>ms</Units>
       <Count>1</Count>
@@ -5362,7 +5405,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_rebpower_Reb_GeneralConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Reb_GeneralConfiguration for category General</Description>
-    <!--CCS: Dictionary_Checksum: 2277039115L -->
+    <!--CCS: Dictionary_Checksum: 1643282362L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -5376,14 +5419,44 @@
       <Description>Delta voltage between Parallel High and Low</Description>
       <IDL_Type>long</IDL_Type>
       <Units>Volt</Units>
+      <Count>8</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>reb location</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_HVRegulationConfiguration for category HVRegulation using level 1-->
+  <!--==================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_rebpower_Reb_HVRegulationConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_rebpower_Reb_HVRegulationConfiguration for category HVRegulation</Description>
+    <!--CCS: Dictionary_Checksum: 2122428541L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array firstDac indexed by location-->
+    <item>
+      <EFDB_Name>firstDac</EFDB_Name>
+      <Description>REB first dac step</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
       <Count>71</Count>
     </item>
-    <!--CCSMETA: Array hvBias indexed by location-->
+    <!--CCSMETA: Array hvBiasSetPoint indexed by location-->
     <item>
-      <EFDB_Name>hvBias</EFDB_Name>
+      <EFDB_Name>hvBiasSetPoint</EFDB_Name>
       <Description>REB bias voltage</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>V</Units>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
       <Count>71</Count>
     </item>
     <item>
@@ -5392,6 +5465,38 @@
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
+    </item>
+    <!--CCSMETA: Array maxDac indexed by location-->
+    <item>
+      <EFDB_Name>maxDac</EFDB_Name>
+      <Description>REB maximum allowed</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>unitless</Units>
+      <Count>71</Count>
+    </item>
+    <!--CCSMETA: Array reff indexed by location-->
+    <item>
+      <EFDB_Name>reff</EFDB_Name>
+      <Description>slope of V = reff * I</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>71</Count>
+    </item>
+    <!--CCSMETA: Array useVoltsPerStepCal indexed by location-->
+    <item>
+      <EFDB_Name>useVoltsPerStepCal</EFDB_Name>
+      <Description>Whether to use VoltsPerStepCal: true or false</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>V</Units>
+      <Count>71</Count>
+    </item>
+    <!--CCSMETA: Array voltsPerStepCal indexed by location-->
+    <item>
+      <EFDB_Name>voltsPerStepCal</EFDB_Name>
+      <Description>Calibrated Volts per HV regulation step</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>V</Units>
+      <Count>71</Count>
     </item>
   </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_rebpower_Reb_LimitsConfiguration for category Limits using level 1-->
@@ -9122,7 +9227,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_LimitsConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_LimitsConfiguration for category Limits</Description>
-    <!--CCS: Dictionary_Checksum: 2968384280L -->
+    <!--CCS: Dictionary_Checksum: 2005870463L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -9154,6 +9259,62 @@
     <item>
       <EFDB_Name>aftercooltmp_limitLo</EFDB_Name>
       <Description>After Cooler Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambienttmp_warnHi</EFDB_Name>
+      <Description>Ambient Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambienttmp_warnLo</EFDB_Name>
+      <Description>Ambient Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambienttmp_limitHi</EFDB_Name>
+      <Description>Ambient Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambienttmp_limitLo</EFDB_Name>
+      <Description>Ambient Temperature low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cabinettmp_warnHi</EFDB_Name>
+      <Description>Cabinet Temperature high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cabinettmp_warnLo</EFDB_Name>
+      <Description>Cabinet Temperature low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cabinettmp_limitHi</EFDB_Name>
+      <Description>Cabinet Temperature high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cabinettmp_limitLo</EFDB_Name>
+      <Description>Cabinet Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -9604,6 +9765,105 @@
       <Description>Water Outlet Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_PicConfiguration for category Pic using level 1-->
+  <!--================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_refrig_Cryo1_PicConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo1_PicConfiguration for category Pic</Description>
+    <!--CCS: Dictionary_Checksum: 4061010445L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_awGain</EFDB_Name>
+      <Description>anti-windup gain</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_baseDuty</EFDB_Name>
+      <Description>base duty cycle</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_gain</EFDB_Name>
+      <Description>loop gain</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_maxInput</EFDB_Name>
+      <Description>maximum input (temp. difference)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_maxOutput</EFDB_Name>
+      <Description>maximum PID output (duty cycle)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_minInput</EFDB_Name>
+      <Description>minimum input (temp. difference)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_minOutput</EFDB_Name>
+      <Description>minimum PID output (duty cycle)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_setTemp</EFDB_Name>
+      <Description>Temperature set point</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_smoothTime</EFDB_Name>
+      <Description>input smoothing time</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_timeConst</EFDB_Name>
+      <Description>Integration time constant</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_tolerance</EFDB_Name>
+      <Description>maximum on-target error (%)</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanctrl_useAbsTemp</EFDB_Name>
+      <Description>true/false to use absolute temperature set point, not difference</Description>
+      <IDL_Type>boolean</IDL_Type>
+      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -10234,7 +10494,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_LimitsConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_LimitsConfiguration for category Limits</Description>
-    <!--CCS: Dictionary_Checksum: 317401243L -->
+    <!--CCS: Dictionary_Checksum: 1413047751L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -10266,62 +10526,6 @@
     <item>
       <EFDB_Name>aftercooltmp_limitLo</EFDB_Name>
       <Description>After Cooler Temperature low alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ambienttmp_warnHi</EFDB_Name>
-      <Description>Ambient Temperature high warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ambienttmp_warnLo</EFDB_Name>
-      <Description>Ambient Temperature low warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ambienttmp_limitHi</EFDB_Name>
-      <Description>Ambient Temperature high alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ambienttmp_limitLo</EFDB_Name>
-      <Description>Ambient Temperature low alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>cabinettmp_warnHi</EFDB_Name>
-      <Description>Cabinet Temperature high warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>cabinettmp_warnLo</EFDB_Name>
-      <Description>Cabinet Temperature low warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>cabinettmp_limitHi</EFDB_Name>
-      <Description>Cabinet Temperature high alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>cabinettmp_limitLo</EFDB_Name>
-      <Description>Cabinet Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -10772,105 +10976,6 @@
       <Description>Water Outlet Temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_PicConfiguration for category Pic using level 1-->
-  <!--================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_refrig_Cryo3_PicConfiguration</EFDB_Topic>
-    <Description>subsystem MTCamera class MTCamera_logevent_refrig_Cryo3_PicConfiguration for category Pic</Description>
-    <!--CCS: Dictionary_Checksum: 3402127099L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_awGain</EFDB_Name>
-      <Description>anti-windup gain</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_baseDuty</EFDB_Name>
-      <Description>base duty cycle</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_gain</EFDB_Name>
-      <Description>loop gain</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_maxInput</EFDB_Name>
-      <Description>maximum input (temp. difference)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_maxOutput</EFDB_Name>
-      <Description>maximum PID output (duty cycle)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_minInput</EFDB_Name>
-      <Description>minimum input (temp. difference)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_minOutput</EFDB_Name>
-      <Description>minimum PID output (duty cycle)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_setTemp</EFDB_Name>
-      <Description>Temperature set point</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_smoothTime</EFDB_Name>
-      <Description>input smoothing time</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>second</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_timeConst</EFDB_Name>
-      <Description>Integration time constant</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>second</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_tolerance</EFDB_Name>
-      <Description>maximum on-target error (%)</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>fanctrl_useAbsTemp</EFDB_Name>
-      <Description>true/false to use absolute temperature set point, not difference</Description>
-      <IDL_Type>boolean</IDL_Type>
-      <Units>unitless</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -12703,7 +12808,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_CryoCompLimits_CompLimitsConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_refrig_CryoCompLimits_CompLimitsConfiguration for category CompLimits</Description>
-    <!--CCS: Dictionary_Checksum: 1390129142L -->
+    <!--CCS: Dictionary_Checksum: 244928127L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12772,6 +12877,20 @@
       <Description>Low discharge temperature limit inhibiting compressor startup</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dryerCheckHighPress</EFDB_Name>
+      <Description>Discharge pressure above which filter dryer warning is issued</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>dryerCheckLowPress</EFDB_Name>
+      <Description>Suction pressure below which filter dryer warning is issued</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>psia</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -12894,7 +13013,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_refrig_PeriodicTasks_PicConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_refrig_PeriodicTasks_PicConfiguration for category Pic</Description>
-    <!--CCS: Dictionary_Checksum: 1012741945L -->
+    <!--CCS: Dictionary_Checksum: 699659214L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -12903,8 +13022,8 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>cryo3_FanCtrl_iterate_updateTime</EFDB_Name>
-      <Description>Periodic task Cryo3/FanCtrl update time</Description>
+      <EFDB_Name>cryo1_FanCtrl_iterate_updateTime</EFDB_Name>
+      <Description>Periodic task Cryo1/FanCtrl update time</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>ms</Units>
       <Count>1</Count>
@@ -16013,7 +16132,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_vacuum_PumpCart_CryoConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_vacuum_PumpCart_CryoConfiguration for category Cryo</Description>
-    <!--CCS: Dictionary_Checksum: 2020908612L -->
+    <!--CCS: Dictionary_Checksum: 1260551578L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16025,6 +16144,13 @@
       <EFDB_Name>devcId</EFDB_Name>
       <Description>The device id</Description>
       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>inletPressureScaleCorrection</EFDB_Name>
+      <Description>Correction factor for ambient pressure calibration (P_summit/P_sealevel)</Description>
+      <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -16405,7 +16531,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_daq_monitor_Stats_StatisticsConfiguration for category Statistics</Description>
-    <!--CCS: Dictionary_Checksum: 3891351454L -->
+    <!--CCS: Dictionary_Checksum: 779585402L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -16480,6 +16606,13 @@
       <EFDB_Name>sumRmsStats</EFDB_Name>
       <Description>Rms Stats for sums over location (colon delimited array)</Description>
       <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>suppressReadErrorAlerts</EFDB_Name>
+      <Description>Suppress register reed errors by checking additional update</Description>
+      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -20971,7 +21104,7 @@
     </item>
     <item>
       <EFDB_Name>idleClearParameters</EFDB_Name>
-      <Description>The parameters used for idle clearing</Description>
+      <Description>The parameters used for guider idle clearing</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -20983,7 +21116,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_focal_plane_SequencerConfig_SequencerConfiguration for category Sequencer</Description>
-    <!--CCS: Dictionary_Checksum: 1247479346L -->
+    <!--CCS: Dictionary_Checksum: 2111718602L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -21006,17 +21139,38 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>idleFlushMain</EFDB_Name>
+      <EFDB_Name>clearRowsParameter</EFDB_Name>
+      <Description>Name of the clear rows parameter (used for idle clear)</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>idleClearMain</EFDB_Name>
       <Description>Name of the idle flush main</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>idleFlushTimeout</EFDB_Name>
-      <Description>Idle time in milliseconds before sequencer will enter IDLE_FLUSH. Can be zero (enter immeidately) or negative (never)</Description>
+      <EFDB_Name>idleClearPeriod</EFDB_Name>
+      <Description>Period in milliseconds at which the periodic idle clear is run when focal-plane is in IDLE_CLEAR state</Description>
       <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>idleClearRows</EFDB_Name>
+      <Description>Value to set the idleRows parameter to during idle clear</Description>
+      <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>idleClearTimeout</EFDB_Name>
+      <Description>QUIESCENT time in milliseconds before sequencer will transition to IDLE_CLEAR state. Can be zero (enter immediately) or negative (never)</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -21149,13 +21303,6 @@
       <EFDB_Name>shiftCountParameter</EFDB_Name>
       <Description>Name of the shift count parameter</Description>
       <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>stepAfterIntegrate</EFDB_Name>
-      <Description>Perform a step rather than stop after integrate</Description>
-      <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
@@ -26905,609 +27052,609 @@
     </item>
     <item>
       <EFDB_Name>a_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>a_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>a_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>da1_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>da1_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>da1_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>da2_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>da2_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>da2_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dr1_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dr1_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dr1_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>du1_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>du1_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>du1_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>du2_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>du2_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>du2_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dz1_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dz1_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>dz1_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ef_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ef_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ef_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f15_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f15_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f15_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f17_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f17_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f17_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f29_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f29_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f29_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f34_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f34_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f34_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f3_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f3_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f3_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f46_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f46_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f46_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f48_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f48_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f48_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f60_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f60_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>f60_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>g_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>g_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>g_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>i_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>i_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>i_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>none_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>none_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>none_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>oa_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>oa_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>oa_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ob_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ob_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ob_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>oc_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>oc_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>oc_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ph_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ph_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ph_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>r_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>r_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>r_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tu_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tu_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>tu_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ty_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ty_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>ty_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>u_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>u_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>u_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>y_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>y_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>y_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>z_family</EFDB_Name>
-      <Description>Filter family: S ; D ; F ; T ; O; U; N</Description>
+      <Description>Filter family: Science | Dummy | French dummy | Test | Open | Unknown | None</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>z_filterID</EFDB_Name>
-      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors.</Description>
+      <Description>Filter identification number as coded on its frame and read with 6 hall effect sensors</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>z_weight</EFDB_Name>
-      <Description>weight of this filter</Description>
+      <Description>Weight of the filter</Description>
       <IDL_Type>double</IDL_Type>
       <Units>kg</Units>
       <Count>1</Count>
@@ -28769,7 +28916,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_fcs_PeriodicTasks_timersConfiguration for category timers</Description>
-    <!--CCS: Dictionary_Checksum: 4217962141L -->
+    <!--CCS: Dictionary_Checksum: 641258320L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -28808,6 +28955,13 @@
     <item>
       <EFDB_Name>publishautochangertemperatures_taskPeriodMillis</EFDB_Name>
       <Description>period for task PublishAutochangerTemperatures</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>ms</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>publishcarouselslipringcurrent_taskPeriodMillis</EFDB_Name>
+      <Description>period for task PublishCarouselSlipRingCurrent</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>ms</Units>
       <Count>1</Count>
@@ -29152,7 +29306,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_GeneralConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_chiller_GeneralConfiguration for category General</Description>
-    <!--CCS: Dictionary_Checksum: 3531999427L -->
+    <!--CCS: Dictionary_Checksum: 774005837L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -29294,6 +29448,13 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>minGlycolFlowToStart</EFDB_Name>
+      <Description>minimum glycol flow to allow starting chiller</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>periodictasks_schedulers_default_nTasks</EFDB_Name>
       <Description>Number of tasks assigned to the Scheduler.</Description>
       <IDL_Type>long</IDL_Type>
@@ -29349,7 +29510,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_logevent_chiller_LimitsConfiguration</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_logevent_chiller_LimitsConfiguration for category Limits</Description>
-    <!--CCS: Dictionary_Checksum: 188752282L -->
+    <!--CCS: Dictionary_Checksum: 1189134400L -->
     <item>
       <EFDB_Name>version</EFDB_Name>
       <Description>Version of the settings, formatted using CCS conventions</Description>
@@ -29407,10 +29568,38 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>maq20_GlycChillerOut_warnLo</EFDB_Name>
+      <Description>TC4: Glycol out of Chiller low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>maq20_GlycChillerOut_limitHi</EFDB_Name>
       <Description>TC4: Glycol out of Chiller high alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maq20_GlycChillerOut_limitLo</EFDB_Name>
+      <Description>TC4: Glycol out of Chiller low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maq20_GlycDeSuHtrFlow_warnLo</EFDB_Name>
+      <Description>Glycol flow at Stg 2 DeSuperHtr low warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>maq20_GlycDeSuHtrFlow_limitLo</EFDB_Name>
+      <Description>Glycol flow at Stg 2 DeSuperHtr low alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>gallon/min</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -31379,49 +31568,6 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration for category Limits using level 2-->
-  <!--==========================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration</EFDB_Topic>
-    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngXPlusTemp_LimitsConfiguration for category Limits</Description>
-    <!--CCS: Dictionary_Checksum: 617135785L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>Back flange X+ in temperature high warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>Back flange X+ in temperature low warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>Back flange X+ in temperature high alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>Back flange X+ in temperature low alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_BackFlngYMinusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--===========================================================================================================================================================-->
   <SALEvent>
@@ -32239,49 +32385,6 @@
       <Count>1</Count>
     </item>
   </SALEvent>
-  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration for category Limits using level 2-->
-  <!--==========================================================================================================================================================-->
-  <SALEvent>
-    <Subsystem>MTCamera</Subsystem>
-    <EFDB_Topic>MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration</EFDB_Topic>
-    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYMinusTemp_LimitsConfiguration for category Limits</Description>
-    <!--CCS: Dictionary_Checksum: 4163972077L -->
-    <item>
-      <EFDB_Name>version</EFDB_Name>
-      <Description>Version of the settings, formatted using CCS conventions</Description>
-      <IDL_Type>string</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnHi</EFDB_Name>
-      <Description>Shroud ring Y- temperature high warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>warnLo</EFDB_Name>
-      <Description>Shroud ring Y- temperature low warning level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitHi</EFDB_Name>
-      <Description>Shroud ring Y- temperature high alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>limitLo</EFDB_Name>
-      <Description>Shroud ring Y- temperature low alarm level</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_Body_ShrdRngYPlusTemp_LimitsConfiguration for category Limits using level 2-->
   <!--=========================================================================================================================================================-->
   <SALEvent>
@@ -32868,6 +32971,35 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanSpeedError_LimitsConfiguration for category Limits using level 2-->
+  <!--=====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_FanSpeedError_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanSpeedError_LimitsConfiguration for category Limits</Description>
+    <!--CCS: Dictionary_Checksum: 2672432332L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>MPC fan speed error high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>MPC fan speed error high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_FanSpeed_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
@@ -33166,6 +33298,35 @@
       <Description>MPC supply air pressure low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_ValvePosnError_LimitsConfiguration for category Limits using level 2-->
+  <!--======================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_MPC_ValvePosnError_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_MPC_ValvePosnError_LimitsConfiguration for category Limits</Description>
+    <!--CCS: Dictionary_Checksum: 737608615L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>MPC coolant valve position error high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>MPC coolant valve position error high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -34184,6 +34345,35 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanSpeedError_LimitsConfiguration for category Limits using level 2-->
+  <!--====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_FanSpeedError_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanSpeedError_LimitsConfiguration for category Limits</Description>
+    <!--CCS: Dictionary_Checksum: 3286148356L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>UT fan speed error high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>UT fan speed error high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_FanSpeed_LimitsConfiguration for category Limits using level 2-->
   <!--===============================================================================================================================================-->
   <SALEvent>
@@ -34482,6 +34672,35 @@
       <Description>UT Top end X+ temperature low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_ValvePosnError_LimitsConfiguration for category Limits using level 2-->
+  <!--=====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_UT_ValvePosnError_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_UT_ValvePosnError_LimitsConfiguration for category Limits</Description>
+    <!--CCS: Dictionary_Checksum: 2220372146L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>UT coolant valve position error high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>UT coolant valve position error high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
   </SALEvent>
@@ -35001,6 +35220,35 @@
       <Count>1</Count>
     </item>
   </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanSpeedError_LimitsConfiguration for category Limits using level 2-->
+  <!--=====================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_FanSpeedError_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanSpeedError_LimitsConfiguration for category Limits</Description>
+    <!--CCS: Dictionary_Checksum: 412586982L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>VPC fan speed error high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>VPC fan speed error high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_FanSpeed_LimitsConfiguration for category Limits using level 2-->
   <!--================================================================================================================================================-->
   <SALEvent>
@@ -35385,6 +35633,35 @@
       <Description>VPC supply air pressure low alarm level</Description>
       <IDL_Type>double</IDL_Type>
       <Units>in. H₂O</Units>
+      <Count>1</Count>
+    </item>
+  </SALEvent>
+  <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_ValvePosnError_LimitsConfiguration for category Limits using level 2-->
+  <!--======================================================================================================================================================-->
+  <SALEvent>
+    <Subsystem>MTCamera</Subsystem>
+    <EFDB_Topic>MTCamera_logevent_utiltrunk_VPC_ValvePosnError_LimitsConfiguration</EFDB_Topic>
+    <Description>subsystem MTCamera class MTCamera_logevent_utiltrunk_VPC_ValvePosnError_LimitsConfiguration for category Limits</Description>
+    <!--CCS: Dictionary_Checksum: 4039841782L -->
+    <item>
+      <EFDB_Name>version</EFDB_Name>
+      <Description>Version of the settings, formatted using CCS conventions</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>warnHi</EFDB_Name>
+      <Description>VPC coolant valve position error high warning level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>limitHi</EFDB_Name>
+      <Description>VPC coolant valve position error high alarm level</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
   </SALEvent>

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Events.xml
@@ -4850,14 +4850,14 @@
       <EFDB_Name>deltaI</EFDB_Name>
       <Description>allowed excess current margin</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>mA</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>maxDeltaVolt</EFDB_Name>
-      <Description>allowed excess current margin</Description>
+      <Description>allowed excess voltage margin</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>Volt</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -5479,7 +5479,7 @@
       <EFDB_Name>reff</EFDB_Name>
       <Description>slope of V = reff * I</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>kOhm</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array useVoltsPerStepCal indexed by location-->

--- a/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/MTCamera/MTCamera_Telemetry.xml
@@ -803,7 +803,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_rebpower_Reb</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_rebpower_Reb</Description>
-    <!--CCS: Dictionary_Checksum: 72957452L -->
+    <!--CCS: Dictionary_Checksum: 2604994575L -->
     <!--CCSMETA: Array analog_IaftLDO indexed by location-->
     <item>
       <EFDB_Name>analog_IaftLDO</EFDB_Name>
@@ -1050,6 +1050,14 @@
       <Description>Voltage before LDO</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Volt</Units>
+      <Count>71</Count>
+    </item>
+    <!--CCSMETA: Array hvbias_DAC indexed by location-->
+    <item>
+      <EFDB_Name>hvbias_DAC</EFDB_Name>
+      <Description>DAC setting</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
       <Count>71</Count>
     </item>
     <!--CCSMETA: Array hvbias_IbefSwch indexed by location-->
@@ -1702,10 +1710,24 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo1</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_refrig_Cryo1</Description>
-    <!--CCS: Dictionary_Checksum: 869246017L -->
+    <!--CCS: Dictionary_Checksum: 4199104483L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>ambientTmp</EFDB_Name>
+      <Description>Ambient Temperature</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>Celsius</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>cabinetTmp</EFDB_Name>
+      <Description>Cabinet Temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -1956,24 +1978,10 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_refrig_Cryo3</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_refrig_Cryo3</Description>
-    <!--CCS: Dictionary_Checksum: 773606185L -->
+    <!--CCS: Dictionary_Checksum: 4281376255L -->
     <item>
       <EFDB_Name>afterCoolTmp</EFDB_Name>
       <Description>After Cooler Temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>ambientTmp</EFDB_Name>
-      <Description>Ambient Temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>cabinetTmp</EFDB_Name>
-      <Description>Cabinet Temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -4219,7 +4227,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Autochanger_AutochangerTrucks_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Autochanger_AutochangerTrucks_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 2202000250L -->
+    <!--CCS: Dictionary_Checksum: 3529804578L -->
     <item>
       <EFDB_Name>actruckxminus_handoffInError</EFDB_Name>
       <Description>Autochanger truck position sensors at handoff are in error</Description>
@@ -4323,6 +4331,13 @@
       <Description>Both autochanger trucks are at standby position</Description>
       <IDL_Type>boolean</IDL_Type>
       <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>deltaDriverFollowerPosition</EFDB_Name>
+      <Description>Difference of position between autochanger driver and follower trucks along linear rails</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>micron</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -4814,7 +4829,7 @@
     <!--CCS: Dictionary_Checksum: 3264837383L -->
     <item>
       <EFDB_Name>id</EFDB_Name>
-      <Description>Identifier of autochangerusing serialNB of plutoGateway device</Description>
+      <Description>Identifier of autochanger using serialNB of plutoGateway device</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -5027,14 +5042,14 @@
       <EFDB_Name>inclinometerXminus</EFDB_Name>
       <Description>Value of Digital Sensor inclinometerXminus</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>degree</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>inclinometerXplus</EFDB_Name>
       <Description>Value of Digital Sensor inclinometerXplus</Description>
       <IDL_Type>double</IDL_Type>
-      <Units>unitless</Units>
+      <Units>degree</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -6192,7 +6207,14 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Canbus0_Hyttc580_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Canbus0_Hyttc580_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 3071168627L -->
+    <!--CCS: Dictionary_Checksum: 3405652215L -->
+    <item>
+      <EFDB_Name>currentSlipRing</EFDB_Name>
+      <Description>Output current from the slip ring</Description>
+      <IDL_Type>long</IDL_Type>
+      <Units>mA</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>plc_caAF3</EFDB_Name>
       <Description>Value of Digital Sensor caAF3</Description>
@@ -7610,14 +7632,14 @@
       <EFDB_Name>forceSensor0</EFDB_Name>
       <Description>Value of Digital Sensor forceSensor0</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>mV</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>forceSensor1</EFDB_Name>
       <Description>Value of Digital Sensor forceSensor1</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>mV</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7743,7 +7765,7 @@
       <EFDB_Name>loaderFilterDistanceSensor</EFDB_Name>
       <Description>Value of Digital Sensor loaderFilterDistanceSensor</Description>
       <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
+      <Units>mV</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -7981,7 +8003,7 @@
     </item>
     <item>
       <EFDB_Name>clampxminus1_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8030,7 +8052,7 @@
     </item>
     <item>
       <EFDB_Name>clampxplus1_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8079,7 +8101,7 @@
     </item>
     <item>
       <EFDB_Name>clampsState</EFDB_Name>
-      <Description>Clamps state on this socket {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Clamps state on this socket {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8143,7 +8165,7 @@
     </item>
     <item>
       <EFDB_Name>clampxminus2_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8192,7 +8214,7 @@
     </item>
     <item>
       <EFDB_Name>clampxplus2_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8241,7 +8263,7 @@
     </item>
     <item>
       <EFDB_Name>clampsState</EFDB_Name>
-      <Description>Clamps state on this socket {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Clamps state on this socket {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8305,7 +8327,7 @@
     </item>
     <item>
       <EFDB_Name>clampxminus3_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8354,7 +8376,7 @@
     </item>
     <item>
       <EFDB_Name>clampxplus3_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8403,7 +8425,7 @@
     </item>
     <item>
       <EFDB_Name>clampsState</EFDB_Name>
-      <Description>Clamps state on this socket {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Clamps state on this socket {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8467,7 +8489,7 @@
     </item>
     <item>
       <EFDB_Name>clampxminus4_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8516,7 +8538,7 @@
     </item>
     <item>
       <EFDB_Name>clampxplus4_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8565,7 +8587,7 @@
     </item>
     <item>
       <EFDB_Name>clampsState</EFDB_Name>
-      <Description>Clamps state on this socket {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Clamps state on this socket {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8629,7 +8651,7 @@
     </item>
     <item>
       <EFDB_Name>clampxminus5_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8678,7 +8700,7 @@
     </item>
     <item>
       <EFDB_Name>clampxplus5_clampState</EFDB_Name>
-      <Description>Carousel clamp state {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Carousel clamp state {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8727,7 +8749,7 @@
     </item>
     <item>
       <EFDB_Name>clampsState</EFDB_Name>
-      <Description>Clamps state on this socket {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>Clamps state on this socket {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8791,7 +8813,7 @@
     </item>
     <item>
       <EFDB_Name>clampsStateAtStandby</EFDB_Name>
-      <Description>State of the clamps for the socket at STANDBY position {READY_TO_CLAMP; UNCLAMPED_ON_FILTER; UNCLAMPED_EMPTY; CLAMPED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
+      <Description>State of the clamps for the socket at STANDBY position {READY_TO_LOCK; UNLOCKED_ON_FILTER; UNLOCKED_EMPTY; LOCKED_ON_FILTER; UNDEFINED; ERROR; UNLOCKABLE}</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8859,10 +8881,17 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Counters_Autochanger_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Counters_Autochanger_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 1345145492L -->
+    <!--CCS: Dictionary_Checksum: 1395154614L -->
     <item>
       <EFDB_Name>autochangertrucks_ALIGN_FOLLOWER</EFDB_Name>
       <Description>Counter for the action ALIGN_FOLLOWER</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_MOVE_DRIVER_TRUCK_ALONE</EFDB_Name>
+      <Description>Counter for the action MOVE_DRIVER_TRUCK_ALONE</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8931,8 +8960,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_HALFWAY_RELATIVE_POSITION</EFDB_Name>
+      <Description>Counter for the action OPEN_HALFWAY_RELATIVE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_HOMING_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action OPEN_HOMING_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Counter for the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -8980,8 +9030,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_HALFWAY_RELATIVE_POSITION</EFDB_Name>
+      <Description>Counter for the action OPEN_HALFWAY_RELATIVE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_HOMING_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action OPEN_HOMING_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Counter for the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9029,8 +9100,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_HALFWAY_RELATIVE_POSITION</EFDB_Name>
+      <Description>Counter for the action OPEN_HALFWAY_RELATIVE_POSITION</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_HOMING_ONLINECLAMP</EFDB_Name>
+      <Description>Counter for the action OPEN_HOMING_ONLINECLAMP</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Counter for the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</EFDB_Name>
+      <Description>Counter for the action OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9063,7 +9155,28 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Counters_Carousel_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Counters_Carousel_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 770763357L -->
+    <!--CCS: Dictionary_Checksum: 2344222059L -->
+    <item>
+      <EFDB_Name>recovery_ROTATION_BACKWARD</EFDB_Name>
+      <Description>Counter for the action RECOVERY_ROTATION_BACKWARD</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recovery_ROTATION_FORWARD</EFDB_Name>
+      <Description>Counter for the action RECOVERY_ROTATION_FORWARD</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recovery_ROTATION_STRAIGHT</EFDB_Name>
+      <Description>Counter for the action RECOVERY_ROTATION_STRAIGHT</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>rotate_CAROUSEL_TO_ABSOLUTE_POSITION</EFDB_Name>
       <Description>Counter for the action ROTATE_CAROUSEL_TO_ABSOLUTE_POSITION</Description>
@@ -9086,8 +9199,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>socket1_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>socket1_UNLOCK_CLAMPS</EFDB_Name>
       <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Counter for the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9102,6 +9236,13 @@
     <item>
       <EFDB_Name>socket1_clampXminus1_UNLOCK</EFDB_Name>
       <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9128,8 +9269,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>socket2_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>socket2_UNLOCK_CLAMPS</EFDB_Name>
       <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Counter for the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9144,6 +9306,13 @@
     <item>
       <EFDB_Name>socket2_clampXminus2_UNLOCK</EFDB_Name>
       <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9170,8 +9339,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>socket3_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>socket3_UNLOCK_CLAMPS</EFDB_Name>
       <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Counter for the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9186,6 +9376,13 @@
     <item>
       <EFDB_Name>socket3_clampXminus3_UNLOCK</EFDB_Name>
       <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9212,8 +9409,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>socket4_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>socket4_UNLOCK_CLAMPS</EFDB_Name>
       <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Counter for the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9228,6 +9446,13 @@
     <item>
       <EFDB_Name>socket4_clampXminus4_UNLOCK</EFDB_Name>
       <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9254,8 +9479,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>socket5_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Counter for the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>socket5_UNLOCK_CLAMPS</EFDB_Name>
       <Description>Counter for the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Counter for the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9270,6 +9516,13 @@
     <item>
       <EFDB_Name>socket5_clampXminus5_UNLOCK</EFDB_Name>
       <Description>Counter for the action UNLOCK</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Counter for the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>double</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -9451,10 +9704,17 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Autochanger_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Duration_Autochanger_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 2716061563L -->
+    <!--CCS: Dictionary_Checksum: 4122358223L -->
     <item>
       <EFDB_Name>autochangertrucks_ALIGN_FOLLOWER</EFDB_Name>
       <Description>Duration of the action ALIGN_FOLLOWER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>autochangertrucks_MOVE_DRIVER_TRUCK_ALONE</EFDB_Name>
+      <Description>Duration of the action MOVE_DRIVER_TRUCK_ALONE</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9470,13 +9730,6 @@
       <EFDB_Name>autochangertrucks_MOVE_TO_ABSOLUTE_POSITION</EFDB_Name>
       <Description>Duration of the action MOVE_TO_ABSOLUTE_POSITION</Description>
       <IDL_Type>long long</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>grab_FILTER_AT_STANDBY</EFDB_Name>
-      <Description>Duration of the action GRAB_FILTER_AT_STANDBY</Description>
-      <IDL_Type>double</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -9509,13 +9762,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>move_AND_CLAMP_FILTER_ONLINE</EFDB_Name>
-      <Description>Duration of the action MOVE_AND_CLAMP_FILTER_ONLINE</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>millisecond</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>onlineclamps_onlineClampXminus_CLOSE_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Duration of the action CLOSE_ONLINECLAMP_MODE_CURRENT</Description>
       <IDL_Type>long long</IDL_Type>
@@ -9537,8 +9783,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_HALFWAY_RELATIVE_POSITION</EFDB_Name>
+      <Description>Duration of the action OPEN_HALFWAY_RELATIVE_POSITION</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_HOMING_ONLINECLAMP</EFDB_Name>
+      <Description>Duration of the action OPEN_HOMING_ONLINECLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Duration of the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXminus_OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</EFDB_Name>
+      <Description>Duration of the action OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9586,8 +9853,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_HALFWAY_RELATIVE_POSITION</EFDB_Name>
+      <Description>Duration of the action OPEN_HALFWAY_RELATIVE_POSITION</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_HOMING_ONLINECLAMP</EFDB_Name>
+      <Description>Duration of the action OPEN_HOMING_ONLINECLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Duration of the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampXplus_OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</EFDB_Name>
+      <Description>Duration of the action OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9635,8 +9923,29 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_HALFWAY_RELATIVE_POSITION</EFDB_Name>
+      <Description>Duration of the action OPEN_HALFWAY_RELATIVE_POSITION</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_HOMING_ONLINECLAMP</EFDB_Name>
+      <Description>Duration of the action OPEN_HOMING_ONLINECLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_CURRENT</EFDB_Name>
       <Description>Duration of the action OPEN_ONLINECLAMP_MODE_CURRENT</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>onlineclamps_onlineClampYminus_OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</EFDB_Name>
+      <Description>Duration of the action OPEN_ONLINECLAMP_MODE_PROFILE_NOBRAKE</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9669,7 +9978,28 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Carousel_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Duration_Carousel_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 932454045L -->
+    <!--CCS: Dictionary_Checksum: 4143368437L -->
+    <item>
+      <EFDB_Name>recovery_ROTATION_BACKWARD</EFDB_Name>
+      <Description>Duration of the action RECOVERY_ROTATION_BACKWARD</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recovery_ROTATION_FORWARD</EFDB_Name>
+      <Description>Duration of the action RECOVERY_ROTATION_FORWARD</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>recovery_ROTATION_STRAIGHT</EFDB_Name>
+      <Description>Duration of the action RECOVERY_ROTATION_STRAIGHT</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
     <item>
       <EFDB_Name>rotate_CAROUSEL_TO_ABSOLUTE_POSITION</EFDB_Name>
       <Description>Duration of the action ROTATE_CAROUSEL_TO_ABSOLUTE_POSITION</Description>
@@ -9686,15 +10016,36 @@
     </item>
     <item>
       <EFDB_Name>socket1_RELEASE_CLAMPS</EFDB_Name>
-      <Description>Duration of action RELEASE_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action RELEASE_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Duration of the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socket1_UNLOCK_CLAMPS</EFDB_Name>
-      <Description>Duration of action UNLOCK_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Duration of the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXminus1_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -9708,6 +10059,13 @@
     <item>
       <EFDB_Name>socket1_clampXminus1_UNLOCK</EFDB_Name>
       <Description>Duration of the action UNLOCK</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket1_clampXplus1_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9728,15 +10086,36 @@
     </item>
     <item>
       <EFDB_Name>socket2_RELEASE_CLAMPS</EFDB_Name>
-      <Description>Duration of action RELEASE_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action RELEASE_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Duration of the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socket2_UNLOCK_CLAMPS</EFDB_Name>
-      <Description>Duration of action UNLOCK_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Duration of the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXminus2_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -9750,6 +10129,13 @@
     <item>
       <EFDB_Name>socket2_clampXminus2_UNLOCK</EFDB_Name>
       <Description>Duration of the action UNLOCK</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket2_clampXplus2_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9770,15 +10156,36 @@
     </item>
     <item>
       <EFDB_Name>socket3_RELEASE_CLAMPS</EFDB_Name>
-      <Description>Duration of action RELEASE_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action RELEASE_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Duration of the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socket3_UNLOCK_CLAMPS</EFDB_Name>
-      <Description>Duration of action UNLOCK_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Duration of the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXminus3_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -9792,6 +10199,13 @@
     <item>
       <EFDB_Name>socket3_clampXminus3_UNLOCK</EFDB_Name>
       <Description>Duration of the action UNLOCK</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket3_clampXplus3_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9812,15 +10226,36 @@
     </item>
     <item>
       <EFDB_Name>socket4_RELEASE_CLAMPS</EFDB_Name>
-      <Description>Duration of action RELEASE_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action RELEASE_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Duration of the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socket4_UNLOCK_CLAMPS</EFDB_Name>
-      <Description>Duration of action UNLOCK_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Duration of the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXminus4_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -9834,6 +10269,13 @@
     <item>
       <EFDB_Name>socket4_clampXminus4_UNLOCK</EFDB_Name>
       <Description>Duration of the action UNLOCK</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket4_clampXplus4_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9854,15 +10296,36 @@
     </item>
     <item>
       <EFDB_Name>socket5_RELEASE_CLAMPS</EFDB_Name>
-      <Description>Duration of action RELEASE_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action RELEASE_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_STORE_FILTER_ON_CAROUSEL</EFDB_Name>
+      <Description>Duration of the action STORE_FILTER_ON_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>socket5_UNLOCK_CLAMPS</EFDB_Name>
-      <Description>Duration of action UNLOCK_CLAMPS</Description>
-      <IDL_Type>long</IDL_Type>
+      <Description>Duration of the action UNLOCK_CLAMPS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_RECOVERY_CLAMP_XMINUS</EFDB_Name>
+      <Description>Duration of the action RECOVERY_CLAMP_XMINUS</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXminus5_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
@@ -9876,6 +10339,13 @@
     <item>
       <EFDB_Name>socket5_clampXminus5_UNLOCK</EFDB_Name>
       <Description>Duration of the action UNLOCK</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>socket5_clampXplus5_RECOVERY_UNCLAMP</EFDB_Name>
+      <Description>Duration of the action RECOVERY_UNCLAMP</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9965,31 +10435,45 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Duration_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Duration_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 252611752L -->
+    <!--CCS: Dictionary_Checksum: 3254638265L -->
     <item>
       <EFDB_Name>connect_LOADER</EFDB_Name>
-      <Description>Duration of CONNECT_LOADER</Description>
+      <Description>Duration of the action CONNECT_LOADER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>disconnect_LOADER</EFDB_Name>
-      <Description>Duration of DISCONNECT_LOADER</Description>
+      <Description>Duration of the action DISCONNECT_LOADER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>disengage_FILTER_FROM_CAROUSEL</EFDB_Name>
-      <Description>Duration of DISENGAGE_FILTER_FROM_CAROUSEL</Description>
+      <Description>Duration of the action DISENGAGE_FILTER_FROM_CAROUSEL</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>grab_FILTER_AT_STANDBY</EFDB_Name>
+      <Description>Duration of the action GRAB_FILTER_AT_STANDBY</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>load_FILTER</EFDB_Name>
-      <Description>Duration of LOAD_FILTER</Description>
+      <Description>Duration of the action LOAD_FILTER</Description>
+      <IDL_Type>long long</IDL_Type>
+      <Units>millisecond</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>move_AND_CLAMP_FILTER_ONLINE</EFDB_Name>
+      <Description>Duration of the action MOVE_AND_CLAMP_FILTER_ONLINE</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -9997,41 +10481,41 @@
     <item>
       <EFDB_Name>rotate_SOCKET_TO_STANDBY</EFDB_Name>
       <Description>Duration of the action ROTATE_SOCKET_TO_STANDBY</Description>
-      <IDL_Type>double</IDL_Type>
+      <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>set_FILTER</EFDB_Name>
-      <Description>Duration of SET_FILTER</Description>
+      <Description>Duration of the action SET_FILTER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>set_FILTER_AT_HANDOFF_FOR_LOADER</EFDB_Name>
-      <Description>Duration of SET_FILTER_AT_HANDOFF_FOR_LOADER</Description>
+      <Description>Duration of the action SET_FILTER_AT_HANDOFF_FOR_LOADER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>set_NO_FILTER</EFDB_Name>
-      <Description>Duration of SET_NO_FILTER</Description>
+      <Description>Duration of the action SET_NO_FILTER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>store_FILTER_ON_CAROUSEL</EFDB_Name>
-      <Description>Duration of STORE_FILTER_ON_CAROUSEL</Description>
+      <Description>Duration of the action STORE_FILTER_ON_CAROUSEL</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
     </item>
     <item>
       <EFDB_Name>unload_FILTER</EFDB_Name>
-      <Description>Duration of UNLOAD_FILTER</Description>
+      <Description>Duration of the action UNLOAD_FILTER</Description>
       <IDL_Type>long long</IDL_Type>
       <Units>millisecond</Units>
       <Count>1</Count>
@@ -10043,7 +10527,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_fcs_Fcs_Mcm_Trending</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_fcs_Fcs_Mcm_Trending for category Trending</Description>
-    <!--CCS: Dictionary_Checksum: 104252808L -->
+    <!--CCS: Dictionary_Checksum: 591873251L -->
     <item>
       <EFDB_Name>autochanger_trucks_position</EFDB_Name>
       <Description>Absolute position of the autochanger trucks</Description>
@@ -10075,13 +10559,6 @@
     <item>
       <EFDB_Name>proximity</EFDB_Name>
       <Description>Value of the autochanger proximity sensor</Description>
-      <IDL_Type>long</IDL_Type>
-      <Units>unitless</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>setfilter_percentage</EFDB_Name>
-      <Description>Progress of the setFilter command [%]</Description>
       <IDL_Type>long</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -10344,7 +10821,7 @@
     <!--CCS: Dictionary_Checksum: 3495373320L -->
     <item>
       <EFDB_Name>id</EFDB_Name>
-      <Description>Identifier of loaderusing serialNB of plutoGateway device</Description>
+      <Description>Identifier of loader using serialNB of plutoGateway device</Description>
       <IDL_Type>string</IDL_Type>
       <Units>unitless</Units>
       <Count>1</Count>
@@ -11455,7 +11932,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_Body</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_utiltrunk_Body</Description>
-    <!--CCS: Dictionary_Checksum: 853845456L -->
+    <!--CCS: Dictionary_Checksum: 42717592L -->
     <item>
       <EFDB_Name>ambAirtemp</EFDB_Name>
       <Description>Ambient air temperature</Description>
@@ -11473,13 +11950,6 @@
     <item>
       <EFDB_Name>backFlngXMinusTemp</EFDB_Name>
       <Description>Back flange X- in temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
-      <EFDB_Name>backFlngXPlusTemp</EFDB_Name>
-      <Description>Back flange X+ in temperature</Description>
       <IDL_Type>double</IDL_Type>
       <Units>Celsius</Units>
       <Count>1</Count>
@@ -11618,13 +12088,6 @@
       <Count>1</Count>
     </item>
     <item>
-      <EFDB_Name>shrdRngYMinusTemp</EFDB_Name>
-      <Description>Shroud ring Y- temperature</Description>
-      <IDL_Type>double</IDL_Type>
-      <Units>Celsius</Units>
-      <Count>1</Count>
-    </item>
-    <item>
       <EFDB_Name>shrdRngYPlusTemp</EFDB_Name>
       <Description>Shroud ring Y+ temperature</Description>
       <IDL_Type>double</IDL_Type>
@@ -11673,7 +12136,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_MPC</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_utiltrunk_MPC</Description>
-    <!--CCS: Dictionary_Checksum: 3295711856L -->
+    <!--CCS: Dictionary_Checksum: 2454498131L -->
     <item>
       <EFDB_Name>avgAirtempOut</EFDB_Name>
       <Description>MPC average air temperature</Description>
@@ -11714,6 +12177,13 @@
       <Description>MPC fan speed</Description>
       <IDL_Type>double</IDL_Type>
       <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanSpeedError</EFDB_Name>
+      <Description>MPC fan speed error</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -11765,6 +12235,13 @@
       <Units>%</Units>
       <Count>1</Count>
     </item>
+    <item>
+      <EFDB_Name>valvePosnError</EFDB_Name>
+      <Description>MPC coolant valve position error</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
   </SALTelemetry>
   <!--Created by xmlmaker2 for subsystem MTCamera class MTCamera_utiltrunk_UT using level 1-->
   <!--=====================================================================================-->
@@ -11772,7 +12249,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_UT</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_utiltrunk_UT</Description>
-    <!--CCS: Dictionary_Checksum: 446270777L -->
+    <!--CCS: Dictionary_Checksum: 1019154847L -->
     <item>
       <EFDB_Name>averageTemp</EFDB_Name>
       <Description>UT weighted average temperature</Description>
@@ -11844,6 +12321,13 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>fanSpeedError</EFDB_Name>
+      <Description>UT fan speed error</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>midXMinusTemp</EFDB_Name>
       <Description>UT Mid-plate X- temperature</Description>
       <IDL_Type>double</IDL_Type>
@@ -11893,6 +12377,13 @@
       <Count>1</Count>
     </item>
     <item>
+      <EFDB_Name>valvePosnError</EFDB_Name>
+      <Description>UT coolant valve position error</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
       <EFDB_Name>w2Q1Temp</EFDB_Name>
       <Description>UT W2 Q1 temperature</Description>
       <IDL_Type>double</IDL_Type>
@@ -11913,7 +12404,7 @@
     <Subsystem>MTCamera</Subsystem>
     <EFDB_Topic>MTCamera_utiltrunk_VPC</EFDB_Topic>
     <Description>subsystem MTCamera class MTCamera_utiltrunk_VPC</Description>
-    <!--CCS: Dictionary_Checksum: 1724543484L -->
+    <!--CCS: Dictionary_Checksum: 3117930011L -->
     <item>
       <EFDB_Name>deltaPressFilt</EFDB_Name>
       <Description>VPC filter delta pressure</Description>
@@ -11947,6 +12438,13 @@
       <Description>VPC fan speed</Description>
       <IDL_Type>double</IDL_Type>
       <Units>rpm</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>fanSpeedError</EFDB_Name>
+      <Description>VPC fan speed error</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
       <Count>1</Count>
     </item>
     <item>
@@ -12008,6 +12506,13 @@
     <item>
       <EFDB_Name>valvePosn</EFDB_Name>
       <Description>VPC coolant valve position</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>%</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>valvePosnError</EFDB_Name>
+      <Description>VPC coolant valve position error</Description>
       <IDL_Type>double</IDL_Type>
       <Units>%</Units>
       <Count>1</Count>


### PR DESCRIPTION
Changes for auxtel and lsstcam.
Note that we have not regenerated dictionaries for comcam, and cannot since it has not been kept up to date. It will almost certainly be necessary to make a new XML release before comcam can be bought back under OCS control, but that is probably a ways off still.