### PR TITLE
Add dimensionless rain level and light level topics for ESS.

### DIFF
--- a/doc/news/interface_changes/OSW-2485.ess.rst
+++ b/doc/news/interface_changes/OSW-2485.ess.rst
@@ -1,0 +1,1 @@
+Added rainLevel and lightLevel telemetry topics for the dimensionless rain and light data provided by the Aurora Cloud Sensor.

--- a/python/lsst/ts/xml/data/sal_interfaces/ESS/ESS_Telemetry.xml
+++ b/python/lsst/ts/xml/data/sal_interfaces/ESS/ESS_Telemetry.xml
@@ -249,6 +249,70 @@
     </item>
   </SALTelemetry>
   <SALTelemetry>
+    <EFDB_Topic>ESS_rainLevel</EFDB_Topic>
+    <Description>Dimensionless rain level, e.g. as reported by the Aurora Cloud Sensor.</Description>
+    <item>
+      <EFDB_Name>sensorName</EFDB_Name>
+      <Description>The name of the sensor.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timestamp</EFDB_Name>
+      <Description>Time at which the data was read (TAI unix seconds).</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>rainLevelItem</EFDB_Name>
+      <Description>Dimensionless rain level.</Description>
+      <IDL_Type>float</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>The location of the sensor.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <SALTelemetry>
+    <EFDB_Topic>ESS_lightLevel</EFDB_Topic>
+    <Description>Dimensionless light level, e.g. as reported by the Aurora Cloud Sensor.</Description>
+    <item>
+      <EFDB_Name>sensorName</EFDB_Name>
+      <Description>The name of the sensor.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>timestamp</EFDB_Name>
+      <Description>Time at which the data was read (TAI unix seconds).</Description>
+      <IDL_Type>double</IDL_Type>
+      <Units>second</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>lightLevelItem</EFDB_Name>
+      <Description>Dimensionless light level.</Description>
+      <IDL_Type>float</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+    <item>
+      <EFDB_Name>location</EFDB_Name>
+      <Description>The location of the sensor.</Description>
+      <IDL_Type>string</IDL_Type>
+      <Units>unitless</Units>
+      <Count>1</Count>
+    </item>
+  </SALTelemetry>
+  <SALTelemetry>
     <EFDB_Topic>ESS_relativeHumidity</EFDB_Topic>
     <Description>Relative humidity.</Description>
     <item>


### PR DESCRIPTION
This change adds `rainLevel` and `lightLevel` topics as per a discussion with Wouter regarding the Aurora Cloud Sensor, which has telemetry on these topics. The `rainRate` topic already exists, but it specifies units whereas the Aurora Cloud Sensor does not document units associated with its data. The new topics are modeled after `rainRate`, but they omit `sensorName` and `location`.